### PR TITLE
Fix guest Settings menu + Dev Mode access

### DIFF
--- a/apps/web/src/app/api/dev/session/route.ts
+++ b/apps/web/src/app/api/dev/session/route.ts
@@ -1,25 +1,26 @@
 /**
- * Temporary Dev Mode APIs — admin only.
- * Lets you regenerate puzzles and walk gated play states while tuning Eve.
+ * Temporary Dev Mode APIs.
+ * Available to any signed-in user (including guests) while testing.
+ * Do not ship long-term without tightening access again.
  */
 
 import { NextResponse } from "next/server";
 import { regenerateTodaysPuzzle } from "@/app/actions/regeneratePuzzleActions";
 import { db } from "@/db";
-import { verifyAdminAccess } from "@/lib/admin-auth";
+import { getAuthenticatedUser } from "@/lib/auth-middleware";
 import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
 import { toPublicPuzzle } from "@/lib/game/public-puzzle";
 
 export async function GET(request: Request) {
-  const admin = await verifyAdminAccess(request);
-  if (!admin) {
-    return NextResponse.json({ success: false, allowed: false }, { status: 403 });
+  const authUser = await getAuthenticatedUser(request);
+  if (!authUser) {
+    return NextResponse.json({ success: false, allowed: false }, { status: 401 });
   }
 
   const puzzleDate = getUtcPuzzleDate();
   const [puzzle, lock] = await Promise.all([
     db.puzzleOps.findTodaysPuzzle(),
-    db.puzzleAttemptOps.hasTodayAttempt(admin.id, puzzleDate),
+    db.puzzleAttemptOps.hasTodayAttempt(authUser.userId, puzzleDate),
   ]);
 
   return NextResponse.json({
@@ -38,19 +39,15 @@ export async function GET(request: Request) {
   });
 }
 
-type DevAction =
-  | "clear-attempts"
-  | "lock-win"
-  | "lock-lose"
-  | "regenerate";
+type DevAction = "clear-attempts" | "lock-win" | "lock-lose" | "regenerate";
 
 export async function POST(request: Request) {
   try {
-    const admin = await verifyAdminAccess(request);
-    if (!admin) {
+    const authUser = await getAuthenticatedUser(request);
+    if (!authUser) {
       return NextResponse.json(
-        { success: false, error: "Admin access required for Dev Mode actions" },
-        { status: 403 }
+        { success: false, error: "Sign in (guest or account) to use Dev Mode actions" },
+        { status: 401 }
       );
     }
 
@@ -65,9 +62,10 @@ export async function POST(request: Request) {
     }
 
     const puzzleDate = getUtcPuzzleDate();
+    const userId = authUser.userId;
 
     if (action === "clear-attempts") {
-      const deleted = await db.puzzleAttemptOps.clearAttemptsForDate(admin.id, puzzleDate);
+      const deleted = await db.puzzleAttemptOps.clearAttemptsForDate(userId, puzzleDate);
       return NextResponse.json({
         success: true,
         action,
@@ -85,12 +83,12 @@ export async function POST(request: Request) {
         );
       }
 
-      await db.puzzleAttemptOps.clearAttemptsForDate(admin.id, puzzleDate);
+      await db.puzzleAttemptOps.clearAttemptsForDate(userId, puzzleDate);
 
       const isWin = action === "lock-win";
       await db.puzzleAttemptOps.create({
         id: crypto.randomUUID(),
-        userId: admin.id,
+        userId,
         puzzleId: puzzle.id,
         attemptedAnswer: isWin ? puzzle.answer : "dev-mode-wrong-guess",
         isCorrect: isWin,
@@ -115,13 +113,10 @@ export async function POST(request: Request) {
 
     if (action === "regenerate") {
       // Clear personal lock so the new puzzle is immediately playable
-      await db.puzzleAttemptOps.clearAttemptsForDate(admin.id, puzzleDate);
+      await db.puzzleAttemptOps.clearAttemptsForDate(userId, puzzleDate);
       const result = await regenerateTodaysPuzzle(body.puzzleType || undefined);
       if (!result.success) {
-        return NextResponse.json(
-          { success: false, error: result.message },
-          { status: 500 }
-        );
+        return NextResponse.json({ success: false, error: result.message }, { status: 500 });
       }
 
       return NextResponse.json({

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -338,8 +338,8 @@ export default function SettingsPage() {
                 </Label>
                 <p className="text-muted-foreground text-sm">
                   Shows a floating panel on every page: regenerate today&apos;s puzzle, unlock/replay
-                  the daily gate, and jump between play → locked → win/lose screens. Server actions
-                  require an admin account.
+                  the daily gate, and jump between play → locked → win/lose screens. Works for
+                  guests and signed-in accounts while this temporary tooling is enabled.
                 </p>
               </div>
               <Switch

--- a/apps/web/src/components/DevToolsPanel.tsx
+++ b/apps/web/src/components/DevToolsPanel.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Temporary floating Dev Mode panel.
- * Enable via Settings → Dev Mode. Server actions require admin.
+ * Enable via Settings → Dev Mode. Server actions require a signed-in user (guest OK).
  */
 
 import {
@@ -63,7 +63,7 @@ export function DevToolsPanel() {
       };
       if (!res.ok || !data.allowed) {
         setAllowed(false);
-        setLockInfo("Admin login required for Dev Mode actions");
+        setLockInfo("Sign in as guest or account to use Dev Mode actions");
         return;
       }
       setAllowed(true);
@@ -159,7 +159,7 @@ export function DevToolsPanel() {
       {open && (
         <div className="space-y-3 p-3 text-xs">
           <p className="text-[11px] text-muted-foreground leading-snug">
-            Temporary testing tools. Actions require an admin account.
+            Temporary testing tools for signed-in users (including guests). Turn off when done.
           </p>
           <p className="rounded-md bg-muted/80 px-2 py-1.5 font-mono text-[10px] text-foreground/80">
             {lockInfo || (allowed === null ? "Checking access…" : "—")}
@@ -167,7 +167,7 @@ export function DevToolsPanel() {
 
           {allowed === false && (
             <p className="text-destructive text-[11px]">
-              Log in as admin (ADMIN_EMAIL / isAdmin) to use these actions.
+              Play as guest or sign in, then refresh to use these actions.
             </p>
           )}
 

--- a/apps/web/src/components/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu.tsx
@@ -135,6 +135,13 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="cursor-pointer gap-2"
+            onClick={() => router.push("/settings")}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer gap-2"
             onClick={() => router.push("/leaderboard")}
           >
             <Trophy className="h-4 w-4" />
@@ -208,6 +215,13 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
             Create an account
           </DropdownMenuItem>
           <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer gap-2"
+            onClick={() => router.push("/settings")}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer gap-2"
             onClick={() => router.push("/how-it-works")}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Guests could not open **Settings** from the avatar menu, so the temporary Dev Mode toggle was hard to find. Dev Mode APIs were also admin-only, so the panel was useless even after enabling it.

## Changes
- Add **Settings** to guest and signed-out `UserMenu` menus
- Allow `/api/dev/session` for any authenticated user (including guests)
- Update Dev Mode / Settings copy to match (no admin requirement while this tooling is temporary)

## Test plan
- [ ] As a guest, open avatar menu → Settings is listed
- [ ] On Settings, enable Dev Mode → amber panel appears bottom-right
- [ ] Panel status loads without “admin required”
- [ ] Unlock today / regenerate / gate jumps work for a guest session

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

