### PR TITLE
Make play path significantly faster

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -49,8 +49,10 @@ const nextConfig = {
 
   images: {
     formats: ["image/avif", "image/webp"],
-    minimumCacheTTL: 60,
+    minimumCacheTTL: 60 * 60 * 24 * 30,
   },
+
+  transpilePackages: ["@rebuzzle/game-logic", "@rebuzzle/config"],
 
   async headers() {
     const isProduction = process.env.NODE_ENV === "production";
@@ -109,6 +111,24 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value: cspDirectives,
+          },
+        ],
+      },
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/:file(.*)\\.(ico|png|jpg|jpeg|gif|webp|avif|svg|woff2)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=604800, stale-while-revalidate=86400",
           },
         ],
       },

--- a/apps/web/src/ai/config/answer-validation.ts
+++ b/apps/web/src/ai/config/answer-validation.ts
@@ -175,10 +175,11 @@ export const IGNORABLE_WORDS: string[] = ["a", "an", "the"];
 
 export const ANSWER_VALIDATION_CONFIG: AnswerValidationConfig = {
   enabled: true,
-  alwaysUseAI: true, // Always use AI for best semantic matching
+  // Prefer fast local matching; AI only for mid-similarity near-misses
+  alwaysUseAI: false,
   quickAcceptThreshold: 0.98, // Skip AI if nearly exact
-  aiMinimumSimilarity: 0.3, // Don't bother AI for very different answers
-  aiTimeoutMs: 5000, // Don't block UX too long
+  aiMinimumSimilarity: 0.45, // Don't bother AI for very different answers
+  aiTimeoutMs: 1800, // Keep guess INP snappy
   tolerateWordOrderVariations: true,
   expandContractions: true,
   ignorePunctuation: true,

--- a/apps/web/src/app/actions/gameActions.ts
+++ b/apps/web/src/app/actions/gameActions.ts
@@ -162,7 +162,8 @@ export async function fetchGameOverSolution(): Promise<{
  */
 export async function fetchGameData(_isPreview = false): Promise<PublicGameData> {
   try {
-    const result = await getTodaysPuzzle();
+    // Never run Eve/AI on the interactive board path — cron owns generation.
+    const result = await getTodaysPuzzle(undefined, undefined, { allowAiGenerate: false });
     const puzzle = (result.success ? result.puzzle : null) as TodaysPuzzle | null;
 
     if (!puzzle) {

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -76,8 +76,13 @@ const FALLBACK_PUZZLES = [
  * @param dateString - Date string in YYYY-MM-DD format
  * @param puzzleType - Optional puzzle type (e.g., "rebus", "word-puzzle")
  */
-async function getOrGenerateDailyPuzzle(dateString: string, puzzleType?: string) {
-  logger.info("Getting puzzle for date", { dateString });
+async function getOrGenerateDailyPuzzle(
+  dateString: string,
+  puzzleType?: string,
+  options?: { allowAiGenerate?: boolean }
+) {
+  const allowAiGenerate = options?.allowAiGenerate !== false;
+  logger.info("Getting puzzle for date", { dateString, allowAiGenerate });
 
   // STEP 1: Cross-request cached DB read via Cache Components ("use cache")
   try {
@@ -110,6 +115,41 @@ async function getOrGenerateDailyPuzzle(dateString: string, puzzleType?: string)
       "Final pre-generation check failed",
       finalCheckError instanceof Error ? finalCheckError : new Error(String(finalCheckError))
     );
+  }
+
+  // Interactive play path: never block TTFB on Eve — persist a fast fallback.
+  // Cron / regenerate / admin regenerate should call with allowAiGenerate: true.
+  if (!allowAiGenerate) {
+    const [y, m, d] = dateString.split("-").map(Number);
+    const dayOfYear = Math.floor(
+      (Date.UTC(y!, (m ?? 1) - 1, d ?? 1) - Date.UTC(y!, 0, 0)) / 86_400_000
+    );
+    const fallback = FALLBACK_PUZZLES[dayOfYear % FALLBACK_PUZZLES.length]!;
+    const persisted = await persistDailyPuzzle({
+      dateString,
+      puzzleDisplay: fallback.rebusPuzzle,
+      puzzleType: "rebus",
+      answer: fallback.answer,
+      difficulty: fallback.difficulty,
+      category: fallback.category,
+      explanation: fallback.explanation,
+      hints: fallback.hints,
+      aiGenerated: false,
+      rebusPuzzle: fallback.rebusPuzzle,
+      metadataExtra: { fallbackReason: "Play-path fast seed (AI deferred to cron)" },
+    });
+    return {
+      id: persisted.id,
+      ...fallback,
+      puzzle: fallback.rebusPuzzle,
+      puzzleType: "rebus" as const,
+      date: dateString,
+      topic: fallback.category,
+      relevanceScore: 7,
+      aiGenerated: false,
+      fromDatabase: true,
+      fallbackReason: "Play-path fast seed",
+    };
   }
 
   // STEP 2: No puzzle in database — Eve tool agent + AI Gateway (ONCE per day)
@@ -306,13 +346,17 @@ async function getOrGenerateDailyPuzzle(dateString: string, puzzleType?: string)
  * @param puzzleType - Optional puzzle type (e.g., "rebus", "word-puzzle"). Defaults to DEFAULT_PUZZLE_TYPE or "rebus"
  * @param dateString - Optional date string in YYYY-MM-DD format. If not provided, uses today's date.
  */
-export async function getTodaysPuzzle(puzzleType?: string, dateString?: string) {
+export async function getTodaysPuzzle(
+  puzzleType?: string,
+  dateString?: string,
+  options?: { allowAiGenerate?: boolean }
+) {
   try {
     // Use provided date string or get today's date
     // NOTE: If called from generateMetadata, dateString should be provided
     // after accessing headers/cookies to satisfy Next.js 16 requirements
     const todayString = dateString || getTodayDateString();
-    const puzzle = await getOrGenerateDailyPuzzle(todayString, puzzleType);
+    const puzzle = await getOrGenerateDailyPuzzle(todayString, puzzleType, options);
 
     return {
       success: true,

--- a/apps/web/src/app/api/puzzles/guess/route.ts
+++ b/apps/web/src/app/api/puzzles/guess/route.ts
@@ -1,5 +1,5 @@
 import { gameSettings } from "@rebuzzle/config";
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { validateAnswer } from "@/ai/services/answer-validation";
 import { db } from "@/db";
 import { updateUserStats } from "@/lib/auth";
@@ -39,7 +39,21 @@ export async function POST(request: Request) {
       return NextResponse.json({ success: false, error: "Not authenticated" }, { status: 401 });
     }
 
-    const limit = await guessRateLimit(request);
+    const [limit, userLimit, body] = await Promise.all([
+      guessRateLimit(request),
+      rateLimit({
+        windowMs: 60 * 1000,
+        maxRequests: 12,
+        keyGenerator: () => getUserKey(`guess:${user.userId}`),
+      })(request),
+      request.json() as Promise<{
+        puzzleId?: string;
+        guess?: string;
+        timeSpentSeconds?: number;
+        hintsUsed?: number;
+      }>,
+    ]);
+
     if (limit && !limit.success) {
       return NextResponse.json(
         { success: false, error: "Too many guesses. Slow down." },
@@ -54,26 +68,12 @@ export async function POST(request: Request) {
       );
     }
 
-    // Per-user budget as well (shared IPs / guests)
-    const userLimiter = rateLimit({
-      windowMs: 60 * 1000,
-      maxRequests: 12,
-      keyGenerator: () => getUserKey(`guess:${user.userId}`),
-    });
-    const userLimit = await userLimiter(request);
     if (userLimit && !userLimit.success) {
       return NextResponse.json(
         { success: false, error: "Too many guesses. Slow down." },
         { status: 429 }
       );
     }
-
-    const body = (await request.json()) as {
-      puzzleId?: string;
-      guess?: string;
-      timeSpentSeconds?: number;
-      hintsUsed?: number;
-    };
 
     const puzzleId = typeof body.puzzleId === "string" ? body.puzzleId.trim() : "";
     const guess = typeof body.guess === "string" ? body.guess.trim() : "";
@@ -89,14 +89,19 @@ export async function POST(request: Request) {
       return NextResponse.json({ success: false, error: "Guess is too long" }, { status: 400 });
     }
 
-    const puzzle = await db.puzzleOps.findById(puzzleId);
+    const puzzleDate = getUtcPuzzleDate();
+
+    // Parallelize puzzle load + today check + attempt context
+    const [puzzle, todays, context] = await Promise.all([
+      db.puzzleOps.findById(puzzleId),
+      db.puzzleOps.findTodaysPuzzle(),
+      db.puzzleAttemptOps.getTodayGuessContext(user.userId, puzzleDate),
+    ]);
+
     if (!puzzle?.answer) {
       return NextResponse.json({ success: false, error: "Puzzle not found" }, { status: 404 });
     }
 
-    // Only today's active puzzle can be played for score/lock
-    const puzzleDate = getUtcPuzzleDate();
-    const todays = await db.puzzleOps.findTodaysPuzzle();
     if (!todays || todays.id !== puzzle.id) {
       return NextResponse.json(
         { success: false, error: "This puzzle is not playable today" },
@@ -105,14 +110,14 @@ export async function POST(request: Request) {
     }
 
     const maxAttempts = gameSettings.maxAttempts;
-    const lock = await db.puzzleAttemptOps.hasTodayAttempt(user.userId, puzzleDate);
-    if (lock.hasAttempt) {
+
+    if (context.hasFinal) {
       return NextResponse.json(
         {
           success: false,
           error: "Already played today",
           locked: true,
-          wasSuccessful: lock.wasSuccessful,
+          wasSuccessful: context.wasSuccessful,
           attemptsLeft: 0,
           gameOver: true,
         },
@@ -120,8 +125,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const priorGuesses = await db.puzzleAttemptOps.countTodayGuesses(user.userId, puzzleDate);
-    if (priorGuesses >= maxAttempts) {
+    if (context.guessCount >= maxAttempts) {
       return NextResponse.json(
         {
           success: false,
@@ -134,28 +138,17 @@ export async function POST(request: Request) {
       );
     }
 
-    const attemptNumber = priorGuesses + 1;
+    const attemptNumber = context.guessCount + 1;
     const claimedHints = clampHints(body.hintsUsed, puzzle.hints?.length ?? 5);
-    const priorMaxHints = await db.puzzleAttemptOps.maxHintsUsedToday(
-      user.userId,
-      puzzleDate
-    );
-    // Never allow under-reporting below what was already claimed today
-    const hintsUsed = Math.max(claimedHints, priorMaxHints);
+    const hintsUsed = Math.max(claimedHints, context.maxHintsUsed);
 
-    // Prefer server-elapsed time from the first guess of the day
-    const firstGuess = await db.puzzleAttemptOps.findFirstGuessToday(
-      user.userId,
-      puzzleDate
-    );
     const nowMs = Date.now();
     let timeSpentSeconds: number;
-    if (firstGuess?.attemptedAt) {
+    if (context.firstGuessAt) {
       timeSpentSeconds = clampTimeSpent(
-        (nowMs - new Date(firstGuess.attemptedAt).getTime()) / 1000
+        (nowMs - context.firstGuessAt.getTime()) / 1000
       );
     } else {
-      // First guess of the day: accept client clock but hard-cap at 30 minutes
       timeSpentSeconds = Math.min(clampTimeSpent(body.timeSpentSeconds), 30 * 60);
     }
 
@@ -179,28 +172,26 @@ export async function POST(request: Request) {
               ? 5
               : Number(puzzle.difficulty) || 5;
 
-    const attemptData = {
-      id: crypto.randomUUID(),
-      userId: user.userId,
-      puzzleId: puzzle.id,
-      attemptedAnswer: guess,
-      isCorrect,
-      abandoned,
-      isFinal,
-      puzzleDate,
-      attemptedAt: new Date(),
-      completedAt: isCorrect ? new Date() : undefined,
-      attemptNumber,
-      maxAttempts,
-      timeSpentSeconds,
-      difficulty: getAchievementDifficultyCategory(difficultyLevel),
-      hintsUsed,
-    };
-
     const write = await db.puzzleAttemptOps.createAtomicDailyAttempt(
       user.userId,
       new Date(`${puzzleDate}T00:00:00.000Z`),
-      attemptData
+      {
+        id: crypto.randomUUID(),
+        userId: user.userId,
+        puzzleId: puzzle.id,
+        attemptedAnswer: guess,
+        isCorrect,
+        abandoned,
+        isFinal,
+        puzzleDate,
+        attemptedAt: new Date(),
+        completedAt: isCorrect ? new Date() : undefined,
+        attemptNumber,
+        maxAttempts,
+        timeSpentSeconds,
+        difficulty: getAchievementDifficultyCategory(difficultyLevel),
+        hintsUsed,
+      }
     );
 
     if (!write.success) {
@@ -218,42 +209,52 @@ export async function POST(request: Request) {
     }
 
     let pointsEarned = 0;
-    if (isFinal && write.success) {
-      // Stats only update when the daily lock write succeeded
-      await updateUserStats(user.userId, {
-        won: isCorrect,
-        attempts: attemptNumber,
-        timeSpent: timeSpentSeconds,
-        difficulty: difficultyLevel,
-      });
+    if (isFinal && isCorrect) {
+      // Cheap estimate for immediate UI; authoritative stats update after response
+      pointsEarned = calculateGamePoints(
+        attemptNumber,
+        timeSpentSeconds,
+        1,
+        difficultyLevel
+      );
+    }
 
-      if (isCorrect) {
-        // Approximate streak for response scoring; updateUserStats already persisted truth
-        const stats = await db.userStatsOps.findByUserId(user.userId);
-        pointsEarned = calculateGamePoints(
-          attemptNumber,
-          timeSpentSeconds,
-          stats?.streak ?? 1,
-          difficultyLevel
-        );
-
-        // Achievements — best-effort, don't fail the guess
+    if (isFinal) {
+      const uid = user.userId;
+      const pid = puzzle.id;
+      after(async () => {
         try {
-          const { checkAndAwardAchievements } = await import("@/lib/achievements/service");
-          await checkAndAwardAchievements(user.userId, {
-            puzzleId: puzzle.id,
+          await updateUserStats(uid, {
+            won: isCorrect,
             attempts: attemptNumber,
-            maxAttempts,
-            timeTaken: timeSpentSeconds,
-            hintsUsed,
-            difficulty: getAchievementDifficultyCategory(difficultyLevel),
-            isCorrect: true,
-            score: pointsEarned,
+            timeSpent: timeSpentSeconds,
+            difficulty: difficultyLevel,
           });
-        } catch (achievementError) {
-          console.error("[guess] achievement error:", achievementError);
+
+          if (isCorrect) {
+            const stats = await db.userStatsOps.findByUserId(uid);
+            const score = calculateGamePoints(
+              attemptNumber,
+              timeSpentSeconds,
+              stats?.streak ?? 1,
+              difficultyLevel
+            );
+            const { checkAndAwardAchievements } = await import("@/lib/achievements/service");
+            await checkAndAwardAchievements(uid, {
+              puzzleId: pid,
+              attempts: attemptNumber,
+              maxAttempts,
+              timeTaken: timeSpentSeconds,
+              hintsUsed,
+              difficulty: getAchievementDifficultyCategory(difficultyLevel),
+              isCorrect: true,
+              score,
+            });
+          }
+        } catch (error) {
+          console.error("[guess] post-response update failed:", error);
         }
-      }
+      });
     }
 
     return NextResponse.json({
@@ -267,7 +268,6 @@ export async function POST(request: Request) {
       gameOver: isFinal,
       locked: isFinal,
       wordResults,
-      // Reveal solution only after the day is locked for this user
       ...(isFinal
         ? {
             answer: puzzle.answer,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata, Viewport } from "next";
 import { connection } from "next/server";
 import { Suspense } from "react";
 import { AuthProvider } from "@/components/AuthProvider";
+import { AuthSessionSeed } from "@/components/AuthSessionSeed";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ThemeProviderWrapper } from "@/components/ThemeProviderWrapper";
 import { Toaster } from "@/components/ui/toaster";
@@ -205,14 +206,12 @@ export const metadata: Metadata = {
 };
 
 /**
- * Dynamic auth shell — reads cookies and seeds AuthProvider.
- * Wrapped in Suspense so the static document shell can still prerender.
+ * Streams session into the stable AuthProvider without remounting page children.
  */
-async function AuthShell({ children }: { children: React.ReactNode }) {
-  // Explicit dynamic boundary for cookie/session reads (Cache Components)
+async function AuthSessionLoader() {
   await connection();
-  const initialSession = await getServerSession();
-  return <AuthProvider initialSession={initialSession}>{children}</AuthProvider>;
+  const session = await getServerSession();
+  return <AuthSessionSeed session={session} />;
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -327,19 +326,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             disableTransitionOnChange
             enableSystem
           >
-            <Suspense
-              fallback={
-                <AuthProvider initialSession={null}>
-                  {children}
-                  <Toaster />
-                </AuthProvider>
-              }
-            >
-              <AuthShell>
-                {children}
-                <Toaster />
-              </AuthShell>
-            </Suspense>
+            <AuthProvider initialSession={null}>
+              <Suspense fallback={null}>
+                <AuthSessionLoader />
+              </Suspense>
+              {children}
+              <Toaster />
+            </AuthProvider>
           </ThemeProviderWrapper>
         </ErrorBoundary>
       </body>

--- a/apps/web/src/components/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider.tsx
@@ -40,8 +40,17 @@ const AuthContext = createContext<AuthState>({
   refreshAuth: async () => {},
 });
 
+type SeedFn = (session: ServerSession | null) => void;
+
+const AuthSeedContext = createContext<SeedFn>(() => {});
+
 export function useAuth() {
   return useContext(AuthContext);
+}
+
+/** Apply a streamed server session without remounting children. */
+export function useAuthSeed() {
+  return useContext(AuthSeedContext);
 }
 
 function sessionToState(session: ServerSession | null | undefined): Pick<
@@ -209,5 +218,22 @@ export function AuthProvider({
     setAuthState((prev) => ({ ...prev, refreshAuth }));
   }, [refreshAuth]);
 
-  return <AuthContext.Provider value={authState}>{children}</AuthContext.Provider>;
+  const seedSession = useCallback((session: ServerSession | null) => {
+    const next = sessionToState(session);
+    setAuthState((prev) => ({
+      ...prev,
+      ...next,
+      isLoading: false,
+    }));
+    if (session?.authenticated && session.user) {
+      setupSessionTracking(session.user.id);
+    }
+    initialCheckComplete.current = true;
+  }, []);
+
+  return (
+    <AuthSeedContext.Provider value={seedSession}>
+      <AuthContext.Provider value={authState}>{children}</AuthContext.Provider>
+    </AuthSeedContext.Provider>
+  );
 }

--- a/apps/web/src/components/AuthSessionSeed.tsx
+++ b/apps/web/src/components/AuthSessionSeed.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { ServerSession } from "@/lib/auth/get-server-session";
+import { useAuthSeed } from "./AuthProvider";
+
+/**
+ * Applies a streamed server session into AuthProvider without remounting
+ * the page tree (avoids re-running PuzzleContent after Suspense resolves).
+ */
+export function AuthSessionSeed({ session }: { session: ServerSession }) {
+  const seed = useAuthSeed();
+  const applied = useRef(false);
+
+  useEffect(() => {
+    if (applied.current) return;
+    applied.current = true;
+    seed(session);
+  }, [seed, session]);
+
+  return null;
+}

--- a/apps/web/src/components/CelebrationOverlay.tsx
+++ b/apps/web/src/components/CelebrationOverlay.tsx
@@ -310,75 +310,7 @@ function formatTime(seconds: number): string {
 /**
  * Calculate score based on performance
  * Re-exports the unified scoring function from gameSettings for backwards compatibility
- *
- * Note: The signature is kept compatible but now includes difficulty bonus internally
  */
 export { calculateGamePoints as calculateScore } from "@/lib/gameSettings";
 
-/**
- * Determine earned achievements based on performance
- */
-export function determineAchievements(
-  attempts: number,
-  maxAttempts: number,
-  timeTaken?: number,
-  streak?: number,
-  usedHints?: boolean
-): Achievement[] {
-  const achievements: Achievement[] = [];
-
-  // First Solve (would need to track this in user data)
-  // Not implemented here - needs backend check
-
-  // Perfect Solve - first attempt
-  if (attempts === 1) {
-    achievements.push({
-      id: "perfect",
-      name: "Perfect!",
-      description: "Solved on the first attempt",
-      icon: "star",
-    });
-  }
-
-  // Speed Demon - under 30 seconds
-  if (timeTaken !== undefined && timeTaken < 30) {
-    achievements.push({
-      id: "speed-demon",
-      name: "Speed Demon",
-      description: "Solved in under 30 seconds",
-      icon: "zap",
-    });
-  }
-
-  // Clutch - last attempt
-  if (attempts === maxAttempts) {
-    achievements.push({
-      id: "clutch",
-      name: "Clutch!",
-      description: "Solved on the last attempt",
-      icon: "trophy",
-    });
-  }
-
-  // No Hints
-  if (usedHints === false) {
-    achievements.push({
-      id: "no-hints",
-      name: "Pure Skill",
-      description: "Solved without using hints",
-      icon: "star",
-    });
-  }
-
-  // Streak achievements
-  if (streak && streak >= 7) {
-    achievements.push({
-      id: "week-streak",
-      name: "Perfect Week",
-      description: "7-day solving streak!",
-      icon: "flame",
-    });
-  }
-
-  return achievements;
-}
+export { determineAchievements } from "@/lib/game/celebration-achievements";

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -24,7 +24,8 @@ import {
 import { haptics } from "@/lib/haptics";
 import { useLazyGuest } from "@/lib/hooks/useLazyGuest";
 import { useAuth } from "./AuthProvider";
-import { calculateScore, determineAchievements } from "./CelebrationOverlay";
+import { determineAchievements } from "@/lib/game/celebration-achievements";
+import { calculateGamePoints as calculateScore } from "@/lib/gameSettings";
 import { DifficultyBadge } from "./DifficultyBadge";
 import { useGameContext } from "./GameContext";
 import { GuessTrail } from "./GuessTrail";

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,11 +1,16 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { DevToolsPanel } from "./DevToolsPanel";
 import { Footer } from "./Footer";
 import { GameProvider, useGameContext } from "./GameContext";
 import Header from "./Header";
+
+const DevToolsPanel = dynamic(
+  () => import("./DevToolsPanel").then((m) => m.DevToolsPanel),
+  { ssr: false }
+);
 
 interface LayoutProps {
   children: ReactNode;

--- a/apps/web/src/db/indexes.ts
+++ b/apps/web/src/db/indexes.ts
@@ -34,6 +34,8 @@ const INDEX_DEFINITIONS: IndexDefinition[] = [
   {
     collection: "users",
     indexes: [
+      // Primary app lookup by public id (auth, stats, admin)
+      { spec: { id: 1 }, options: { unique: true } },
       // Unique email lookup (authentication)
       { spec: { email: 1 }, options: { unique: true } },
       // Unique username lookup (profile display)

--- a/apps/web/src/db/operations.ts
+++ b/apps/web/src/db/operations.ts
@@ -381,6 +381,7 @@ export const puzzleAttemptOps = {
 
   /**
    * Check if user has already finalized today's puzzle (won or out of attempts).
+   * Hot path for home lock — no countDocuments.
    */
   async hasTodayAttempt(
     userId: string,
@@ -398,31 +399,31 @@ export const puzzleAttemptOps = {
 
     // Prefer puzzleDate + isFinal (new lock path)
     const finalAttempt =
-      (await collection.findOne({
-        userId,
-        puzzleDate: dateKey,
-        isFinal: true,
-      })) ||
-      // Legacy fallback: finals without puzzleDate/isFinal
-      (await collection.findOne({
-        userId,
-        attemptedAt: {
-          $gte: new Date(`${dateKey}T00:00:00.000Z`),
-          $lt: new Date(`${dateKey}T23:59:59.999Z`),
+      (await collection.findOne(
+        {
+          userId,
+          puzzleDate: dateKey,
+          isFinal: true,
         },
-        $or: [{ isCorrect: true }, { abandoned: true }],
-      }));
-
-    const attemptsUsed = await collection.countDocuments({
-      userId,
-      puzzleDate: dateKey,
-    });
+        { projection: { isCorrect: 1, puzzleId: 1 } }
+      )) ||
+      // Legacy fallback: finals without puzzleDate/isFinal
+      (await collection.findOne(
+        {
+          userId,
+          attemptedAt: {
+            $gte: new Date(`${dateKey}T00:00:00.000Z`),
+            $lt: new Date(`${dateKey}T23:59:59.999Z`),
+          },
+          $or: [{ isCorrect: true }, { abandoned: true }],
+        },
+        { projection: { isCorrect: 1, puzzleId: 1 } }
+      ));
 
     return {
       hasAttempt: !!finalAttempt,
       wasSuccessful: finalAttempt?.isCorrect ?? false,
       puzzleId: finalAttempt?.puzzleId,
-      attemptsUsed,
     };
   },
 
@@ -447,14 +448,58 @@ export const puzzleAttemptOps = {
   /** Max hintsUsed reported on any guess today (prevents under-reporting later). */
   async maxHintsUsedToday(userId: string, puzzleDate: string): Promise<number> {
     const collection = getCollection<PuzzleAttempt>("puzzleAttempts");
+    const top = await collection.findOne(
+      { userId, puzzleDate },
+      { sort: { hintsUsed: -1 }, projection: { hintsUsed: 1 } }
+    );
+    return typeof top?.hintsUsed === "number" ? top.hintsUsed : 0;
+  },
+
+  /**
+   * Single round-trip for guess handling: lock + count + first guess + max hints.
+   */
+  async getTodayGuessContext(
+    userId: string,
+    puzzleDate: string
+  ): Promise<{
+    hasFinal: boolean;
+    wasSuccessful: boolean;
+    guessCount: number;
+    firstGuessAt: Date | null;
+    maxHintsUsed: number;
+  }> {
+    const collection = getCollection<PuzzleAttempt>("puzzleAttempts");
     const rows = await collection
       .find({ userId, puzzleDate })
-      .project({ hintsUsed: 1 })
+      .project({ isFinal: 1, isCorrect: 1, abandoned: 1, attemptedAt: 1, hintsUsed: 1 })
       .toArray();
-    return rows.reduce((max, row) => {
-      const n = typeof row.hintsUsed === "number" ? row.hintsUsed : 0;
-      return Math.max(max, n);
-    }, 0);
+
+    let hasFinal = false;
+    let wasSuccessful = false;
+    let firstGuessAt: Date | null = null;
+    let maxHintsUsed = 0;
+
+    for (const row of rows) {
+      if (row.isFinal || row.isCorrect || row.abandoned) {
+        hasFinal = true;
+        if (row.isCorrect) wasSuccessful = true;
+      }
+      if (row.attemptedAt) {
+        const at = new Date(row.attemptedAt);
+        if (!firstGuessAt || at < firstGuessAt) firstGuessAt = at;
+      }
+      if (typeof row.hintsUsed === "number" && row.hintsUsed > maxHintsUsed) {
+        maxHintsUsed = row.hintsUsed;
+      }
+    }
+
+    return {
+      hasFinal,
+      wasSuccessful,
+      guessCount: rows.length,
+      firstGuessAt,
+      maxHintsUsed,
+    };
   },
 
   /** Dev tools: wipe a user's guesses for a UTC day so they can replay. */

--- a/apps/web/src/lib/auth/get-server-session.ts
+++ b/apps/web/src/lib/auth/get-server-session.ts
@@ -1,5 +1,4 @@
 import { cookies } from "next/headers";
-import { db } from "@/db";
 import { verifyToken } from "@/lib/jwt";
 
 const AUTH_COOKIE = "rebuzzle_auth";
@@ -19,6 +18,9 @@ export type ServerSession = {
 /**
  * Read the auth cookie on the server and return a session suitable for
  * seeding the client AuthProvider (avoids a client waterfall on first paint).
+ *
+ * Uses JWT claims only — no Mongo round-trip on the document critical path.
+ * Stale users are corrected on next /api/auth/session refresh.
  */
 export async function getServerSession(): Promise<ServerSession> {
   try {
@@ -34,19 +36,15 @@ export async function getServerSession(): Promise<ServerSession> {
       return { authenticated: false, user: null };
     }
 
-    const user = await db.userOps.findById(payload.userId);
-    if (!user) {
-      return { authenticated: false, user: null };
-    }
-
-    const isGuest = user.email?.endsWith("@guest.rebuzzle.local") ?? false;
+    const email = payload.email || "";
+    const isGuest = email.endsWith("@guest.rebuzzle.local");
 
     return {
       authenticated: true,
       user: {
-        id: user.id,
-        username: user.username || user.email?.split("@")[0] || "User",
-        email: user.email || "",
+        id: payload.userId,
+        username: payload.username || email.split("@")[0] || "User",
+        email,
         isGuest,
       },
     };

--- a/apps/web/src/lib/game/celebration-achievements.ts
+++ b/apps/web/src/lib/game/celebration-achievements.ts
@@ -1,0 +1,64 @@
+export type CelebrationAchievement = {
+  id: string;
+  name: string;
+  description: string;
+  icon: "star" | "zap" | "trophy" | "flame";
+};
+
+/** Lightweight cosmetic achievements for the win overlay (no heavy UI imports). */
+export function determineAchievements(
+  attempts: number,
+  maxAttempts: number,
+  timeTaken?: number,
+  streak?: number,
+  usedHints?: boolean
+): CelebrationAchievement[] {
+  const achievements: CelebrationAchievement[] = [];
+
+  if (attempts === 1) {
+    achievements.push({
+      id: "perfect",
+      name: "Perfect!",
+      description: "Solved on the first attempt",
+      icon: "star",
+    });
+  }
+
+  if (timeTaken !== undefined && timeTaken < 30) {
+    achievements.push({
+      id: "speed-demon",
+      name: "Speed Demon",
+      description: "Solved in under 30 seconds",
+      icon: "zap",
+    });
+  }
+
+  if (attempts === maxAttempts) {
+    achievements.push({
+      id: "clutch",
+      name: "Clutch!",
+      description: "Solved on the last attempt",
+      icon: "trophy",
+    });
+  }
+
+  if (usedHints === false) {
+    achievements.push({
+      id: "no-hints",
+      name: "Pure Skill",
+      description: "Solved without using hints",
+      icon: "star",
+    });
+  }
+
+  if (streak && streak >= 7) {
+    achievements.push({
+      id: "week-streak",
+      name: "Perfect Week",
+      description: "7-day solving streak!",
+      icon: "flame",
+    });
+  }
+
+  return achievements;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

High-impact speedups for home/board TTFB, guess INP, and client JS.

### TTFB / first paint
- Auth seeds from **JWT only** (no Mongo `users` lookup on every document)
- Auth Suspense no longer remounts the page tree (`AuthSessionSeed`)
- Board load **never waits on Eve/AI** — cron/admin regenerate owns generation; play path uses cache/DB or a fast fallback seed
- Slimmer daily lock check (no `countDocuments` on home)

### Guess path
- Parallel rate-limit + body parse; parallel puzzle/today/attempt context
- Single `getTodayGuessContext` round-trip instead of 3–4 queries
- Local/fuzzy validation first (`alwaysUseAI: false`, 1.8s AI timeout)
- Stats + achievements deferred with `after()` so the response returns immediately

### Client / assets
- Lazy `DevToolsPanel`; GameBoard no longer pulls CelebrationOverlay for scoring helpers
- Long-cache headers for `/_next/static` + image assets
- Higher `images.minimumCacheTTL`; `transpilePackages` for monorepo packages
- Index on `users.id`

## Test plan
- [ ] Load `/` — board appears quickly; no remount flash after auth
- [ ] Submit guesses — wrong/correct feel snappy; finals still lock + reveal answer
- [ ] Cold day (no puzzle) — playable fallback appears without long AI wait
- [ ] Cron/admin regenerate still AI-generates (`allowAiGenerate` default true)
- [ ] Dev Mode panel still loads when enabled

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

