### PR TITLE
Dev Mode testing tools + harder Eve puzzle quality gates

### DIFF
--- a/apps/web/agent/agent.ts
+++ b/apps/web/agent/agent.ts
@@ -5,5 +5,5 @@ import { defineAgent } from "eve";
  * Models resolve through Vercel AI Gateway (`provider/model` ids).
  */
 export default defineAgent({
-  model: process.env.EVE_PUZZLE_MODEL || "google/gemini-2.5-flash",
+  model: process.env.EVE_PUZZLE_MODEL || "openai/gpt-5.4-mini",
 });

--- a/apps/web/agent/instructions.md
+++ b/apps/web/agent/instructions.md
@@ -40,8 +40,10 @@ Always call `get_difficulty_brief` for the requested target and keep the final c
 
 - Never put the answer literally in the puzzle display  
 - Prefer visual wordplay (emoji, position, phonetics, math symbols)  
+- Always set a real `techniqueId` from the library — no emoji-padding for funScore  
 - Keep content appropriate for a general audience  
 - Fill metadata: fingerprint, uniqueness, quality, funScore, calibrated difficulty, difficultyLevel  
+- Only return when publishable: quality ≥ 70, funScore ≥ 65, unique, solvable, in-band  
 
 ## Style
 

--- a/apps/web/src/ai/client.ts
+++ b/apps/web/src/ai/client.ts
@@ -14,7 +14,8 @@ import { enforceQuota } from "./quota-manager";
 
 export type ModelTier = "fast" | "smart" | "creative";
 
-function ensureGatewayKey(): void {
+/** Ensure gateway auth env is set (OIDC token → AI_GATEWAY_API_KEY). */
+export function ensureGatewayKey(): void {
   const key = AI_CONFIG.gateway.apiKey;
   if (key && !process.env.AI_GATEWAY_API_KEY) {
     process.env.AI_GATEWAY_API_KEY = key;

--- a/apps/web/src/ai/config.ts
+++ b/apps/web/src/ai/config.ts
@@ -50,9 +50,12 @@ export const AI_CONFIG = {
 
   /** Eve / ToolLoopAgent puzzle generation */
   puzzleAgent: {
-    model: process.env.EVE_PUZZLE_MODEL || "google/gemini-2.5-flash",
-    maxSteps: 16,
+    // Prefer creative-tier models for wordplay; override with EVE_PUZZLE_MODEL
+    model: process.env.EVE_PUZZLE_MODEL || "openai/gpt-5.4-mini",
+    maxSteps: 20,
     qualityThreshold: 70,
+    minFunScore: 65,
+    maxAttempts: 3,
   },
 
   generation: {

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -9,6 +9,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { gateway } from "@ai-sdk/gateway";
 import { Output, stepCountIs, ToolLoopAgent } from "ai";
+import { ensureGatewayKey, getGatewayModelChain } from "../client";
 import { AI_CONFIG } from "../config";
 import { enforceQuota } from "../quota-manager";
 import {
@@ -32,17 +33,45 @@ export interface PuzzleGenerationParams {
 }
 
 function loadInstructions(): string {
+  const fallback = `You are Rebuzzle's puzzle architect. Use tools to inspect type specs, avoid recent answers, validate, check uniqueness, calibrate difficulty, and score quality. Return one publishable puzzle.`;
+
+  let instructions = fallback;
   try {
-    return readFileSync(join(process.cwd(), "agent/instructions.md"), "utf8");
+    instructions = readFileSync(join(process.cwd(), "agent/instructions.md"), "utf8");
   } catch {
-    return `You are Rebuzzle's puzzle architect. Use tools to inspect type specs, avoid recent answers, validate, check uniqueness, calibrate difficulty, and score quality. Return one publishable puzzle.`;
+    // keep fallback
   }
+
+  let skill = "";
+  try {
+    skill = readFileSync(
+      join(process.cwd(), "agent/skills/generate-daily-puzzle.md"),
+      "utf8"
+    );
+  } catch {
+    // optional
+  }
+
+  return [
+    instructions,
+    skill
+      ? `\n\n## Skill: generate-daily-puzzle\n${skill}`
+      : "",
+    "",
+    "## Hard publish rules (non-negotiable)",
+    "- techniqueId is required — pick a real technique from the library; no emoji salad.",
+    "- funScore must come from technique fit + clever wordplay, NOT emoji count padding.",
+    "- rebusPuzzle must be non-empty and must NOT equal or contain the answer.",
+    "- Require overall quality ≥ threshold, funScore ≥ 65, unique, solvable, in-band difficulty.",
+    "- If validation fails, redesign the visual — do not bump scores or ship placeholders.",
+  ].join("\n");
 }
 
-function buildUserMessage(params: PuzzleGenerationParams): string {
+function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string): string {
   const puzzleType = params.puzzleType ?? "rebus";
   const qualityThreshold =
     params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
+  const minFun = AI_CONFIG.puzzleAgent.minFunScore;
 
   const level = getDifficultyLevelForScore(params.targetDifficulty);
 
@@ -55,11 +84,12 @@ function buildUserMessage(params: PuzzleGenerationParams): string {
     params.requireNovelty !== false
       ? "Novelty is required — avoid recent answers and similar visuals."
       : null,
-    `Quality threshold: overall >= ${qualityThreshold}; prefer funScore >= 65.`,
+    `Quality gates: overall >= ${qualityThreshold}, funScore >= ${minFun}, publishable=true, unique, solvable.`,
+    priorFailure ? `Previous attempt failed: ${priorFailure}. Fix that specific issue.` : null,
     "Workflow:",
     "1) get_puzzle_type_spec + get_difficulty_brief",
     "2) list_recent_answers + propose_concept_seeds",
-    "3) assemble_visual_components + craft_hint_ladder",
+    "3) list_technique_library → pick techniqueId, then assemble_visual_components + craft_hint_ladder",
     "4) validate → uniqueness → calibrate → stress_test_solvability → score_quality",
     "5) Revise until in-band, unique, solvable, publishable",
     "6) Return structured result with difficultyLevel + techniqueId",
@@ -68,106 +98,170 @@ function buildUserMessage(params: PuzzleGenerationParams): string {
     .join("\n");
 }
 
+function passesPublishGates(
+  puzzle: {
+    rebusPuzzle: string;
+    answer: string;
+    techniqueId?: string;
+  },
+  quality: { overall: number; funScore?: number; publishable?: boolean; issues?: string[] },
+  qualityThreshold: number
+): { ok: true } | { ok: false; reason: string } {
+  const display = (puzzle.rebusPuzzle || "").trim();
+  const answer = (puzzle.answer || "").trim();
+  const minFun = AI_CONFIG.puzzleAgent.minFunScore;
+
+  if (!display) return { ok: false, reason: "Empty puzzle display" };
+  if (!answer) return { ok: false, reason: "Empty answer" };
+  if (display.toLowerCase() === answer.toLowerCase()) {
+    return { ok: false, reason: "Puzzle text equals answer" };
+  }
+  if (answer.length > 3 && display.toLowerCase().includes(answer.toLowerCase())) {
+    return { ok: false, reason: "Answer leaked into puzzle text" };
+  }
+  if (!puzzle.techniqueId) {
+    return { ok: false, reason: "Missing techniqueId" };
+  }
+  if (quality.overall < qualityThreshold) {
+    return {
+      ok: false,
+      reason: `Quality ${quality.overall} below threshold ${qualityThreshold}`,
+    };
+  }
+  if ((quality.funScore ?? 0) < minFun) {
+    return {
+      ok: false,
+      reason: `funScore ${quality.funScore ?? 0} below ${minFun}`,
+    };
+  }
+  if (quality.publishable === false) {
+    return {
+      ok: false,
+      reason: `Not publishable: ${(quality.issues || []).join("; ") || "failed quality checks"}`,
+    };
+  }
+  return { ok: true };
+}
+
 /**
  * Run the puzzle ToolLoopAgent against AI Gateway.
  */
 export async function runPuzzleAgentGeneration(
   params: PuzzleGenerationParams
 ): Promise<PuzzleAgentResult> {
+  ensureGatewayKey();
   await enforceQuota();
 
   const start = Date.now();
-  const maxAttempts = params.maxAttempts ?? 2;
+  const maxAttempts =
+    params.maxAttempts ?? AI_CONFIG.puzzleAgent.maxAttempts ?? 3;
   const qualityThreshold =
     params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
-  const modelId = AI_CONFIG.puzzleAgent.model;
+
+  // Primary Eve model, then creative-tier fallbacks
+  const modelChain = Array.from(
+    new Set([AI_CONFIG.puzzleAgent.model, ...getGatewayModelChain("creative")])
+  ).slice(0, 3);
 
   let lastError: Error | null = null;
+  let priorFailure: string | undefined;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const agent = new ToolLoopAgent({
-        model: gateway(modelId),
-        instructions: loadInstructions(),
-        tools: puzzleAgentTools,
-        temperature: AI_CONFIG.generation.temperature.creative,
-        stopWhen: stepCountIs(AI_CONFIG.puzzleAgent.maxSteps),
-        output: Output.object({ schema: PuzzleAgentResultSchema }),
-      });
-
-      const result = await agent.generate({
-        prompt: `${buildUserMessage(params)}\n\nAttempt ${attempt}/${maxAttempts}.`,
-        abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.agent),
-      });
-
-      const output = result.output;
-      if (!output) {
-        throw new Error("Puzzle agent returned no structured output");
-      }
-
-      const puzzle = output.puzzle;
-      const calibrated =
-        output.metadata.calibratedDifficulty || puzzle.difficulty;
-      const level = getDifficultyLevelForScore(
-        params.targetDifficulty || calibrated
-      );
-      const fingerprint =
-        output.metadata.fingerprint ||
-        fingerprintCandidate({
-          rebusPuzzle: puzzle.rebusPuzzle,
-          answer: puzzle.answer,
-          category: puzzle.category,
+  for (const modelId of modelChain) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const agent = new ToolLoopAgent({
+          model: gateway(modelId),
+          instructions: loadInstructions(),
+          tools: puzzleAgentTools,
+          temperature: AI_CONFIG.generation.temperature.creative,
+          stopWhen: stepCountIs(AI_CONFIG.puzzleAgent.maxSteps),
+          output: Output.object({ schema: PuzzleAgentResultSchema }),
         });
-      const quality =
-        output.metadata.qualityScore > 0
-          ? {
-              overall: output.metadata.qualityScore,
-              verdict: output.metadata.qualityVerdict,
-              funScore: output.metadata.funScore,
-            }
-          : scorePuzzleQuality({
-              ...puzzle,
-              targetDifficulty: params.targetDifficulty,
-            });
 
-      if (quality.overall < qualityThreshold && attempt < maxAttempts) {
-        lastError = new Error(
-          `Quality ${quality.overall} below threshold ${qualityThreshold}`
+        const result = await agent.generate({
+          prompt: `${buildUserMessage(params, priorFailure)}\n\nModel ${modelId} — attempt ${attempt}/${maxAttempts}.`,
+          abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.agent),
+        });
+
+        const output = result.output;
+        if (!output) {
+          throw new Error("Puzzle agent returned no structured output");
+        }
+
+        const puzzle = output.puzzle;
+        const calibrated =
+          output.metadata.calibratedDifficulty || puzzle.difficulty;
+        const level = getDifficultyLevelForScore(
+          params.targetDifficulty || calibrated
         );
-        continue;
-      }
+        const fingerprint =
+          output.metadata.fingerprint ||
+          fingerprintCandidate({
+            rebusPuzzle: puzzle.rebusPuzzle,
+            answer: puzzle.answer,
+            category: puzzle.category,
+          });
 
-      const difficultyLevel =
-        puzzle.difficultyLevel ||
-        output.metadata.difficultyLevel ||
-        level.label;
-
-      return {
-        ...output,
-        puzzle: {
+        const quality = scorePuzzleQuality({
           ...puzzle,
-          difficulty: calibrated,
-          difficultyLevel,
-        },
-        metadata: {
-          ...output.metadata,
-          fingerprint,
-          calibratedDifficulty: calibrated,
-          difficultyLevel,
-          qualityScore: quality.overall,
-          qualityVerdict: quality.verdict,
-          funScore: quality.funScore ?? output.metadata.funScore,
-          generationAttempts: attempt,
-          thinkingSummary:
-            output.metadata.thinkingSummary ??
-            `${difficultyLevel} puzzle via ToolLoopAgent + AI Gateway (${modelId}) in ${Date.now() - start}ms`,
-        },
-        status: "success",
-        recommendations: output.recommendations ?? [],
-      };
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      if (attempt >= maxAttempts) break;
+          targetDifficulty: params.targetDifficulty,
+          techniqueId: puzzle.techniqueId,
+        });
+
+        const gate = passesPublishGates(
+          {
+            rebusPuzzle: puzzle.rebusPuzzle,
+            answer: puzzle.answer,
+            techniqueId: puzzle.techniqueId,
+          },
+          {
+            overall: quality.overall,
+            funScore: quality.funScore,
+            publishable: quality.publishable,
+            issues: quality.issues,
+          },
+          qualityThreshold
+        );
+
+        if (!gate.ok) {
+          priorFailure = gate.reason;
+          lastError = new Error(gate.reason);
+          continue;
+        }
+
+        const difficultyLevel =
+          puzzle.difficultyLevel ||
+          output.metadata.difficultyLevel ||
+          level.label;
+
+        return {
+          ...output,
+          puzzle: {
+            ...puzzle,
+            difficulty: calibrated,
+            difficultyLevel,
+            techniqueId: puzzle.techniqueId,
+          },
+          metadata: {
+            ...output.metadata,
+            fingerprint,
+            calibratedDifficulty: calibrated,
+            difficultyLevel,
+            qualityScore: quality.overall,
+            qualityVerdict: quality.verdict,
+            funScore: quality.funScore ?? output.metadata.funScore,
+            generationAttempts: attempt,
+            thinkingSummary:
+              output.metadata.thinkingSummary ??
+              `${difficultyLevel} puzzle via Eve ToolLoopAgent + AI Gateway (${modelId}) in ${Date.now() - start}ms`,
+          },
+          status: "success",
+          recommendations: output.recommendations ?? [],
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        priorFailure = lastError.message;
+      }
     }
   }
 

--- a/apps/web/src/ai/puzzle-agent/tool-impl.ts
+++ b/apps/web/src/ai/puzzle-agent/tool-impl.ts
@@ -222,14 +222,17 @@ export function assembleVisualComponents(input: {
     }
   }
 
+  // Reward technique fit + spatial structure; cap emoji so agents can't pad for funScore
+  const emojiBonus = Math.min(12, emojiCount * 3);
   const funScore = Math.max(
     0,
     Math.min(
       100,
-      55 +
-        emojiCount * 6 +
+      50 +
+        emojiBonus +
         components.arrows.length * 8 +
-        (technique ? 10 : 0) -
+        components.symbols.length * 4 +
+        (technique ? 18 : -12) -
         issues.length * 15
     )
   );
@@ -448,6 +451,11 @@ export function scorePuzzleQuality(
   } else {
     strengths.push(`${input.hints.length} hints`);
   }
+  if (!input.techniqueId) {
+    issues.push("Missing techniqueId — pick a named technique from the library");
+  } else {
+    strengths.push(`Technique ${input.techniqueId}`);
+  }
 
   const assembly = assembleVisualComponents({
     answer,
@@ -470,7 +478,8 @@ export function scorePuzzleQuality(
   score -= issues.length * 11;
   score += Math.min(12, strengths.length * 3);
   score += Math.round((assembly.funScore - 50) / 10);
-  if (hasEmoji) score += 3;
+  // Small visual bonus only — technique already weighted in funScore
+  if (hasEmoji && input.techniqueId) score += 2;
   score = Math.max(0, Math.min(100, score));
 
   const verdict =
@@ -491,7 +500,7 @@ export function scorePuzzleQuality(
     issues,
     funScore: assembly.funScore,
     tier: level.label,
-    publishable: score >= 70 && issues.length === 0,
+    publishable: score >= 70 && issues.length === 0 && Boolean(input.techniqueId),
   };
 }
 

--- a/apps/web/src/app/actions/gameActions.ts
+++ b/apps/web/src/app/actions/gameActions.ts
@@ -174,7 +174,7 @@ export async function fetchGameData(_isPreview = false): Promise<PublicGameData>
 
     const metadata = {
       topic: puzzle.topic,
-      keyword: puzzle.keyword,
+      // Never include keyword — it was derived from the answer
       category: puzzle.category,
       relevanceScore: puzzle.relevanceScore,
       hints: puzzle.hints,
@@ -182,7 +182,7 @@ export async function fetchGameData(_isPreview = false): Promise<PublicGameData>
     } as PuzzleMetadata;
 
     return {
-      id: puzzle.id || puzzle.keyword || "",
+      id: puzzle.id || "",
       puzzle: puzzleDisplay,
       puzzleType,
       // answer omitted — never ship the solution to an active client

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -134,8 +134,8 @@ async function getOrGenerateDailyPuzzle(dateString: string, puzzleType?: string)
       targetDifficulty: difficulty,
       requireNovelty: true,
       qualityThreshold: 70,
-      maxAttempts: 3, // Increased from 2 to 3 for better chance of success
-      puzzleType: typeToUse, // Use config-driven puzzle type
+      maxAttempts: 4,
+      puzzleType: typeToUse,
     });
 
     logger.info("AI puzzle generation successful", {
@@ -429,16 +429,16 @@ export async function previewPuzzleGeneration() {
     const result = await generateMasterPuzzle({
       targetDifficulty: 5,
       requireNovelty: true,
-      qualityThreshold: 70, // Lowered for more realistic testing
-      maxAttempts: 1,
+      qualityThreshold: 70,
+      maxAttempts: 2,
     });
 
     return {
       success: true,
       puzzle: result.puzzle,
       metadata: result.metadata,
-      message: "Successfully generated puzzle with Google AI",
-      provider: "google-gemini",
+      message: "Successfully generated puzzle via Eve ToolLoopAgent + AI Gateway",
+      provider: "ai-gateway",
     };
   } catch (error) {
     logger.error(

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -4,6 +4,7 @@ import { revalidateTag } from "next/cache";
 import { generateMasterPuzzle } from "@/ai/advanced";
 import { db } from "@/db";
 import { getCachedDailyPuzzleFromDb } from "@/lib/cache/daily-puzzle";
+import { persistDailyPuzzle } from "@/lib/game/persist-daily-puzzle";
 import { logger } from "@/lib/logger";
 
 /**
@@ -180,135 +181,67 @@ async function getOrGenerateDailyPuzzle(dateString: string, puzzleType?: string)
       }
     }
 
-    // Extract puzzle data - handle both rebus and other puzzle types
-    const puzzleData: any = {
-      id: `ai-${dateString}`,
-      puzzle: puzzleDisplay, // Generic puzzle field (works for all types)
-      puzzleType: typeToUse, // Store puzzle type
+    // Persist first — clients must receive a real DB id for /api/puzzles/guess
+    const persisted = await persistDailyPuzzle({
+      dateString,
+      puzzleDisplay,
+      puzzleType: typeToUse,
+      answer: result.puzzle.answer,
+      difficulty: result.puzzle.difficulty,
+      category: result.puzzle.category || "general",
+      explanation: result.puzzle.explanation,
+      hints: result.puzzle.hints || [],
+      aiGenerated: true,
+      rebusPuzzle: typeToUse === "rebus" ? puzzleDisplay : undefined,
+      metadataExtra: {
+        qualityScore: result.metadata.qualityMetrics?.scores?.overall,
+        uniquenessScore: result.metadata.uniquenessScore,
+      },
+    });
+
+    // Best-effort embedding (non-blocking)
+    void (async () => {
+      try {
+        const { generatePuzzleEmbedding, isEmbeddingAvailable } = await import(
+          "@/ai/services/embeddings"
+        );
+        if (isEmbeddingAvailable()) {
+          const embedding = await generatePuzzleEmbedding({
+            puzzle: puzzleDisplay,
+            answer: result.puzzle.answer,
+            category: result.puzzle.category,
+            puzzleType: typeToUse,
+            explanation: result.puzzle.explanation,
+          });
+          await db.puzzleOps.updateEmbedding(persisted.id, embedding);
+        }
+      } catch (embeddingError) {
+        logger.warn("Failed to generate embedding (non-critical)", {
+          error:
+            embeddingError instanceof Error ? embeddingError.message : String(embeddingError),
+        });
+      }
+    })();
+
+    return {
+      id: persisted.id,
+      puzzle: puzzleDisplay,
+      rebusPuzzle: typeToUse === "rebus" ? puzzleDisplay : undefined,
+      puzzleType: typeToUse,
       difficulty: result.puzzle.difficulty,
       answer: result.puzzle.answer,
       explanation: result.puzzle.explanation,
       hints: result.puzzle.hints,
       date: dateString,
       topic: result.puzzle.category,
-      keyword: result.puzzle.answer.replace(/\s+/g, ""),
       category: result.puzzle.category,
       relevanceScore: Math.round((result.metadata.qualityMetrics?.scores?.overall || 85) / 10),
-      seoMetadata: {
-        keywords: [result.puzzle.answer, `${typeToUse} puzzle`, "AI generated", "brain teaser"],
-        description: `Solve this AI-generated ${typeToUse} puzzle: ${result.puzzle.answer}`,
-        ogTitle: `Rebuzzle: ${result.puzzle.answer} Puzzle`,
-        ogDescription: `Challenge yourself with today's AI-generated ${typeToUse} puzzle. Can you solve it?`,
-      },
       aiGenerated: true,
       generationMethod: "ai-master",
       qualityScore: result.metadata.qualityMetrics?.scores?.overall || 0,
       uniquenessScore: result.metadata.uniquenessScore || 0,
+      fromDatabase: true,
     };
-
-    // Add legacy rebusPuzzle field for backward compatibility
-    if (typeToUse === "rebus" && puzzleDisplay) {
-      puzzleData.rebusPuzzle = puzzleDisplay;
-    }
-
-    // Add any other puzzle-specific fields
-    for (const key of Object.keys(result.puzzle)) {
-      if (
-        !puzzleData[key] &&
-        key !== "difficulty" &&
-        key !== "answer" &&
-        key !== "explanation" &&
-        key !== "hints" &&
-        key !== "category" &&
-        key !== puzzleDisplayField
-      ) {
-        puzzleData[key] = (result.puzzle as Record<string, any>)[key];
-      }
-    }
-
-    // STEP 3: Store in database for all future users today
-    try {
-      // Bind publishedAt to the UTC dateString so findByDate lookups match
-      const publishedAt = new Date(`${dateString}T00:00:00.000Z`);
-
-      const puzzle = {
-        id: crypto.randomUUID(),
-        puzzle: puzzleData.puzzle, // Generic puzzle field
-        puzzleType: typeToUse, // Store puzzle type
-        answer: result.puzzle.answer,
-        difficulty: (result.puzzle.difficulty <= 3
-          ? "easy"
-          : result.puzzle.difficulty <= 7
-            ? "medium"
-            : "hard") as "easy" | "medium" | "hard",
-        category: result.puzzle.category || "general",
-        explanation: result.puzzle.explanation,
-        hints: result.puzzle.hints || [],
-        publishedAt,
-        createdAt: new Date(),
-        active: true,
-        metadata: {
-          topic: result.puzzle.category,
-          keyword: result.puzzle.answer.replace(/\s+/g, ""),
-          category: result.puzzle.category,
-          puzzleType: typeToUse, // Store in metadata too
-          seoMetadata: puzzleData.seoMetadata,
-          aiGenerated: true,
-          qualityScore: result.metadata.qualityMetrics?.scores?.overall,
-          uniquenessScore: result.metadata.uniquenessScore,
-          generatedAt: new Date().toISOString(),
-        },
-        // Legacy field for backward compatibility
-        rebusPuzzle: typeToUse === "rebus" ? puzzleData.puzzle : undefined,
-      };
-
-      await db.puzzleOps.create(puzzle);
-
-      logger.info("Puzzle stored in database", {
-        puzzleId: puzzle.id,
-        futureRequestsFree: true,
-      });
-
-      // Revalidate the daily-puzzle cache so all users see the new puzzle immediately
-      revalidateTag("daily-puzzle", "max");
-      logger.info("Puzzle cache revalidated");
-
-      // Generate embedding asynchronously (non-blocking)
-      // This enables semantic search and recommendations
-      (async () => {
-        try {
-          const { generatePuzzleEmbedding, isEmbeddingAvailable } = await import(
-            "@/ai/services/embeddings"
-          );
-          if (isEmbeddingAvailable()) {
-            const embedding = await generatePuzzleEmbedding({
-              puzzle: puzzle.puzzle,
-              answer: puzzle.answer,
-              category: puzzle.category,
-              puzzleType: typeToUse,
-              explanation: puzzle.explanation,
-            });
-
-            // Update puzzle with embedding using puzzleOps
-            await db.puzzleOps.updateEmbedding(puzzle.id, embedding);
-            logger.info("Generated puzzle embedding for semantic search");
-          }
-        } catch (embeddingError) {
-          logger.warn("Failed to generate embedding (non-critical)", {
-            error:
-              embeddingError instanceof Error ? embeddingError.message : String(embeddingError),
-          });
-        }
-      })();
-    } catch (saveError) {
-      logger.error(
-        "Failed to store puzzle - will regenerate on next request",
-        saveError instanceof Error ? saveError : new Error(String(saveError)),
-        { willUseMoreTokens: true }
-      );
-    }
-
-    return puzzleData;
   } catch (error) {
     logger.error(
       "Failed to generate puzzle with AI",
@@ -318,33 +251,44 @@ async function getOrGenerateDailyPuzzle(dateString: string, puzzleType?: string)
       }
     );
 
-    // STEP 4: AI failed - use emergency fallback
-    // Use the dateString parameter to calculate day of year
-    const puzzleDate = new Date(`${dateString}T00:00:00Z`);
-    const yearStart = new Date(puzzleDate.getFullYear(), 0, 0);
-    const dayOfYear = Math.floor((puzzleDate.getTime() - yearStart.getTime()) / 86_400_000);
-    const fallbackIndex = dayOfYear % FALLBACK_PUZZLES.length;
-    const fallback = FALLBACK_PUZZLES[fallbackIndex]!;
+    // STEP 4: AI failed — persist a deterministic fallback so guessing still works
+    const [y, m, d] = dateString.split("-").map(Number);
+    const dayOfYear = Math.floor(
+      (Date.UTC(y!, (m ?? 1) - 1, d ?? 1) - Date.UTC(y!, 0, 0)) / 86_400_000
+    );
+    const fallback = FALLBACK_PUZZLES[dayOfYear % FALLBACK_PUZZLES.length]!;
 
-    logger.warn("Using emergency fallback puzzle", {
-      answer: fallback.answer,
+    logger.warn("Persisting emergency fallback puzzle", {
+      dateString,
       reason: "AI generation failed",
     });
 
+    const persisted = await persistDailyPuzzle({
+      dateString,
+      puzzleDisplay: fallback.rebusPuzzle,
+      puzzleType: "rebus",
+      answer: fallback.answer,
+      difficulty: fallback.difficulty,
+      category: fallback.category,
+      explanation: fallback.explanation,
+      hints: fallback.hints,
+      aiGenerated: false,
+      rebusPuzzle: fallback.rebusPuzzle,
+      metadataExtra: {
+        fallbackReason: error instanceof Error ? error.message : "AI generation failed",
+      },
+    });
+
     return {
-      id: `fallback-${dateString}`,
+      id: persisted.id,
       ...fallback,
+      puzzle: fallback.rebusPuzzle,
+      puzzleType: "rebus",
       date: dateString,
       topic: fallback.category,
-      keyword: fallback.answer,
       relevanceScore: 7,
-      seoMetadata: {
-        keywords: [fallback.answer, "rebus puzzle", "word game", "brain teaser"],
-        description: `Solve this rebus puzzle: ${fallback.answer}`,
-        ogTitle: `Rebuzzle: ${fallback.answer} Puzzle`,
-        ogDescription: `Challenge yourself with today's rebus puzzle.`,
-      },
       aiGenerated: false,
+      fromDatabase: true,
       fallbackReason: error instanceof Error ? error.message : "AI generation failed",
     };
   }
@@ -383,28 +327,55 @@ export async function getTodaysPuzzle(puzzleType?: string, dateString?: string) 
       error instanceof Error ? error : new Error(String(error))
     );
 
-    // Last resort fallback
+    // Last resort — still persist so /api/puzzles/guess can resolve the id
     const lastResortPuzzle = FALLBACK_PUZZLES[0]!;
-    // Use provided date string or get today's date
     const todayString = dateString || getTodayDateString();
 
-    return {
-      success: true,
-      puzzle: {
-        id: `emergency-fallback-${todayString}`,
-        ...lastResortPuzzle,
-        date: todayString,
-        topic: lastResortPuzzle.category,
-        keyword: lastResortPuzzle.answer,
-        relevanceScore: 5,
+    try {
+      const persisted = await persistDailyPuzzle({
+        dateString: todayString,
+        puzzleDisplay: lastResortPuzzle.rebusPuzzle,
+        puzzleType: "rebus",
+        answer: lastResortPuzzle.answer,
+        difficulty: lastResortPuzzle.difficulty,
+        category: lastResortPuzzle.category,
+        explanation: lastResortPuzzle.explanation,
+        hints: lastResortPuzzle.hints,
         aiGenerated: false,
-        fallbackReason: "Emergency fallback",
-      },
-      generatedAt: new Date().toISOString(),
-      cached: false,
-      fallback: true,
-      emergency: true,
-    };
+        rebusPuzzle: lastResortPuzzle.rebusPuzzle,
+        metadataExtra: { fallbackReason: "Emergency fallback" },
+      });
+
+      return {
+        success: true,
+        puzzle: {
+          id: persisted.id,
+          ...lastResortPuzzle,
+          puzzle: lastResortPuzzle.rebusPuzzle,
+          puzzleType: "rebus",
+          date: todayString,
+          topic: lastResortPuzzle.category,
+          relevanceScore: 5,
+          aiGenerated: false,
+          fromDatabase: true,
+          fallbackReason: "Emergency fallback",
+        },
+        generatedAt: new Date().toISOString(),
+        cached: false,
+        fallback: true,
+        emergency: true,
+      };
+    } catch (persistError) {
+      logger.error(
+        "Failed to persist emergency fallback",
+        persistError instanceof Error ? persistError : new Error(String(persistError))
+      );
+      return {
+        success: false,
+        error: "Unable to load today's puzzle",
+        generatedAt: new Date().toISOString(),
+      };
+    }
   }
 }
 

--- a/apps/web/src/app/actions/regeneratePuzzleActions.ts
+++ b/apps/web/src/app/actions/regeneratePuzzleActions.ts
@@ -1,12 +1,13 @@
 "use server";
 
+import { revalidateTag } from "next/cache";
 import type { Puzzle } from "@/db/models";
 import { getCollection } from "@/db/mongodb";
+import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
 import { getTodaysPuzzle } from "./puzzleGenerationActions";
 
 /**
- * Delete today's puzzle from the database
- * This allows regenerating it with the new system
+ * Delete today's puzzle from the database (UTC day window only).
  */
 export async function deleteTodaysPuzzle(): Promise<{
   success: boolean;
@@ -14,18 +15,23 @@ export async function deleteTodaysPuzzle(): Promise<{
 }> {
   try {
     const collection = getCollection<Puzzle>("puzzles");
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);  // Use UTC for consistent behavior
+    const dateKey = getUtcPuzzleDate();
+    const start = new Date(`${dateKey}T00:00:00.000Z`);
+    const end = new Date(`${dateKey}T23:59:59.999Z`);
 
     const result = await collection.deleteMany({
-      publishedAt: { $gte: today },
+      publishedAt: { $gte: start, $lte: end },
       active: true,
     });
+
+    // Must bust Data Cache or getTodaysPuzzle will keep serving the deleted row
+    revalidateTag("daily-puzzle", "max");
+    revalidateTag(`daily-puzzle-${dateKey}`, "max");
 
     if (result.deletedCount > 0) {
       return {
         success: true,
-        message: `Deleted ${result.deletedCount} puzzle(s) for today`,
+        message: `Deleted ${result.deletedCount} puzzle(s) for ${dateKey}`,
       };
     }
 
@@ -43,16 +49,12 @@ export async function deleteTodaysPuzzle(): Promise<{
 }
 
 /**
- * Regenerate today's puzzle using the new system
- * This deletes the old puzzle and generates a new one
- *
- * @param puzzleType - Optional puzzle type (e.g., "rebus", "word-puzzle"). Defaults to DEFAULT_PUZZLE_TYPE or "rebus"
+ * Regenerate today's puzzle (admin path only — callers must authorize).
  */
 export async function regenerateTodaysPuzzle(
   puzzleType?: string
-): Promise<{ success: boolean; message: string; puzzle?: any }> {
+): Promise<{ success: boolean; message: string; puzzle?: unknown }> {
   try {
-    // Step 1: Delete today's puzzle
     const deleteResult = await deleteTodaysPuzzle();
     if (!deleteResult.success) {
       return {
@@ -61,15 +63,14 @@ export async function regenerateTodaysPuzzle(
       };
     }
 
-    console.log(`✅ Deleted old puzzle: ${deleteResult.message}`);
-
-    // Step 2: Generate new puzzle (this will use the new system)
     const puzzleResult = await getTodaysPuzzle(puzzleType);
 
     if (!(puzzleResult.success && puzzleResult.puzzle)) {
       return {
         success: false,
-        message: `Failed to generate new puzzle: ${"error" in puzzleResult ? puzzleResult.error : "Unknown error"}`,
+        message: `Failed to generate new puzzle: ${
+          "error" in puzzleResult ? puzzleResult.error : "Unknown error"
+        }`,
       };
     }
 
@@ -77,7 +78,7 @@ export async function regenerateTodaysPuzzle(
 
     return {
       success: true,
-      message: `Successfully regenerated today's puzzle with the new system (type: ${typeUsed})`,
+      message: `Successfully regenerated today's puzzle (type: ${typeUsed})`,
       puzzle: puzzleResult.puzzle,
     };
   } catch (error) {

--- a/apps/web/src/app/api/dev/session/route.ts
+++ b/apps/web/src/app/api/dev/session/route.ts
@@ -1,0 +1,148 @@
+/**
+ * Temporary Dev Mode APIs — admin only.
+ * Lets you regenerate puzzles and walk gated play states while tuning Eve.
+ */
+
+import { NextResponse } from "next/server";
+import { regenerateTodaysPuzzle } from "@/app/actions/regeneratePuzzleActions";
+import { db } from "@/db";
+import { verifyAdminAccess } from "@/lib/admin-auth";
+import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
+import { toPublicPuzzle } from "@/lib/game/public-puzzle";
+
+export async function GET(request: Request) {
+  const admin = await verifyAdminAccess(request);
+  if (!admin) {
+    return NextResponse.json({ success: false, allowed: false }, { status: 403 });
+  }
+
+  const puzzleDate = getUtcPuzzleDate();
+  const [puzzle, lock] = await Promise.all([
+    db.puzzleOps.findTodaysPuzzle(),
+    db.puzzleAttemptOps.hasTodayAttempt(admin.id, puzzleDate),
+  ]);
+
+  return NextResponse.json({
+    success: true,
+    allowed: true,
+    puzzleDate,
+    puzzle: puzzle
+      ? toPublicPuzzle({
+          id: puzzle.id,
+          puzzle: puzzle.puzzle ?? puzzle.rebusPuzzle,
+          puzzleType: puzzle.puzzleType ?? "rebus",
+          difficulty: puzzle.difficulty,
+        })
+      : null,
+    lock,
+  });
+}
+
+type DevAction =
+  | "clear-attempts"
+  | "lock-win"
+  | "lock-lose"
+  | "regenerate";
+
+export async function POST(request: Request) {
+  try {
+    const admin = await verifyAdminAccess(request);
+    if (!admin) {
+      return NextResponse.json(
+        { success: false, error: "Admin access required for Dev Mode actions" },
+        { status: 403 }
+      );
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      action?: DevAction;
+      puzzleType?: string;
+    };
+
+    const action = body.action;
+    if (!action) {
+      return NextResponse.json({ success: false, error: "action required" }, { status: 400 });
+    }
+
+    const puzzleDate = getUtcPuzzleDate();
+
+    if (action === "clear-attempts") {
+      const deleted = await db.puzzleAttemptOps.clearAttemptsForDate(admin.id, puzzleDate);
+      return NextResponse.json({
+        success: true,
+        action,
+        deleted,
+        message: `Cleared ${deleted} attempt(s) for ${puzzleDate}`,
+      });
+    }
+
+    if (action === "lock-win" || action === "lock-lose") {
+      const puzzle = await db.puzzleOps.findTodaysPuzzle();
+      if (!puzzle) {
+        return NextResponse.json(
+          { success: false, error: "No puzzle for today — regenerate first" },
+          { status: 404 }
+        );
+      }
+
+      await db.puzzleAttemptOps.clearAttemptsForDate(admin.id, puzzleDate);
+
+      const isWin = action === "lock-win";
+      await db.puzzleAttemptOps.create({
+        id: crypto.randomUUID(),
+        userId: admin.id,
+        puzzleId: puzzle.id,
+        attemptedAnswer: isWin ? puzzle.answer : "dev-mode-wrong-guess",
+        isCorrect: isWin,
+        abandoned: !isWin,
+        isFinal: true,
+        puzzleDate,
+        attemptedAt: new Date(),
+        completedAt: isWin ? new Date() : undefined,
+        attemptNumber: isWin ? 1 : 5,
+        maxAttempts: 5,
+        timeSpentSeconds: 42,
+        hintsUsed: 0,
+      });
+
+      return NextResponse.json({
+        success: true,
+        action,
+        message: isWin ? "Locked as WIN for today" : "Locked as LOSS for today",
+        puzzleId: puzzle.id,
+      });
+    }
+
+    if (action === "regenerate") {
+      // Clear personal lock so the new puzzle is immediately playable
+      await db.puzzleAttemptOps.clearAttemptsForDate(admin.id, puzzleDate);
+      const result = await regenerateTodaysPuzzle(body.puzzleType || undefined);
+      if (!result.success) {
+        return NextResponse.json(
+          { success: false, error: result.message },
+          { status: 500 }
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        action,
+        message: result.message,
+        puzzle: result.puzzle
+          ? toPublicPuzzle(result.puzzle as Record<string, unknown>)
+          : undefined,
+      });
+    }
+
+    return NextResponse.json({ success: false, error: "Unknown action" }, { status: 400 });
+  } catch (error) {
+    console.error("[dev/session]", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Dev action failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/puzzle/preview/route.ts
+++ b/apps/web/src/app/api/puzzle/preview/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse } from "next/server";
 import { previewPuzzleGeneration } from "../../../actions/puzzleGenerationActions";
+import { verifyAdminAccess } from "@/lib/admin-auth";
 
-export async function GET() {
+/**
+ * Admin-only AI generation smoke test. Returns generated content to admins only.
+ */
+export async function GET(request: Request) {
   try {
+    const admin = await verifyAdminAccess(request);
+    if (!admin) {
+      return NextResponse.json({ success: false, error: "Admin access required" }, { status: 403 });
+    }
+
     const result = await previewPuzzleGeneration();
 
     if (result.success) {
       return NextResponse.json({
         success: true,
-        puzzle: result.puzzle, // Changed from puzzles to puzzle
+        puzzle: result.puzzle,
         metadata: result.metadata,
         message: result.message,
         provider: result.provider,

--- a/apps/web/src/app/api/puzzle/regenerate/route.ts
+++ b/apps/web/src/app/api/puzzle/regenerate/route.ts
@@ -1,42 +1,37 @@
 import { NextResponse } from "next/server";
 import { hasPuzzleType, listPuzzleTypes } from "@/ai/config/puzzle-types";
 import { regenerateTodaysPuzzle } from "@/app/actions/regeneratePuzzleActions";
+import { verifyAdminAccess } from "@/lib/admin-auth";
+import { toPublicPuzzle } from "@/lib/game/public-puzzle";
 
 /**
- * API endpoint to regenerate today's puzzle
- *
- * This deletes the old puzzle and generates a new one using the new system
- *
- * Usage:
- * - GET /api/puzzle/regenerate - Regenerate with default puzzle type
- * - GET /api/puzzle/regenerate?type=rebus - Regenerate with specific type
- * - GET /api/puzzle/regenerate?type=word-puzzle - Generate word puzzle
- * - GET /api/puzzle/regenerate?list=true - List available puzzle types
+ * Admin-only: regenerate today's puzzle.
  */
 export async function GET(request: Request) {
   try {
+    const admin = await verifyAdminAccess(request);
+    if (!admin) {
+      return NextResponse.json({ success: false, error: "Admin access required" }, { status: 403 });
+    }
+
     const { searchParams } = new URL(request.url);
     const listTypes = searchParams.get("list") === "true";
     const puzzleType = searchParams.get("type");
 
-    // List available puzzle types
     if (listTypes) {
-      const types = listPuzzleTypes();
       return NextResponse.json({
         success: true,
-        availableTypes: types,
+        availableTypes: listPuzzleTypes(),
         defaultType: process.env.DEFAULT_PUZZLE_TYPE || "rebus",
       });
     }
 
-    // Validate puzzle type if provided
     if (puzzleType && !hasPuzzleType(puzzleType)) {
-      const availableTypes = listPuzzleTypes();
       return NextResponse.json(
         {
           success: false,
           error: `Invalid puzzle type: "${puzzleType}"`,
-          availableTypes,
+          availableTypes: listPuzzleTypes(),
         },
         { status: 400 }
       );
@@ -46,10 +41,7 @@ export async function GET(request: Request) {
 
     if (!result.success) {
       return NextResponse.json(
-        {
-          success: false,
-          error: result.message,
-        },
+        { success: false, error: result.message },
         { status: 500 }
       );
     }
@@ -57,7 +49,11 @@ export async function GET(request: Request) {
     return NextResponse.json({
       success: true,
       message: result.message,
-      puzzle: result.puzzle,
+      // Never ship the answer even to admin list UIs via this route's default —
+      // admin tools that need it should use the admin puzzles API.
+      puzzle: result.puzzle
+        ? toPublicPuzzle(result.puzzle as Record<string, unknown>)
+        : undefined,
     });
   } catch (error) {
     console.error("Error regenerating puzzle:", error);

--- a/apps/web/src/app/api/puzzle/today/route.ts
+++ b/apps/web/src/app/api/puzzle/today/route.ts
@@ -1,49 +1,62 @@
 import { NextResponse } from "next/server";
 import { getTodaysPuzzle } from "../../../actions/puzzleGenerationActions";
+import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { toPublicPuzzle } from "@/lib/game/public-puzzle";
 
+/**
+ * GET /api/puzzle/today
+ *
+ * Public daily puzzle for clients. Never includes the answer.
+ * Scoring goes through POST /api/puzzles/guess.
+ */
 export async function GET() {
   try {
     const result = await getTodaysPuzzle();
-
-    // Calculate next puzzle time (next midnight UTC)
     const now = new Date();
-    const tomorrow = new Date(now);
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-    tomorrow.setUTCHours(0, 0, 0, 0);
+    const nextPuzzleTime = getNextUtcMidnight(now).toISOString();
 
-    if (result.success) {
+    if (result.success && result.puzzle) {
+      const raw = result.puzzle as Record<string, unknown>;
       return NextResponse.json({
         success: true,
-        puzzle: result.puzzle,
+        puzzle: toPublicPuzzle({
+          id: raw.id,
+          puzzle: raw.puzzle ?? raw.rebusPuzzle,
+          rebusPuzzle: raw.rebusPuzzle,
+          puzzleType: raw.puzzleType ?? "rebus",
+          difficulty: raw.difficulty,
+          hints: raw.hints ?? [],
+          date: raw.date,
+          category: raw.category,
+          topic: raw.topic,
+          relevanceScore: raw.relevanceScore,
+          aiGenerated: raw.aiGenerated ?? false,
+        }),
         cached: result.cached,
         generatedAt: result.generatedAt,
-        // Server time data for accurate countdown
         serverTime: now.toISOString(),
-        nextPuzzleTime: tomorrow.toISOString(),
+        nextPuzzleTime,
       });
     }
+
     return NextResponse.json(
       {
         success: false,
         error: "Failed to generate puzzle",
         serverTime: now.toISOString(),
-        nextPuzzleTime: tomorrow.toISOString(),
+        nextPuzzleTime,
       },
       { status: 500 }
     );
   } catch (error) {
     console.error("Error in puzzle API:", error);
     const now = new Date();
-    const tomorrow = new Date(now);
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-    tomorrow.setUTCHours(0, 0, 0, 0);
-
     return NextResponse.json(
       {
         success: false,
         error: "Internal server error",
         serverTime: now.toISOString(),
-        nextPuzzleTime: tomorrow.toISOString(),
+        nextPuzzleTime: getNextUtcMidnight(now).toISOString(),
       },
       { status: 500 }
     );

--- a/apps/web/src/app/api/puzzles/guess/route.ts
+++ b/apps/web/src/app/api/puzzles/guess/route.ts
@@ -169,7 +169,15 @@ export async function POST(request: Request) {
     const attemptsLeft = isCorrect ? 0 : Math.max(0, maxAttempts - attemptNumber);
     const wordResults = buildWordResults(guess, puzzle.answer);
     const difficultyLevel =
-      typeof puzzle.difficulty === "number" ? puzzle.difficulty : Number(puzzle.difficulty) || 5;
+      typeof puzzle.difficulty === "number"
+        ? puzzle.difficulty
+        : puzzle.difficulty === "easy"
+          ? 3
+          : puzzle.difficulty === "hard"
+            ? 7
+            : puzzle.difficulty === "medium"
+              ? 5
+              : Number(puzzle.difficulty) || 5;
 
     const attemptData = {
       id: crypto.randomUUID(),
@@ -195,7 +203,7 @@ export async function POST(request: Request) {
       attemptData
     );
 
-    if (!write.success && isFinal) {
+    if (!write.success) {
       return NextResponse.json(
         {
           success: false,

--- a/apps/web/src/app/api/puzzles/recommendations/route.ts
+++ b/apps/web/src/app/api/puzzles/recommendations/route.ts
@@ -1,24 +1,38 @@
 /**
- * Puzzle Recommendations API
- *
- * Provides personalized puzzle recommendations for users
+ * Puzzle Recommendations API — auth required; answers stripped.
  */
 
 import { NextResponse } from "next/server";
 import { getPersonalizedPuzzles, recommendNextPuzzle } from "@/ai/services/recommendations";
+import { getAuthenticatedUser } from "@/lib/auth-middleware";
+import { toPublicPuzzle } from "@/lib/game/public-puzzle";
+
+function sanitizeRecommendation(rec: unknown): unknown {
+  if (!rec || typeof rec !== "object") return rec;
+  const obj = rec as Record<string, unknown>;
+  if (obj.puzzle && typeof obj.puzzle === "object") {
+    return {
+      ...obj,
+      puzzle: toPublicPuzzle(obj.puzzle as Record<string, unknown>),
+    };
+  }
+  return toPublicPuzzle(obj);
+}
 
 export async function GET(request: Request) {
   try {
+    const authUser = await getAuthenticatedUser(request);
+    if (!authUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
-    const userId = searchParams.get("userId");
     const currentPuzzleId = searchParams.get("currentPuzzleId");
     const limit = Number.parseInt(searchParams.get("limit") || "10", 10);
 
-    if (!userId) {
-      return NextResponse.json({ error: "userId is required" }, { status: 400 });
-    }
+    // Always use the authenticated user — never trust client userId
+    const userId = authUser.userId;
 
-    // If currentPuzzleId is provided, recommend next puzzle
     if (currentPuzzleId) {
       const recommendation = await recommendNextPuzzle(userId, currentPuzzleId);
 
@@ -28,16 +42,15 @@ export async function GET(request: Request) {
 
       return NextResponse.json({
         success: true,
-        recommendation,
+        recommendation: sanitizeRecommendation(recommendation),
       });
     }
 
-    // Otherwise, get personalized recommendations
     const recommendations = await getPersonalizedPuzzles(userId, limit);
 
     return NextResponse.json({
       success: true,
-      recommendations,
+      recommendations: recommendations.map(sanitizeRecommendation),
       count: recommendations.length,
     });
   } catch (error) {

--- a/apps/web/src/app/api/puzzles/semantic-search/route.ts
+++ b/apps/web/src/app/api/puzzles/semantic-search/route.ts
@@ -1,48 +1,48 @@
 /**
- * Semantic Search API
- *
- * Provides semantic search capabilities for finding similar puzzles
+ * Semantic Search API — admin only; answers stripped from results.
  */
 
 import { NextResponse } from "next/server";
 import { findSimilarPuzzles, searchPuzzlesByConcept } from "@/ai/services/semantic-search";
+import { verifyAdminAccess } from "@/lib/admin-auth";
+import { toPublicPuzzle } from "@/lib/game/public-puzzle";
 
 export async function GET(request: Request) {
   try {
+    const admin = await verifyAdminAccess(request);
+    if (!admin) {
+      return NextResponse.json({ success: false, error: "Admin access required" }, { status: 403 });
+    }
+
     const { searchParams } = new URL(request.url);
     const puzzleId = searchParams.get("puzzleId");
     const concept = searchParams.get("concept");
     const limitParam = Number.parseInt(searchParams.get("limit") || "10", 10);
     const minSimilarityParam = Number.parseFloat(searchParams.get("minSimilarity") || "0.7");
 
-    // Validate and clamp parameters
     const limit = Number.isNaN(limitParam) || limitParam < 1 ? 10 : Math.min(limitParam, 100);
     const minSimilarity = Number.isNaN(minSimilarityParam)
       ? 0.7
       : Math.max(0, Math.min(1, minSimilarityParam));
 
-    // Search by puzzle ID (find similar puzzles)
     if (puzzleId) {
       const results = await findSimilarPuzzles(puzzleId, limit, minSimilarity);
-
       return NextResponse.json({
         success: true,
         results: results.map((r) => ({
-          puzzle: r.puzzle,
+          puzzle: toPublicPuzzle(r.puzzle as unknown as Record<string, unknown>),
           similarity: r.similarity,
         })),
         count: results.length,
       });
     }
 
-    // Search by concept
     if (concept) {
       const results = await searchPuzzlesByConcept(concept, limit, minSimilarity);
-
       return NextResponse.json({
         success: true,
         results: results.map((r) => ({
-          puzzle: r.puzzle,
+          puzzle: toPublicPuzzle(r.puzzle as unknown as Record<string, unknown>),
           similarity: r.similarity,
         })),
         count: results.length,
@@ -58,7 +58,7 @@ export async function GET(request: Request) {
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : "Failed to perform semantic search",
+        error: error instanceof Error ? error.message : "Search failed",
       },
       { status: 500 }
     );

--- a/apps/web/src/app/api/workflows/daily-content/route.ts
+++ b/apps/web/src/app/api/workflows/daily-content/route.ts
@@ -15,8 +15,33 @@ import { logger } from "@/lib/logger";
  *
  * Native implementation - no workflow library needed
  */
+function authorizeWorkflow(request: Request): boolean {
+  const authHeader = request.headers.get("authorization");
+  const vercelCronSecret = request.headers.get("x-vercel-cron-secret");
+  const cronSecret = process.env.CRON_SECRET;
+  const vercelCronSecretEnv = process.env.VERCEL_CRON_SECRET;
+
+  const vercelOk =
+    Boolean(vercelCronSecretEnv) && vercelCronSecret === vercelCronSecretEnv;
+  const bearerOk = Boolean(cronSecret) && authHeader === `Bearer ${cronSecret}`;
+
+  // In production require at least one configured secret and a match
+  if (process.env.NODE_ENV === "production") {
+    if (!(vercelCronSecretEnv || cronSecret)) return false;
+    return vercelOk || bearerOk;
+  }
+
+  // Dev: allow if no secrets configured, otherwise require a match
+  if (!(vercelCronSecretEnv || cronSecret)) return true;
+  return vercelOk || bearerOk;
+}
+
 export async function POST(request: Request) {
   try {
+    if (!authorizeWorkflow(request)) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
     const body = await request.json().catch(() => ({}));
     const triggeredBy = body.triggeredBy || "manual";
 
@@ -27,10 +52,11 @@ export async function POST(request: Request) {
     const puzzleResult = await generateNextPuzzle();
 
     if (!puzzleResult.success) {
-      logger.error(
-        "Puzzle generation failed",
-        new Error((puzzleResult as any).error || "Unknown error")
-      );
+      const errMsg =
+        "error" in puzzleResult && typeof puzzleResult.error === "string"
+          ? puzzleResult.error
+          : "Unknown error";
+      logger.error("Puzzle generation failed", new Error(errMsg));
     }
 
     // Step 1.5: Revalidate puzzle cache to ensure all users see the new puzzle
@@ -42,9 +68,18 @@ export async function POST(request: Request) {
     logger.info("Generating blog post for previous puzzle");
     const blogResult = await generateBlogForYesterday();
 
+    // Don't echo puzzle answers in the workflow response
     return NextResponse.json({
       success: true,
-      puzzle: puzzleResult,
+      puzzle: {
+        success: puzzleResult.success,
+        cached: "cached" in puzzleResult ? puzzleResult.cached : undefined,
+        fallback: "fallback" in puzzleResult ? puzzleResult.fallback : undefined,
+        puzzleId:
+          puzzleResult.success && puzzleResult.puzzle
+            ? (puzzleResult.puzzle as { id?: string }).id
+            : undefined,
+      },
       blog: blogResult,
       completedAt: new Date().toISOString(),
     });

--- a/apps/web/src/app/game-over/game-over-client.tsx
+++ b/apps/web/src/app/game-over/game-over-client.tsx
@@ -70,31 +70,40 @@ export default function GameOverClient({
     answer: gameData.answer || "",
     explanation: gameData.explanation || "",
   });
-  const [hasLocalLock, setHasLocalLock] = useState(Boolean(gameData.locked || gameData.answer));
 
   useEffect(() => {
-    // Prefer server solution (only present after daily lock); fall back to guess reveal
-    if (gameData.answer) {
-      setSolution({ answer: gameData.answer, explanation: gameData.explanation });
-      setHasLocalLock(true);
+    // Server lock is authoritative — never unlock results from localStorage alone
+    if (!gameData.locked) {
+      setSolution({ answer: "", explanation: "" });
       return;
     }
+
+    if (gameData.answer) {
+      setSolution({ answer: gameData.answer, explanation: gameData.explanation });
+      return;
+    }
+
+    // Locked but answer not in RSC payload — use today's guess reveal only
     try {
+      const todayKey = new Date().toISOString().slice(0, 10);
       const stored = localStorage.getItem("lastGameSolution");
       if (stored) {
-        const parsed = JSON.parse(stored) as { answer?: string; explanation?: string };
-        if (parsed.answer) {
+        const parsed = JSON.parse(stored) as {
+          answer?: string;
+          explanation?: string;
+          puzzleDate?: string;
+        };
+        if (parsed.answer && (!parsed.puzzleDate || parsed.puzzleDate === todayKey)) {
           setSolution({
             answer: parsed.answer,
             explanation: parsed.explanation || "",
           });
-          setHasLocalLock(true);
         }
       }
     } catch {
       // ignore
     }
-  }, [gameData.answer, gameData.explanation]);
+  }, [gameData.answer, gameData.explanation, gameData.locked]);
 
   useEffect(() => {
     async function loadClientExtras() {
@@ -159,7 +168,8 @@ export default function GameOverClient({
     loadClientExtras();
   }, [userId]);
 
-  const success = params.success === "true";
+  // Prefer server-locked success; URL param is cosmetic only when locked
+  const success = Boolean(gameData.locked) && params.success === "true";
   const attempts =
     typeof params.attempts === "string"
       ? Number.parseInt(params.attempts, 10)
@@ -201,8 +211,8 @@ export default function GameOverClient({
     return () => clearInterval(interval);
   }, [success, loading, finalScore, animationComplete]);
 
-  // Not locked and no local reveal — send them to play (don't leak empty "results")
-  if (!gameData.locked && !hasLocalLock && !solution.answer) {
+  // Server lock required — no spoofing via query params / stale localStorage
+  if (!gameData.locked) {
     return (
       <Layout>
         <div className="mx-auto max-w-lg px-4 py-16 text-center space-y-6">

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import {
   ChevronRight,
+  FlaskConical,
   Lock,
   Moon,
   Save,
@@ -26,6 +27,7 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import type { AvatarPreferences } from "@/lib/avatar";
+import { isDevModeEnabled, setDevModeEnabled } from "@/lib/dev-mode";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -33,6 +35,7 @@ export default function SettingsPage() {
   const { theme, setTheme } = useTheme();
   const { user, isAuthenticated } = useAuth();
   const [mounted, setMounted] = useState(false);
+  const [devMode, setDevMode] = useState(false);
   const [settings, setSettings] = useState({
     notifications: false,
     sound: true,
@@ -71,6 +74,7 @@ export default function SettingsPage() {
 
   useEffect(() => {
     setMounted(true);
+    setDevMode(isDevModeEnabled());
   }, []);
 
   // Load profile data
@@ -317,6 +321,44 @@ export default function SettingsPage() {
 
           {/* Email Notifications Form */}
           <EmailNotificationForm />
+
+          {/* Temporary Dev Mode */}
+          <Card className="border-amber-500/40 p-6">
+            <h2 className="mb-4 flex items-center gap-2 font-semibold text-xl">
+              <FlaskConical className="h-5 w-5 text-amber-600" />
+              Dev Mode
+              <span className="rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-[10px] text-amber-800 uppercase tracking-wide dark:text-amber-300">
+                Temporary
+              </span>
+            </h2>
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-0.5">
+                <Label className="cursor-pointer text-base" htmlFor="dev-mode">
+                  Enable testing tools
+                </Label>
+                <p className="text-muted-foreground text-sm">
+                  Shows a floating panel on every page: regenerate today&apos;s puzzle, unlock/replay
+                  the daily gate, and jump between play → locked → win/lose screens. Server actions
+                  require an admin account.
+                </p>
+              </div>
+              <Switch
+                checked={devMode}
+                disabled={!mounted}
+                id="dev-mode"
+                onCheckedChange={(checked) => {
+                  setDevMode(checked);
+                  setDevModeEnabled(checked);
+                  toast({
+                    title: checked ? "Dev Mode on" : "Dev Mode off",
+                    description: checked
+                      ? "Look for the amber Dev Mode panel (bottom-right)."
+                      : "Testing tools hidden.",
+                  });
+                }}
+              />
+            </div>
+          </Card>
 
           {/* Gameplay */}
           <Card className="p-6">

--- a/apps/web/src/components/CountdownTimer.tsx
+++ b/apps/web/src/components/CountdownTimer.tsx
@@ -3,7 +3,7 @@
 import { Clock } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { getNextUtcMidnight, msUntilNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getNextUtcMidnight } from "@/lib/game/daily-lock";
 
 function formatCountdown(diffMs: number): string {
   const totalSeconds = Math.max(0, Math.floor(diffMs / 1000));
@@ -16,23 +16,32 @@ function formatCountdown(diffMs: number): string {
 }
 
 /**
- * Counts down to the next UTC midnight (puzzle rollover), then reloads home.
+ * Counts down to a fixed next UTC midnight (captured once on the client),
+ * then navigates home so today's puzzle can load.
  */
 export function CountdownTimer() {
   const router = useRouter();
-  const [timeLeft, setTimeLeft] = useState(() => formatCountdown(msUntilNextUtcMidnight()));
+  const targetRef = useRef<Date | null>(null);
+  const [timeLeft, setTimeLeft] = useState("--:--:--");
+  const [nextAt, setNextAt] = useState<Date | null>(null);
   const reloadedRef = useRef(false);
 
   useEffect(() => {
+    // Capture once — calling getNextUtcMidnight() every tick never reaches zero
+    if (!targetRef.current) {
+      targetRef.current = getNextUtcMidnight();
+      setNextAt(targetRef.current);
+    }
+
     const tick = () => {
-      const diff = msUntilNextUtcMidnight();
+      const target = targetRef.current;
+      if (!target) return;
+      const diff = target.getTime() - Date.now();
       setTimeLeft(formatCountdown(diff));
 
       if (diff <= 0 && !reloadedRef.current) {
         reloadedRef.current = true;
-        // New UTC day — pull today's puzzle (don't sit on yesterday's results)
-        router.push("/");
-        router.refresh();
+        router.replace("/");
       }
     };
 
@@ -40,8 +49,6 @@ export function CountdownTimer() {
     const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [router]);
-
-  const nextAt = getNextUtcMidnight();
 
   return (
     <div className="inline-flex items-center gap-3 rounded-2xl bg-gradient-to-r from-purple-600 to-pink-600 px-6 py-4 text-white shadow-lg">
@@ -51,10 +58,13 @@ export function CountdownTimer() {
           Next Puzzle In
         </div>
         <div className="font-bold text-3xl tabular-nums">{timeLeft}</div>
-        <div className="mt-1 text-[10px] uppercase tracking-wide opacity-75">
-          Resets {nextAt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}{" "}
-          local ({nextAt.toISOString().slice(11, 16)} UTC)
-        </div>
+        {nextAt && (
+          <div className="mt-1 text-[10px] uppercase tracking-wide opacity-75">
+            Resets{" "}
+            {nextAt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })} local (
+            {nextAt.toISOString().slice(11, 16)} UTC)
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/DevToolsPanel.tsx
+++ b/apps/web/src/components/DevToolsPanel.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+/**
+ * Temporary floating Dev Mode panel.
+ * Enable via Settings → Dev Mode. Server actions require admin.
+ */
+
+import {
+  ChevronDown,
+  ChevronUp,
+  FlaskConical,
+  Loader2,
+  RefreshCw,
+  Trophy,
+  Unlock,
+  X,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  clearDevClientGameState,
+  DEV_MODE_STORAGE_KEY,
+  isDevModeEnabled,
+  setDevModeEnabled,
+} from "@/lib/dev-mode";
+import { cn } from "@/lib/utils";
+
+type DevAction = "clear-attempts" | "lock-win" | "lock-lose" | "regenerate";
+
+export function DevToolsPanel() {
+  const router = useRouter();
+  const [enabled, setEnabled] = useState(false);
+  const [open, setOpen] = useState(true);
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [status, setStatus] = useState<string>("");
+  const [lockInfo, setLockInfo] = useState<string>("");
+
+  useEffect(() => {
+    const sync = () => setEnabled(isDevModeEnabled());
+    sync();
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === DEV_MODE_STORAGE_KEY || e.key === null) sync();
+    };
+    const onCustom = () => sync();
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("rebuzzle:dev-mode", onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("rebuzzle:dev-mode", onCustom);
+    };
+  }, []);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dev/session", { credentials: "include" });
+      const data = (await res.json()) as {
+        allowed?: boolean;
+        lock?: { hasAttempt?: boolean; wasSuccessful?: boolean };
+        puzzle?: { id?: string; puzzle?: string };
+        puzzleDate?: string;
+      };
+      if (!res.ok || !data.allowed) {
+        setAllowed(false);
+        setLockInfo("Admin login required for Dev Mode actions");
+        return;
+      }
+      setAllowed(true);
+      const locked = data.lock?.hasAttempt
+        ? data.lock.wasSuccessful
+          ? "LOCKED · win"
+          : "LOCKED · loss"
+        : "UNLOCKED · can play";
+      setLockInfo(
+        `${data.puzzleDate ?? "today"} · ${locked}${
+          data.puzzle?.id ? ` · ${data.puzzle.id.slice(0, 8)}…` : " · no puzzle"
+        }`
+      );
+    } catch {
+      setAllowed(false);
+      setLockInfo("Could not reach Dev API");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (enabled) void refreshStatus();
+  }, [enabled, refreshStatus]);
+
+  const runAction = async (action: DevAction, thenNavigate?: string) => {
+    setBusy(action);
+    setStatus("");
+    try {
+      const res = await fetch("/api/dev/session", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      const data = (await res.json()) as { success?: boolean; message?: string; error?: string };
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || "Action failed");
+      }
+      clearDevClientGameState();
+      setStatus(data.message || "Done");
+      await refreshStatus();
+      if (thenNavigate) {
+        router.push(thenNavigate);
+        router.refresh();
+      } else {
+        router.refresh();
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const go = (path: string) => {
+    router.push(path);
+  };
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto fixed bottom-3 right-3 z-[80] w-[min(100vw-1.5rem,20rem)]",
+        "rounded-xl border border-amber-500/40 bg-background/95 shadow-xl backdrop-blur-md"
+      )}
+    >
+      <div className="flex items-center gap-2 border-b border-amber-500/30 px-3 py-2">
+        <FlaskConical className="h-4 w-4 text-amber-600" />
+        <span className="flex-1 font-semibold text-amber-800 text-xs dark:text-amber-300">
+          Dev Mode
+        </span>
+        <button
+          aria-label={open ? "Collapse" : "Expand"}
+          className="rounded p-1 text-muted-foreground hover:bg-muted"
+          onClick={() => setOpen((v) => !v)}
+          type="button"
+        >
+          {open ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+        </button>
+        <button
+          aria-label="Turn off Dev Mode"
+          className="rounded p-1 text-muted-foreground hover:bg-muted"
+          onClick={() => {
+            setDevModeEnabled(false);
+            setEnabled(false);
+          }}
+          type="button"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {open && (
+        <div className="space-y-3 p-3 text-xs">
+          <p className="text-[11px] text-muted-foreground leading-snug">
+            Temporary testing tools. Actions require an admin account.
+          </p>
+          <p className="rounded-md bg-muted/80 px-2 py-1.5 font-mono text-[10px] text-foreground/80">
+            {lockInfo || (allowed === null ? "Checking access…" : "—")}
+          </p>
+
+          {allowed === false && (
+            <p className="text-destructive text-[11px]">
+              Log in as admin (ADMIN_EMAIL / isAdmin) to use these actions.
+            </p>
+          )}
+
+          <div className="space-y-1.5">
+            <p className="font-medium text-[10px] uppercase tracking-wide text-muted-foreground">
+              Puzzle
+            </p>
+            <Button
+              className="h-8 w-full justify-start gap-2 text-xs"
+              disabled={!!busy || allowed === false}
+              onClick={() => void runAction("regenerate", "/")}
+              size="sm"
+              variant="secondary"
+            >
+              {busy === "regenerate" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              Generate new puzzle
+            </Button>
+            <Button
+              className="h-8 w-full justify-start gap-2 text-xs"
+              disabled={!!busy || allowed === false}
+              onClick={() => void runAction("clear-attempts", "/")}
+              size="sm"
+              variant="outline"
+            >
+              {busy === "clear-attempts" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Unlock className="h-3.5 w-3.5" />
+              )}
+              Unlock today (clear lock)
+            </Button>
+          </div>
+
+          <div className="space-y-1.5">
+            <p className="font-medium text-[10px] uppercase tracking-wide text-muted-foreground">
+              Gate states
+            </p>
+            <div className="grid grid-cols-2 gap-1.5">
+              <Button
+                className="h-8 text-[11px]"
+                disabled={!!busy || allowed === false}
+                onClick={() => void runAction("clear-attempts", "/")}
+                size="sm"
+                variant="outline"
+              >
+                → Play
+              </Button>
+              <Button
+                className="h-8 text-[11px]"
+                disabled={!!busy || allowed === false}
+                onClick={() => void runAction("lock-win", "/")}
+                size="sm"
+                variant="outline"
+              >
+                → Locked
+              </Button>
+              <Button
+                className="h-8 text-[11px]"
+                disabled={!!busy || allowed === false}
+                onClick={() => void runAction("lock-win", "/game-over?success=true")}
+                size="sm"
+                variant="outline"
+              >
+                <Trophy className="mr-1 h-3 w-3" />
+                Win
+              </Button>
+              <Button
+                className="h-8 text-[11px]"
+                disabled={!!busy || allowed === false}
+                onClick={() => void runAction("lock-lose", "/game-over?success=false")}
+                size="sm"
+                variant="outline"
+              >
+                Lose
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <p className="font-medium text-[10px] uppercase tracking-wide text-muted-foreground">
+              Jump
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {(
+                [
+                  ["/", "Home"],
+                  ["/?preview=true", "Preview"],
+                  ["/game-over", "Game over"],
+                  ["/leaderboard", "Board"],
+                  ["/settings", "Settings"],
+                  ["/how-it-works", "How"],
+                ] as const
+              ).map(([href, label]) => (
+                <Button
+                  key={href}
+                  className="h-7 px-2 text-[11px]"
+                  onClick={() => go(href)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {status && (
+            <p className="rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px]">
+              {status}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -402,14 +402,18 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         return;
       }
 
-      // Must have an authenticated (or guest) session before scoring
+      // Must have a session cookie before scoring. ensureGuest sets cookies even
+      // if React auth state hasn't re-rendered yet — continue after success.
       if (!userId) {
-        toast({
-          title: "Getting ready…",
-          description: "Starting your session — try again in a moment.",
-        });
-        await ensureGuest();
-        return;
+        const created = await ensureGuest();
+        if (!created) {
+          toast({
+            title: "Session error",
+            description: "Couldn't start your session. Please refresh and try again.",
+            variant: "destructive",
+          });
+          return;
+        }
       }
 
       // Update state with the guess if provided
@@ -480,6 +484,26 @@ export default function GameBoard({ gameData }: GameBoardProps) {
             result.pointsEarned ??
             calculateGamePoints(attempts, timeTaken, userStats.streak + 1, difficultyLevel);
 
+          const winningHistory = [
+            ...gameState.guessHistory,
+            {
+              text: guessToCheck,
+              timestamp: new Date(),
+              wordResults,
+              attemptNumber: attempts,
+            },
+          ];
+
+          dispatch({
+            type: "ADD_GUESS_HISTORY",
+            payload: {
+              text: guessToCheck,
+              timestamp: new Date(),
+              wordResults,
+              attemptNumber: attempts,
+            },
+          });
+
           setCompletionState(true, guessToCheck, attempts, earnedPoints);
 
           const newStats = { ...userStats };
@@ -519,21 +543,14 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                 answer: result.answer,
                 explanation: result.explanation,
                 puzzleId: gameData.id,
+                puzzleDate: new Date().toISOString().slice(0, 10),
               })
             );
           }
           localStorage.setItem(
             "lastGameCompletion",
             JSON.stringify({
-              guessHistory: [
-                ...gameState.guessHistory,
-                {
-                  text: guessToCheck,
-                  timestamp: new Date(),
-                  wordResults,
-                  attemptNumber: attempts,
-                },
-              ],
+              guessHistory: winningHistory,
               timeTaken,
               usedHints: gameState.hintsUsed,
               streak: userStats.streak + 1,
@@ -588,6 +605,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                 answer: result.answer,
                 explanation: result.explanation,
                 puzzleId: gameData.id,
+                puzzleDate: new Date().toISOString().slice(0, 10),
               })
             );
           }

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { DevToolsPanel } from "./DevToolsPanel";
 import { GameProvider, useGameContext } from "./GameContext";
 import Header from "./Header";
 
@@ -78,6 +79,9 @@ function LayoutContent({ children, nextPlayTime, puzzleType, className, isGamePa
       >
         {children}
       </main>
+
+      {/* Temporary Dev Mode tools — enable in Settings */}
+      <DevToolsPanel />
     </div>
   );
 }

--- a/apps/web/src/components/Timer.tsx
+++ b/apps/web/src/components/Timer.tsx
@@ -23,21 +23,25 @@ function formatCountdown(diffMs: number): string {
 
 export function Timer({ nextPlayTime, className }: TimerProps) {
   const router = useRouter();
-  const [timeLeft, setTimeLeft] = useState("");
+  const [timeLeft, setTimeLeft] = useState("--:--:--");
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const reloadedRef = useRef(false);
+  // Fixed target for this mount when nextPlayTime is null — set in effect to avoid prerender Date()
+  const fallbackTargetRef = useRef<Date | null>(null);
 
   useEffect(() => {
+    if (!fallbackTargetRef.current) {
+      fallbackTargetRef.current = getNextUtcMidnight();
+    }
+    const targetTime = nextPlayTime ? new Date(nextPlayTime) : fallbackTargetRef.current;
+
     const calculateTimeLeft = () => {
-      const now = new Date();
-      const targetTime = nextPlayTime ? new Date(nextPlayTime) : getNextUtcMidnight(now);
-      const difference = targetTime.getTime() - now.getTime();
+      const difference = targetTime.getTime() - Date.now();
 
       if (difference <= 0) {
         if (!reloadedRef.current) {
           reloadedRef.current = true;
-          router.push("/");
-          router.refresh();
+          router.replace("/");
         }
         return "00:00:00";
       }

--- a/apps/web/src/db/indexes.ts
+++ b/apps/web/src/db/indexes.ts
@@ -86,6 +86,8 @@ const INDEX_DEFINITIONS: IndexDefinition[] = [
       { spec: { createdAt: -1 } },
       // Combined index for filtered date queries
       { spec: { active: 1, publishedAt: -1, puzzleType: 1 } },
+      // Speeds UTC-day lookups used by findByDate
+      { spec: { active: 1, publishedAt: 1 } },
     ],
   },
 

--- a/apps/web/src/db/operations.ts
+++ b/apps/web/src/db/operations.ts
@@ -327,10 +327,14 @@ export const puzzleOps = {
     const start = new Date(`${dateString}T00:00:00.000Z`);
     const end = new Date(`${dateString}T23:59:59.999Z`);
 
-    return await collection.findOne({
-      publishedAt: { $gte: start, $lte: end },
-      active: true,
-    });
+    // Prefer newest if duplicates ever exist
+    return await collection.findOne(
+      {
+        publishedAt: { $gte: start, $lte: end },
+        active: true,
+      },
+      { sort: { publishedAt: -1, createdAt: -1 } }
+    );
   },
 
   async findTodaysPuzzle(): Promise<Puzzle | null> {

--- a/apps/web/src/db/operations.ts
+++ b/apps/web/src/db/operations.ts
@@ -457,6 +457,22 @@ export const puzzleAttemptOps = {
     }, 0);
   },
 
+  /** Dev tools: wipe a user's guesses for a UTC day so they can replay. */
+  async clearAttemptsForDate(userId: string, puzzleDate: string): Promise<number> {
+    const collection = getCollection<PuzzleAttempt>("puzzleAttempts");
+    const result = await collection.deleteMany({ userId, puzzleDate });
+    // Also clear legacy rows keyed only by attemptedAt window
+    const legacy = await collection.deleteMany({
+      userId,
+      puzzleDate: { $exists: false },
+      attemptedAt: {
+        $gte: new Date(`${puzzleDate}T00:00:00.000Z`),
+        $lt: new Date(`${puzzleDate}T23:59:59.999Z`),
+      },
+    });
+    return (result.deletedCount ?? 0) + (legacy.deletedCount ?? 0);
+  },
+
   /**
    * Record a guess. Finals use a unique partial index on {userId, puzzleDate}
    * so concurrent completions cannot both succeed.

--- a/apps/web/src/lib/cache/daily-puzzle.ts
+++ b/apps/web/src/lib/cache/daily-puzzle.ts
@@ -85,8 +85,8 @@ export async function getCachedDailyPuzzleFromDb(
   // Query by the passed dateString — never Date.now() inside "use cache"
   const existingPuzzle = await db.puzzleOps.findByDate(dateString);
   if (!existingPuzzle) {
-    // Misses must not stick for hours — generation may land moments later
-    cacheLife("minutes");
+    // Misses must not stick — generation may land moments later
+    cacheLife("seconds");
     return null;
   }
 

--- a/apps/web/src/lib/dev-mode.ts
+++ b/apps/web/src/lib/dev-mode.ts
@@ -1,0 +1,46 @@
+/**
+ * Temporary client-side Dev Mode flag (Settings toggle).
+ * Powerful actions still require admin on the server.
+ */
+
+export const DEV_MODE_STORAGE_KEY = "rebuzzle_dev_mode";
+
+export function isDevModeEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return localStorage.getItem(DEV_MODE_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function setDevModeEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled) {
+      localStorage.setItem(DEV_MODE_STORAGE_KEY, "true");
+    } else {
+      localStorage.removeItem(DEV_MODE_STORAGE_KEY);
+    }
+    window.dispatchEvent(new CustomEvent("rebuzzle:dev-mode", { detail: { enabled } }));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export function clearDevClientGameState(): void {
+  if (typeof window === "undefined") return;
+  const keys = [
+    "lastGameCompletion",
+    "lastGameSolution",
+    "gameCompletion",
+    "userStats",
+  ];
+  for (const key of keys) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/apps/web/src/lib/game/persist-daily-puzzle.ts
+++ b/apps/web/src/lib/game/persist-daily-puzzle.ts
@@ -1,0 +1,81 @@
+/**
+ * Persist a daily puzzle with a real UUID so /api/puzzles/guess can resolve it.
+ */
+
+import { revalidateTag } from "next/cache";
+import { db } from "@/db";
+import { logger } from "@/lib/logger";
+
+export type PersistDailyPuzzleInput = {
+  dateString: string;
+  puzzleDisplay: string;
+  puzzleType: string;
+  answer: string;
+  difficulty: number;
+  category: string;
+  explanation: string;
+  hints: string[];
+  aiGenerated: boolean;
+  rebusPuzzle?: string;
+  metadataExtra?: Record<string, unknown>;
+};
+
+function toDifficultyLabel(difficulty: number): "easy" | "medium" | "hard" {
+  if (difficulty <= 3) return "easy";
+  if (difficulty <= 7) return "medium";
+  return "hard";
+}
+
+/**
+ * Upsert-ish: if today's puzzle already exists, return it.
+ * Otherwise insert with UTC-midnight publishedAt and a real UUID.
+ */
+export async function persistDailyPuzzle(input: PersistDailyPuzzleInput): Promise<{
+  id: string;
+  alreadyExisted: boolean;
+}> {
+  const existing = await db.puzzleOps.findByDate(input.dateString);
+  if (existing) {
+    return { id: existing.id, alreadyExisted: true };
+  }
+
+  const id = crypto.randomUUID();
+  const publishedAt = new Date(`${input.dateString}T00:00:00.000Z`);
+
+  await db.puzzleOps.create({
+    id,
+    puzzle: input.puzzleDisplay,
+    puzzleType: input.puzzleType,
+    answer: input.answer,
+    difficulty: toDifficultyLabel(input.difficulty),
+    category: input.category || "general",
+    explanation: input.explanation,
+    hints: input.hints || [],
+    publishedAt,
+    createdAt: new Date(),
+    active: true,
+    metadata: {
+      topic: input.category,
+      category: input.category,
+      puzzleType: input.puzzleType,
+      aiGenerated: input.aiGenerated,
+      generatedAt: new Date().toISOString(),
+      // Intentionally omit keyword (= answer) from metadata
+      ...input.metadataExtra,
+    },
+    rebusPuzzle:
+      input.rebusPuzzle ??
+      (input.puzzleType === "rebus" ? input.puzzleDisplay : undefined),
+  });
+
+  revalidateTag("daily-puzzle", "max");
+  revalidateTag(`daily-puzzle-${input.dateString}`, "max");
+
+  logger.info("Persisted daily puzzle", {
+    puzzleId: id,
+    dateString: input.dateString,
+    aiGenerated: input.aiGenerated,
+  });
+
+  return { id, alreadyExisted: false };
+}

--- a/apps/web/src/lib/game/public-puzzle.ts
+++ b/apps/web/src/lib/game/public-puzzle.ts
@@ -1,0 +1,59 @@
+/**
+ * Strip solution fields from puzzle payloads before sending to clients.
+ */
+
+type LoosePuzzle = Record<string, unknown>;
+
+const SECRET_KEYS = new Set([
+  "answer",
+  "explanation",
+  "keyword",
+  "seoMetadata",
+  "embedding",
+  "fallbackReason",
+]);
+
+/** Public shape safe for an active (unsolved) daily board. */
+export function toPublicPuzzle<T extends LoosePuzzle>(
+  puzzle: T
+): Omit<T, "answer" | "explanation" | "keyword" | "seoMetadata" | "embedding" | "fallbackReason"> {
+  const {
+    answer: _a,
+    explanation: _e,
+    keyword: _k,
+    seoMetadata: _s,
+    embedding: _emb,
+    fallbackReason: _f,
+    ...rest
+  } = puzzle;
+
+  const publicRest: LoosePuzzle = { ...rest };
+
+  // Nested metadata may still carry keyword/seo
+  if (publicRest.metadata && typeof publicRest.metadata === "object" && publicRest.metadata !== null) {
+    const meta = { ...(publicRest.metadata as LoosePuzzle) };
+    delete meta.keyword;
+    delete meta.seoMetadata;
+    delete meta.answer;
+    publicRest.metadata = meta;
+  }
+
+  return publicRest as Omit<
+    T,
+    "answer" | "explanation" | "keyword" | "seoMetadata" | "embedding" | "fallbackReason"
+  >;
+}
+
+export function stripPuzzleAnswersFromList<T extends LoosePuzzle>(
+  items: Array<{ puzzle: T; [key: string]: unknown }>
+): Array<{ puzzle: ReturnType<typeof toPublicPuzzle<T>>; [key: string]: unknown }> {
+  return items.map((item) => ({
+    ...item,
+    puzzle: toPublicPuzzle(item.puzzle),
+  }));
+}
+
+export function hasSecretPuzzleFields(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  return Object.keys(value as LoosePuzzle).some((k) => SECRET_KEYS.has(k));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Temporary **Dev Mode** (Settings toggle) plus Eve quality upgrades so you can regenerate and walk every gated screen while tuning puzzle AI.

### Dev Mode (temporary)
- **Settings → Dev Mode** toggle (localStorage)
- Floating amber panel on every page (via `Layout`) with:
  - **Generate new puzzle** (admin regenerate + unlock)
  - **Unlock today** (clear your daily lock)
  - Gate navigation: Play → Locked → Win / Lose
  - Quick jumps: Home, Preview, Game over, Leaderboard, Settings, How it works
- Server actions at `POST /api/dev/session` are **admin-only** (toggle alone isn’t enough)

### Eve / AI quality
- Default model → `openai/gpt-5.4-mini` (override with `EVE_PUZZLE_MODEL`)
- Loads `agent/skills/generate-daily-puzzle.md` into the in-process agent
- Ensures gateway auth (`ensureGatewayKey`) on the Eve path
- Creative-tier **model fallbacks** on failure
- **Hard publish gates**: techniqueId, non-empty display, no answer leak, quality ≥ 70, funScore ≥ 65, `publishable`
- Retries include the prior failure reason; bad puzzles no longer soft-accepted on the last attempt
- Fun score no longer rewards emoji padding without a technique

> Note: this branch is based on `cursor/bugfix-scan-8968` (#7). If #7 isn’t merged yet, this PR includes those fixes too.

## How to use
1. Log in as admin (`ADMIN_EMAIL` / `isAdmin`)
2. Open **Settings** → enable **Dev Mode**
3. Use the bottom-right panel to regenerate and jump states

## Test plan
- [ ] Enable Dev Mode in Settings → panel appears
- [ ] As admin: Generate new puzzle → home shows a new board you can play
- [ ] Lock win / lose → game-over shows solution only when locked
- [ ] Unlock today → can play again
- [ ] Non-admin: panel shows “Admin login required”, actions 403
- [ ] Confirm `EVE_PUZZLE_MODEL` / `AI_GATEWAY_API_KEY` work for generation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

