### PR TITLE
Add visual themes: Default + 8-bit (8bitcn)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -71,6 +71,10 @@
 
     --radius: 0.5rem; /* marketing radius 8px; sm 4px / md 6px derive from it */
     --header-height: 56px;
+
+    /* Semantic font stacks — skins rebind these; next/font fills --font-geist-* */
+    --font-sans: var(--font-geist-sans), Inter, system-ui, -apple-system, sans-serif;
+    --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
   }
 
   .dark {
@@ -111,6 +115,130 @@
     --shadow-lg: 0 2px 2px rgb(0 0 0 / 0.28), 0 8px 16px -4px rgb(0 0 0 / 0.32);
     --shadow-menu: 0 1px 1px rgb(0 0 0 / 0.24), 0 8px 16px -4px rgb(0 0 0 / 0.32),
       0 24px 32px -8px rgb(0 0 0 / 0.4);
+  }
+
+  /* ============================================================
+     8-BIT SKIN — inspired by 8bitcn/ui
+     Composes with .dark. Sharp corners, pixel font, chunky borders.
+     https://www.8bitcn.com/docs
+     ============================================================ */
+  html[data-skin="8bit"] {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 15%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 15%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 15%;
+    --inset: 0 0% 97%;
+
+    --primary: 0 0% 21%;
+    --primary-foreground: 0 0% 98%;
+
+    --secondary: 0 0% 97%;
+    --secondary-foreground: 0 0% 21%;
+    --muted: 0 0% 97%;
+    --muted-foreground: 0 0% 45%;
+    --subtle-foreground: 0 0% 55%;
+    --accent: 0 0% 97%;
+    --accent-foreground: 0 0% 21%;
+
+    --border: 0 0% 70%;
+    --border-strong: 0 0% 20%;
+    --input: 0 0% 70%;
+    --ring: 0 0% 40%;
+
+    --link: 212 100% 42%;
+    --link-deep: 212 100% 36%;
+    --success: 131 45% 38%;
+    --warning: 40 95% 48%;
+    --destructive: 12 85% 48%;
+    --destructive-foreground: 0 0% 100%;
+
+    --chart-1: 28 90% 52%;
+    --chart-2: 184 55% 42%;
+    --chart-3: 220 35% 40%;
+    --chart-4: 84 70% 55%;
+    --chart-5: 50 85% 52%;
+
+    --shadow-border: inset 0 0 0 2px hsl(0 0% 15%);
+    --shadow-sm: 2px 2px 0 0 hsl(0 0% 15%);
+    --shadow-md: 3px 3px 0 0 hsl(0 0% 15%);
+    --shadow-lg: 4px 4px 0 0 hsl(0 0% 15%);
+    --shadow-menu: 4px 4px 0 0 hsl(0 0% 15%);
+
+    --radius: 0rem;
+    --font-sans: var(--font-pixel), "Press Start 2P", ui-monospace, monospace;
+    --font-mono: var(--font-pixel), "Press Start 2P", ui-monospace, monospace;
+    /* Press Start 2P is oversized at 16px — dial the root down */
+    font-size: 12px;
+  }
+
+  html[data-skin="8bit"].dark {
+    --background: 0 0% 15%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 21%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 21%;
+    --popover-foreground: 0 0% 98%;
+    --inset: 0 0% 18%;
+
+    --primary: 0 0% 92%;
+    --primary-foreground: 0 0% 21%;
+
+    --secondary: 0 0% 27%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 27%;
+    --muted-foreground: 0 0% 70%;
+    --subtle-foreground: 0 0% 60%;
+    --accent: 0 0% 27%;
+    --accent-foreground: 0 0% 98%;
+
+    --border: 0 0% 45%;
+    --border-strong: 0 0% 80%;
+    --input: 0 0% 45%;
+    --ring: 0 0% 70%;
+
+    --link: 212 100% 65%;
+    --link-deep: 212 100% 72%;
+    --success: 131 45% 52%;
+    --warning: 40 95% 55%;
+    --destructive: 12 80% 58%;
+    --destructive-foreground: 0 0% 100%;
+
+    --chart-1: 264 70% 55%;
+    --chart-2: 162 55% 48%;
+    --chart-3: 50 85% 55%;
+    --chart-4: 303 65% 55%;
+    --chart-5: 16 80% 55%;
+
+    --shadow-border: inset 0 0 0 2px hsl(0 0% 92%);
+    --shadow-sm: 2px 2px 0 0 hsl(0 0% 92%);
+    --shadow-md: 3px 3px 0 0 hsl(0 0% 92%);
+    --shadow-lg: 4px 4px 0 0 hsl(0 0% 92%);
+    --shadow-menu: 4px 4px 0 0 hsl(0 0% 92%);
+  }
+
+  html[data-skin="8bit"] body {
+    font-feature-settings: normal;
+    /* Pixel fonts read better slightly smaller with more line height */
+    letter-spacing: 0;
+    line-height: 1.6;
+    image-rendering: pixelated;
+  }
+
+  html[data-skin="8bit"] h1,
+  html[data-skin="8bit"] h2,
+  html[data-skin="8bit"] h3,
+  html[data-skin="8bit"] h4 {
+    letter-spacing: 0;
+    font-weight: 400;
+    line-height: 1.4;
+  }
+
+  html[data-skin="8bit"] :focus-visible {
+    outline-width: 3px;
+    outline-offset: 2px;
+    border-radius: 0;
   }
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Press_Start_2P } from "next/font/google";
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import { connection } from "next/server";
@@ -8,6 +8,7 @@ import { AuthSessionSeed } from "@/components/AuthSessionSeed";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ThemeProviderWrapper } from "@/components/ThemeProviderWrapper";
 import { Toaster } from "@/components/ui/toaster";
+import { VisualThemeProvider } from "@/components/VisualThemeProvider";
 import { getServerSession } from "@/lib/auth/get-server-session";
 import {
   generateAccessibilitySchema,
@@ -17,6 +18,7 @@ import {
   generateSoftwareApplicationSchema,
   generateWebSiteSchema,
 } from "@/lib/seo/structured-data";
+import { VISUAL_THEME_BOOTSTRAP_SCRIPT } from "@/lib/visual-theme";
 
 // Geometric sans carries display, body, button — everything narrative.
 const geistSans = Geist({
@@ -25,7 +27,8 @@ const geistSans = Geist({
   preload: true,
   fallback: ["Inter", "system-ui", "-apple-system", "sans-serif"],
   adjustFontFallback: true,
-  variable: "--font-sans",
+  // Distinct from --font-sans so visual skins can rebind the semantic stack.
+  variable: "--font-geist-sans",
 });
 
 // Mono carries the technical layer only: eyebrows, code, puzzle ciphers.
@@ -34,7 +37,16 @@ const geistMono = Geist_Mono({
   display: "swap",
   preload: false,
   fallback: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
-  variable: "--font-mono",
+  variable: "--font-geist-mono",
+});
+
+// Pixel face for the optional 8-bit visual skin (8bitcn-inspired).
+const pressStart = Press_Start_2P({
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+  preload: false,
+  variable: "--font-pixel",
 });
 
 // Enhanced viewport configuration for mobile
@@ -236,8 +248,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const accessibilitySchema = generateAccessibilitySchema();
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      className={`${geistSans.variable} ${geistMono.variable} ${pressStart.variable}`}
+      data-skin="default"
+      lang="en"
+      suppressHydrationWarning
+    >
       <head>
+        <script dangerouslySetInnerHTML={{ __html: VISUAL_THEME_BOOTSTRAP_SCRIPT }} />
         {/* JSON-LD Structured Data */}
         <script
           dangerouslySetInnerHTML={{
@@ -309,9 +327,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* Notification permission hint for mobile */}
         <meta content="granted" name="notification-permission" />
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} min-h-screen overflow-x-hidden bg-background font-sans antialiased`}
-      >
+      <body className="min-h-screen overflow-x-hidden bg-background font-sans antialiased">
         {/* Skip to content link for keyboard navigation */}
         <a
           className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-foreground focus:px-4 focus:py-2 focus:font-medium focus:text-background focus:text-sm"
@@ -326,13 +342,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             disableTransitionOnChange
             enableSystem
           >
-            <AuthProvider initialSession={null}>
-              <Suspense fallback={null}>
-                <AuthSessionLoader />
-              </Suspense>
-              {children}
-              <Toaster />
-            </AuthProvider>
+            <VisualThemeProvider>
+              <AuthProvider initialSession={null}>
+                <Suspense fallback={null}>
+                  <AuthSessionLoader />
+                </Suspense>
+                {children}
+                <Toaster />
+              </AuthProvider>
+            </VisualThemeProvider>
           </ThemeProviderWrapper>
         </ErrorBoundary>
       </body>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import {
+  Check,
   ChevronRight,
   FlaskConical,
+  Gamepad2,
   Lock,
-  Moon,
+  Palette,
   Save,
   Settings as SettingsIcon,
   Shield,
@@ -25,14 +27,18 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { useVisualTheme } from "@/components/VisualThemeProvider";
 import { useToast } from "@/hooks/use-toast";
 import type { AvatarPreferences } from "@/lib/avatar";
 import { isDevModeEnabled, setDevModeEnabled } from "@/lib/dev-mode";
+import { cn } from "@/lib/utils";
+import { VISUAL_THEME_META, VISUAL_THEMES, type VisualTheme } from "@/lib/visual-theme";
 
 export default function SettingsPage() {
   const router = useRouter();
   const { toast } = useToast();
   const { theme, setTheme } = useTheme();
+  const { visualTheme, setVisualTheme, mounted: themeMounted } = useVisualTheme();
   const { user, isAuthenticated } = useAuth();
   const [mounted, setMounted] = useState(false);
   const [devMode, setDevMode] = useState(false);
@@ -337,9 +343,9 @@ export default function SettingsPage() {
                   Enable testing tools
                 </Label>
                 <p className="text-muted-foreground text-sm">
-                  Shows a floating panel on every page: regenerate today&apos;s puzzle, unlock/replay
-                  the daily gate, and jump between play → locked → win/lose screens. Server actions
-                  require an admin account.
+                  Shows a floating panel on every page: regenerate today&apos;s puzzle,
+                  unlock/replay the daily gate, and jump between play → locked → win/lose screens.
+                  Server actions require an admin account.
                 </p>
               </div>
               <Switch
@@ -407,17 +413,83 @@ export default function SettingsPage() {
           {/* Appearance */}
           <Card className="p-6">
             <h2 className="mb-4 flex items-center gap-2 font-semibold text-xl">
-              <Moon className="h-5 w-5" />
+              <Palette className="h-5 w-5" />
               Appearance
             </h2>
 
-            <div className="space-y-4">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <div>
+                  <Label className="text-base">Theme</Label>
+                  <p className="text-muted-foreground text-sm">
+                    Visual style for the whole app. Default is the current Rebuzzle look; 8-bit is
+                    inspired by{" "}
+                    <a
+                      className="text-link underline-offset-2 hover:underline"
+                      href="https://www.8bitcn.com/docs"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      8bitcn/ui
+                    </a>
+                    .
+                  </p>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {VISUAL_THEMES.map((id) => {
+                    const meta = VISUAL_THEME_META[id];
+                    const selected = themeMounted && visualTheme === id;
+                    const Icon = id === "8bit" ? Gamepad2 : Palette;
+                    return (
+                      <button
+                        key={id}
+                        type="button"
+                        disabled={!themeMounted}
+                        onClick={() => {
+                          setVisualTheme(id as VisualTheme);
+                          toast({
+                            title: `${meta.label} theme`,
+                            description: meta.description,
+                          });
+                        }}
+                        className={cn(
+                          "relative flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors",
+                          "hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          selected ? "border-foreground bg-muted/40" : "border-border bg-card"
+                        )}
+                      >
+                        <div className="flex w-full items-center gap-2">
+                          <Icon className="h-4 w-4 shrink-0" />
+                          <span className="font-medium text-sm">{meta.label}</span>
+                          {selected && <Check className="ml-auto h-4 w-4" />}
+                        </div>
+                        <p className="text-muted-foreground text-xs leading-snug">
+                          {meta.description}
+                        </p>
+                        {id === "8bit" && (
+                          <span
+                            className="mt-1 font-normal text-[10px] uppercase tracking-wide text-subtle"
+                            style={{ fontFamily: "var(--font-pixel), monospace" }}
+                          >
+                            PRESS START
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <Separator />
+
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
                   <Label className="cursor-pointer text-base" htmlFor="dark-mode">
                     Dark Mode
                   </Label>
-                  <p className="text-muted-foreground text-sm">Switch to dark theme</p>
+                  <p className="text-muted-foreground text-sm">
+                    Works with every theme (Default and 8-bit)
+                  </p>
                 </div>
                 <Switch
                   checked={settings.darkMode}

--- a/apps/web/src/components/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu.tsx
@@ -28,6 +28,7 @@ import {
 import { generateAvatarProps, getAvatarClassName } from "@/lib/avatar";
 import { cn } from "@/lib/utils";
 import { useAuth } from "./AuthProvider";
+import { VisualThemeMenuItems } from "./VisualThemeMenuItems";
 
 type UserMenuProps = {
   isAuthenticated: boolean;
@@ -142,11 +143,19 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
           </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer gap-2"
+            onClick={() => router.push("/settings")}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer gap-2"
             onClick={() => router.push("/how-it-works")}
           >
             <HelpCircle className="h-4 w-4" />
             How It Works
           </DropdownMenuItem>
+          <VisualThemeMenuItems />
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="cursor-pointer gap-2"
@@ -210,11 +219,19 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="cursor-pointer gap-2"
+            onClick={() => router.push("/settings")}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer gap-2"
             onClick={() => router.push("/how-it-works")}
           >
             <HelpCircle className="h-4 w-4" />
             How It Works
           </DropdownMenuItem>
+          <VisualThemeMenuItems />
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="cursor-pointer gap-2"
@@ -349,6 +366,7 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
           How It Works
         </DropdownMenuItem>
 
+        <VisualThemeMenuItems />
         <DropdownMenuSeparator />
 
         <DropdownMenuItem

--- a/apps/web/src/components/VisualThemeMenuItems.tsx
+++ b/apps/web/src/components/VisualThemeMenuItems.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Check, Gamepad2, Palette } from "lucide-react";
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { useVisualTheme } from "@/components/VisualThemeProvider";
+import { cn } from "@/lib/utils";
+import { VISUAL_THEME_META, VISUAL_THEMES, type VisualTheme } from "@/lib/visual-theme";
+
+const THEME_ICONS: Record<VisualTheme, typeof Palette> = {
+  default: Palette,
+  "8bit": Gamepad2,
+};
+
+/**
+ * Theme picker for the account dropdown — works for guest, signed-out, and signed-in.
+ */
+export function VisualThemeMenuItems() {
+  const { visualTheme, setVisualTheme, mounted } = useVisualTheme();
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel>Theme</DropdownMenuLabel>
+      {VISUAL_THEMES.map((id) => {
+        const meta = VISUAL_THEME_META[id];
+        const Icon = THEME_ICONS[id];
+        const selected = mounted && visualTheme === id;
+        return (
+          <DropdownMenuItem
+            key={id}
+            className="cursor-pointer gap-2"
+            disabled={!mounted}
+            onClick={() => setVisualTheme(id)}
+          >
+            <Icon className="h-4 w-4 shrink-0" />
+            <span className="flex-1">{meta.label}</span>
+            <Check
+              className={cn("h-3.5 w-3.5", selected ? "opacity-100" : "opacity-0")}
+              aria-hidden={!selected}
+            />
+          </DropdownMenuItem>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/VisualThemeProvider.tsx
+++ b/apps/web/src/components/VisualThemeProvider.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  applyVisualTheme,
+  getStoredVisualTheme,
+  setStoredVisualTheme,
+  VISUAL_THEME_STORAGE_KEY,
+  type VisualTheme,
+} from "@/lib/visual-theme";
+
+type VisualThemeContextValue = {
+  visualTheme: VisualTheme;
+  setVisualTheme: (theme: VisualTheme) => void;
+  mounted: boolean;
+};
+
+const VisualThemeContext = createContext<VisualThemeContextValue>({
+  visualTheme: "default",
+  setVisualTheme: () => {},
+  mounted: false,
+});
+
+export function useVisualTheme() {
+  return useContext(VisualThemeContext);
+}
+
+export function VisualThemeProvider({ children }: { children: ReactNode }) {
+  const [visualTheme, setThemeState] = useState<VisualTheme>("default");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const initial = getStoredVisualTheme();
+    setThemeState(initial);
+    applyVisualTheme(initial);
+    setMounted(true);
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === VISUAL_THEME_STORAGE_KEY || e.key === null) {
+        const next = getStoredVisualTheme();
+        setThemeState(next);
+        applyVisualTheme(next);
+      }
+    };
+    const onCustom = (e: Event) => {
+      const detail = (e as CustomEvent<{ theme?: VisualTheme }>).detail;
+      if (detail?.theme) {
+        setThemeState(detail.theme);
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("rebuzzle:visual-theme", onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("rebuzzle:visual-theme", onCustom);
+    };
+  }, []);
+
+  const setVisualTheme = useCallback((theme: VisualTheme) => {
+    setThemeState(theme);
+    setStoredVisualTheme(theme);
+  }, []);
+
+  const value = useMemo(
+    () => ({ visualTheme, setVisualTheme, mounted }),
+    [visualTheme, setVisualTheme, mounted]
+  );
+
+  return <VisualThemeContext.Provider value={value}>{children}</VisualThemeContext.Provider>;
+}

--- a/apps/web/src/lib/visual-theme.ts
+++ b/apps/web/src/lib/visual-theme.ts
@@ -1,0 +1,54 @@
+/**
+ * Visual skin (independent of light/dark mode).
+ * Default = current Rebuzzle ink-on-canvas design.
+ * 8bit = 8bitcn-inspired retro skin (sharp corners, pixel font).
+ */
+
+export const VISUAL_THEME_STORAGE_KEY = "rebuzzle_visual_theme";
+export const VISUAL_THEME_ATTRIBUTE = "data-skin";
+
+export const VISUAL_THEMES = ["default", "8bit"] as const;
+export type VisualTheme = (typeof VISUAL_THEMES)[number];
+
+export const VISUAL_THEME_META: Record<VisualTheme, { label: string; description: string }> = {
+  default: {
+    label: "Default",
+    description: "Ink-on-canvas — the current Rebuzzle look",
+  },
+  "8bit": {
+    label: "8-bit",
+    description: "Retro pixel style inspired by 8bitcn/ui",
+  },
+};
+
+export function isVisualTheme(value: unknown): value is VisualTheme {
+  return typeof value === "string" && (VISUAL_THEMES as readonly string[]).includes(value);
+}
+
+export function getStoredVisualTheme(): VisualTheme {
+  if (typeof window === "undefined") return "default";
+  try {
+    const stored = window.localStorage.getItem(VISUAL_THEME_STORAGE_KEY);
+    return isVisualTheme(stored) ? stored : "default";
+  } catch {
+    return "default";
+  }
+}
+
+export function applyVisualTheme(theme: VisualTheme): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.setAttribute(VISUAL_THEME_ATTRIBUTE, theme);
+}
+
+export function setStoredVisualTheme(theme: VisualTheme): void {
+  applyVisualTheme(theme);
+  try {
+    window.localStorage.setItem(VISUAL_THEME_STORAGE_KEY, theme);
+  } catch {
+    // ignore quota / private mode
+  }
+  window.dispatchEvent(new CustomEvent("rebuzzle:visual-theme", { detail: { theme } }));
+}
+
+/** Inline script for layout <head> — applies skin before paint to avoid FOUC. */
+export const VISUAL_THEME_BOOTSTRAP_SCRIPT = `(function(){try{var k=${JSON.stringify(VISUAL_THEME_STORAGE_KEY)};var a=${JSON.stringify(VISUAL_THEME_ATTRIBUTE)};var v=localStorage.getItem(k);if(v!=="default"&&v!=="8bit")v="default";document.documentElement.setAttribute(a,v);}catch(e){document.documentElement.setAttribute(${JSON.stringify(VISUAL_THEME_ATTRIBUTE)},"default");}})();`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a **visual theme** (skin) system alongside light/dark mode. The current ink-on-canvas design is **Default**; **8-bit** is a retro skin inspired by [8bitcn/ui](https://www.8bitcn.com/docs).

## How it works
- Skin is stored as `data-skin` on `<html>` (`default` | `8bit`), independent of next-themes light/dark
- Persisted in `localStorage` with a small FOUC bootstrap script
- 8-bit: Press Start 2P, zero radius, chunky pixel shadows, stronger borders

## Where to switch
- **Account dropdown** → Theme → Default / 8-bit (guest, signed-out, and signed-in)
- **Settings → Appearance** → theme cards + dark mode toggle

Also adds Settings links for guest / signed-out menus so Appearance is reachable.

## Test plan
- [ ] Open avatar menu → Theme → switch Default ↔ 8-bit; UI updates immediately
- [ ] Toggle dark mode while on 8-bit — both modes look correct
- [ ] Reload page — chosen theme persists without a flash
- [ ] Settings → Appearance theme cards match the dropdown selection

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

