### PR TITLE
fix(deploy): unblock Vercel production (remove withEve service)

### DIFF
--- a/apps/web/docs/API_DOCUMENTATION.md
+++ b/apps/web/docs/API_DOCUMENTATION.md
@@ -320,7 +320,7 @@ Puzzle generation uses the Eve tool agent + Vercel AI Gateway
 canonical bands: Hard 4–5 · Difficult 6 · Evil 7 · Impossible 8–9.
 See `docs/DIFFICULTY_AND_GENERATION.md`.
 
-Durable Eve sessions (when mounted via `withEve`) are available at `/eve/v1/*`.
+Puzzle generation uses the in-process Eve ToolLoopAgent + AI Gateway (server actions / cron). Durable `/eve/v1/*` HTTP sessions are not mounted in production.
 
 #### `POST /api/ai/generate-puzzle` / admin generate routes
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,3 @@
-import { withEve } from "eve/next";
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -118,4 +116,8 @@ const nextConfig = {
   },
 };
 
-export default withEve(nextConfig);
+// Puzzle generation uses Eve/ToolLoopAgent in-process (see src/ai/puzzle-agent).
+// Do not wrap with withEve() here — that registers a Vercel Build Output service
+// at `.eve/vercel-services/eve` which is not produced by `next build` in this
+// monorepo and fails production deploys.
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=24"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/apps/web/src/ai/README.md
+++ b/apps/web/src/ai/README.md
@@ -25,7 +25,7 @@ getTodaysPuzzle
 
 Authoritative Eve files live under `apps/web/agent/` (instructions, skills, `defineTool` wrappers). In-process generation uses the same implementations in `src/ai/puzzle-agent/`.
 
-`withEve(nextConfig)` mounts durable Eve HTTP at `/eve/v1/*`.
+Puzzle generation runs **in-process** via ToolLoopAgent + AI Gateway (no separate Eve Vercel service). Durable `/eve/v1/*` HTTP mounting via `withEve()` is intentionally not enabled — it breaks monorepo Vercel deploys unless `eve build` artifacts exist under `.eve/vercel-services/eve`.
 
 ## Difficulty tiers (canonical)
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,56 @@
 {
   "$schema": "https://turborepo.com/schema.json",
+  "globalPassThroughEnv": [
+    "REBUZZLE_MONGODB_URI",
+    "MONGODB_URI",
+    "DATABASE_URL",
+    "MONGODB_DB",
+    "AI_GATEWAY_API_KEY",
+    "AI_PROVIDER",
+    "AUTH_SECRET",
+    "CRON_SECRET",
+    "VERCEL_CRON_SECRET",
+    "VERCEL_OIDC_TOKEN",
+    "NEXT_PUBLIC_APP_URL",
+    "RESEND_API_KEY",
+    "RESEND_FROM_EMAIL",
+    "FROM_EMAIL",
+    "EVE_PUZZLE_MODEL",
+    "DEFAULT_PUZZLE_TYPE",
+    "AI_PUZZLE_GENERATION",
+    "AI_ADVANCED_GENERATION",
+    "AI_SMART_VALIDATION",
+    "AI_DYNAMIC_HINTS",
+    "XAI_API_KEY",
+    "GOOGLE_AI_API_KEY",
+    "GROQ_API_KEY",
+    "OPENAI_API_KEY",
+    "VAPID_PRIVATE_KEY",
+    "VAPID_PUBLIC_KEY",
+    "SENTRY_AUTH_TOKEN",
+    "SENTRY_ORG",
+    "SENTRY_PROJECT",
+    "CLERK_SECRET_KEY",
+    "NODE_ENV",
+    "VERCEL",
+    "VERCEL_ENV",
+    "VERCEL_URL",
+    "CI"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "dist/**", ".expo/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", ".expo/**"],
+      "passThroughEnv": [
+        "REBUZZLE_MONGODB_URI",
+        "MONGODB_URI",
+        "DATABASE_URL",
+        "AI_GATEWAY_API_KEY",
+        "AI_PROVIDER",
+        "AUTH_SECRET",
+        "CRON_SECRET",
+        "NEXT_PUBLIC_APP_URL"
+      ]
     },
     "dev": {
       "cache": false,

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "pnpm install",
+  "installCommand": "pnpm install --filter=@rebuzzle/web...",
   "buildCommand": "pnpm turbo build --filter=@rebuzzle/web",
-  "outputDirectory": "apps/web/.next",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "outputDirectory": "apps/web/.next"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Production deploy failed after Next build with:

`Error: Service "eve" has root ".eve/vercel-services/eve" but that directory does not exist.`

`withEve(nextConfig)` registers a Vercel Build Output service that this monorepo never materializes during `next build`.

## Fix
- Remove `withEve` wrapper — puzzle generation stays **in-process** via ToolLoopAgent + AI Gateway
- Pin Node to `24.x` (project was on 20.x; Eve/web need 24)
- Pass Mongo/AI/auth env vars through `turbo.json` so Vercel secrets reach the build
- Install only `@rebuzzle/web...` to avoid desktop `electron`/`node-liblzma` native install noise

## Verify
- Local `pnpm turbo build --filter=@rebuzzle/web` succeeds
- After merge, production should deploy to https://rebuzzle.byronwade.com
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

