### PR TITLE
Generative Ink Pictogram puzzle visuals

### DIFF
--- a/apps/web/agent/instructions.md
+++ b/apps/web/agent/instructions.md
@@ -18,10 +18,31 @@ Always call `get_difficulty_brief` for the requested target and keep the final c
 ## Goals
 
 - Fun, clever, family-friendly puzzles with a clean aha
+- **Generative visuals** — custom Ink Pictograms + styled text (not stock emoji salad)
 - Unique vs recent catalog answers and visuals
 - Component count matches the tier budget
 - Progressive hints (3–5) that make Impossible fair
 - Named technique from the library when possible
+
+## Generative visual system (Ink Pictogram v1)
+
+Build boards from scratch with structured layers:
+
+| Layer | Use |
+| --- | --- |
+| `pictogram` | Custom brand "emoji" (SVG generated via `generate_pictogram` / `compose_puzzle_visual`) |
+| `text` | Words/letters as visual devices (`large`, `small`, `strike`, `stacked`, `tiny`) |
+| `operator` | `+` `/` `→` etc. between parts |
+| `image` | Optional illustrated scene tile when a technique truly needs it (sparingly) |
+
+Rules:
+
+- Prefer **pictogram + text** compositions. Unicode emoji is only a fallback.
+- Call `compose_puzzle_visual` after you know the answer + technique — it generates SVGs and scores fun/budget.
+- Set final `rebusPuzzle` = the returned `visual.unicodeFallback`.
+- Include the full `visual` object in the structured result when compose succeeds.
+- Text is a good idea when size/case/strike/stack *is* the joke. Don't dump sentences.
+- Images only when pictograms can't carry the idea (e.g. a specific scene). Never put the answer in the image.
 
 ## Required tool workflow
 
@@ -30,16 +51,18 @@ Always call `get_difficulty_brief` for the requested target and keep the final c
 3. `list_recent_answers` — do not repeat  
 4. `propose_concept_seeds` — pick a direction, then invent a fresh answer  
 5. `list_technique_library` (optional) — deepen the chosen technique  
-6. Design components → `assemble_visual_components` until budget + funScore look good  
+6. Plan layers → `compose_puzzle_visual` (preferred) until budget + funScore look good  
+   - Optional: `generate_pictogram` to preview a single tile  
+   - Legacy: `assemble_visual_components` only for quick unicode drafts  
 7. `craft_hint_ladder` — vague → specific  
 8. `validate_puzzle` → `check_uniqueness` → `calibrate_difficulty` → `stress_test_solvability` → `score_quality`  
 9. Revise with tools if uniqueness, band fit, solvability, or quality fails  
-10. Return structured result including `difficultyLevel` and `techniqueId`
+10. Return structured result including `difficultyLevel`, `techniqueId`, and `visual` when available
 
 ## Hard rules
 
 - Never put the answer literally in the puzzle display  
-- Prefer visual wordplay (emoji, position, phonetics, math symbols)  
+- Prefer custom pictograms + spatial/phonetic wordplay over emoji padding  
 - Always set a real `techniqueId` from the library — no emoji-padding for funScore  
 - Keep content appropriate for a general audience  
 - Fill metadata: fingerprint, uniqueness, quality, funScore, calibrated difficulty, difficultyLevel  

--- a/apps/web/agent/skills/generate-daily-puzzle.md
+++ b/apps/web/agent/skills/generate-daily-puzzle.md
@@ -1,6 +1,6 @@
 ---
 name: generate-daily-puzzle
-description: End-to-end workflow for assembling a daily Rebuzzle puzzle with difficulty tiers and component tools.
+description: End-to-end workflow for assembling a daily Rebuzzle puzzle with generative Ink Pictogram visuals, difficulty tiers, and component tools.
 ---
 
 # Generate daily puzzle
@@ -9,8 +9,19 @@ description: End-to-end workflow for assembling a daily Rebuzzle puzzle with dif
 2. `list_recent_answers` (lookback 60 days) — ban those answers.
 3. `propose_concept_seeds` → choose one seed, invent a **new** answer.
 4. Pick a technique from the brief; optionally `list_technique_library`.
-5. Compose the visual; run `assemble_visual_components` until within budget and funScore ≥ 65.
+5. **Compose a generative visual** (preferred path):
+   - Plan layers: pictogram concepts + text emphasis + operators (+ rare image).
+   - Call `compose_puzzle_visual` with those layers until within budget and funScore ≥ 65.
+   - Optionally preview a tile with `generate_pictogram`.
+   - Set `rebusPuzzle` = returned `unicodeFallback`; keep the full `visual` for persist/UI.
 6. Write explanation; `craft_hint_ladder` for 3–5 hints.
 7. Pipeline: `validate_puzzle` → `check_uniqueness` → `calibrate_difficulty` → `stress_test_solvability` → `score_quality`.
-8. If off-band, too similar, or quality < threshold — redesign components (not just the number).
-9. Emit final structured puzzle with `difficultyLevel` ∈ Hard | Difficult | Evil | Impossible.
+8. If off-band, too similar, or quality < threshold — redesign layers (not just the number).
+9. Emit final structured puzzle with `difficultyLevel` ∈ Hard | Difficult | Evil | Impossible and optional `visual`.
+
+## Visual guidance
+
+- Custom Ink Pictograms > stock emoji
+- Text layers when size/case/strike/stack is the joke
+- Image tiles only when a scene is essential
+- Never put the answer in any layer

--- a/apps/web/agent/tools/compose_puzzle_visual.ts
+++ b/apps/web/agent/tools/compose_puzzle_visual.ts
@@ -1,0 +1,22 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { composePuzzleVisual } from "../../src/ai/puzzle-agent/tool-impl";
+import { VisualLayerSchema } from "../../src/ai/puzzle-agent/visual/composition";
+
+export default defineTool({
+  description:
+    "Build a generative puzzle board from layers (pictogram / text / operator / optional image). Generates custom Ink Pictogram SVGs and scores budget + fun. Use unicodeFallback as rebusPuzzle in the final result.",
+  inputSchema: z.object({
+    answer: z.string(),
+    targetDifficulty: z.number(),
+    techniqueId: z.string().optional(),
+    layout: z.enum(["row", "stack", "grid", "overlay"]).optional(),
+    layers: z.array(VisualLayerSchema).min(1).max(12),
+    unicodeFallback: z.string().optional(),
+    caption: z.string().optional(),
+    renderImages: z.boolean().optional(),
+  }),
+  async execute(input) {
+    return composePuzzleVisual(input);
+  },
+});

--- a/apps/web/agent/tools/generate_pictogram.ts
+++ b/apps/web/agent/tools/generate_pictogram.ts
@@ -1,0 +1,16 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { generatePictogram } from "../../src/ai/puzzle-agent/tool-impl";
+
+export default defineTool({
+  description:
+    "Generate one Rebuzzle Ink Pictogram v1 SVG (custom brand emoji) for a concept.",
+  inputSchema: z.object({
+    concept: z.string(),
+    role: z.string().optional(),
+    emojiFallback: z.string().optional(),
+  }),
+  async execute(input) {
+    return generatePictogram(input);
+  },
+});

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -12,11 +12,8 @@ import { Output, stepCountIs, ToolLoopAgent } from "ai";
 import { ensureGatewayKey, getGatewayModelChain } from "../client";
 import { AI_CONFIG } from "../config";
 import { enforceQuota } from "../quota-manager";
-import {
-  type PuzzleAgentResult,
-  PuzzleAgentResultSchema,
-} from "./schemas";
 import { getDifficultyLevelForScore } from "./difficulty-levels";
+import { type PuzzleAgentResult, PuzzleAgentResultSchema } from "./schemas";
 import { fingerprintCandidate, scorePuzzleQuality } from "./tool-impl";
 import { puzzleAgentTools } from "./tools";
 
@@ -44,23 +41,20 @@ function loadInstructions(): string {
 
   let skill = "";
   try {
-    skill = readFileSync(
-      join(process.cwd(), "agent/skills/generate-daily-puzzle.md"),
-      "utf8"
-    );
+    skill = readFileSync(join(process.cwd(), "agent/skills/generate-daily-puzzle.md"), "utf8");
   } catch {
     // optional
   }
 
   return [
     instructions,
-    skill
-      ? `\n\n## Skill: generate-daily-puzzle\n${skill}`
-      : "",
+    skill ? `\n\n## Skill: generate-daily-puzzle\n${skill}` : "",
     "",
     "## Hard publish rules (non-negotiable)",
     "- techniqueId is required — pick a real technique from the library; no emoji salad.",
+    "- Prefer compose_puzzle_visual so the board uses Ink Pictogram SVGs + text layers.",
     "- funScore must come from technique fit + clever wordplay, NOT emoji count padding.",
+    "- rebusPuzzle must equal visual.unicodeFallback when visual is present.",
     "- rebusPuzzle must be non-empty and must NOT equal or contain the answer.",
     "- Require overall quality ≥ threshold, funScore ≥ 65, unique, solvable, in-band difficulty.",
     "- If validation fails, redesign the visual — do not bump scores or ship placeholders.",
@@ -69,8 +63,7 @@ function loadInstructions(): string {
 
 function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string): string {
   const puzzleType = params.puzzleType ?? "rebus";
-  const qualityThreshold =
-    params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
+  const qualityThreshold = params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
   const minFun = AI_CONFIG.puzzleAgent.minFunScore;
 
   const level = getDifficultyLevelForScore(params.targetDifficulty);
@@ -89,10 +82,10 @@ function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string)
     "Workflow:",
     "1) get_puzzle_type_spec + get_difficulty_brief",
     "2) list_recent_answers + propose_concept_seeds",
-    "3) list_technique_library → pick techniqueId, then assemble_visual_components + craft_hint_ladder",
+    "3) list_technique_library → pick techniqueId, then compose_puzzle_visual + craft_hint_ladder",
     "4) validate → uniqueness → calibrate → stress_test_solvability → score_quality",
-    "5) Revise until in-band, unique, solvable, publishable",
-    "6) Return structured result with difficultyLevel + techniqueId",
+    "5) Revise until in-band, unique, solvable, publishable (prefer a composed visual with ≥1 pictogram SVG)",
+    "6) Return structured result with difficultyLevel + techniqueId + visual",
   ]
     .filter(Boolean)
     .join("\n");
@@ -103,11 +96,17 @@ function passesPublishGates(
     rebusPuzzle: string;
     answer: string;
     techniqueId?: string;
+    visual?: {
+      unicodeFallback?: string;
+      layers?: Array<{ kind: string; svg?: string }>;
+      mode?: string;
+    };
   },
   quality: { overall: number; funScore?: number; publishable?: boolean; issues?: string[] },
   qualityThreshold: number
 ): { ok: true } | { ok: false; reason: string } {
-  const display = (puzzle.rebusPuzzle || "").trim();
+  const visualFallback = puzzle.visual?.unicodeFallback?.trim();
+  const display = (visualFallback || puzzle.rebusPuzzle || "").trim();
   const answer = (puzzle.answer || "").trim();
   const minFun = AI_CONFIG.puzzleAgent.minFunScore;
 
@@ -121,6 +120,17 @@ function passesPublishGates(
   }
   if (!puzzle.techniqueId) {
     return { ok: false, reason: "Missing techniqueId" };
+  }
+  if (
+    puzzle.visual &&
+    visualFallback &&
+    puzzle.rebusPuzzle.trim() &&
+    puzzle.rebusPuzzle.trim() !== visualFallback
+  ) {
+    return {
+      ok: false,
+      reason: "rebusPuzzle must equal visual.unicodeFallback",
+    };
   }
   if (quality.overall < qualityThreshold) {
     return {
@@ -153,10 +163,8 @@ export async function runPuzzleAgentGeneration(
   await enforceQuota();
 
   const start = Date.now();
-  const maxAttempts =
-    params.maxAttempts ?? AI_CONFIG.puzzleAgent.maxAttempts ?? 3;
-  const qualityThreshold =
-    params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
+  const maxAttempts = params.maxAttempts ?? AI_CONFIG.puzzleAgent.maxAttempts ?? 3;
+  const qualityThreshold = params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
 
   // Primary Eve model, then creative-tier fallbacks
   const modelChain = Array.from(
@@ -189,11 +197,8 @@ export async function runPuzzleAgentGeneration(
         }
 
         const puzzle = output.puzzle;
-        const calibrated =
-          output.metadata.calibratedDifficulty || puzzle.difficulty;
-        const level = getDifficultyLevelForScore(
-          params.targetDifficulty || calibrated
-        );
+        const calibrated = output.metadata.calibratedDifficulty || puzzle.difficulty;
+        const level = getDifficultyLevelForScore(params.targetDifficulty || calibrated);
         const fingerprint =
           output.metadata.fingerprint ||
           fingerprintCandidate({
@@ -202,10 +207,16 @@ export async function runPuzzleAgentGeneration(
             category: puzzle.category,
           });
 
+        // Keep share string aligned with generative board
+        if (puzzle.visual?.unicodeFallback) {
+          puzzle.rebusPuzzle = puzzle.visual.unicodeFallback;
+        }
+
         const quality = scorePuzzleQuality({
           ...puzzle,
           targetDifficulty: params.targetDifficulty,
           techniqueId: puzzle.techniqueId,
+          visual: puzzle.visual,
         });
 
         const gate = passesPublishGates(
@@ -213,6 +224,7 @@ export async function runPuzzleAgentGeneration(
             rebusPuzzle: puzzle.rebusPuzzle,
             answer: puzzle.answer,
             techniqueId: puzzle.techniqueId,
+            visual: puzzle.visual,
           },
           {
             overall: quality.overall,
@@ -230,9 +242,7 @@ export async function runPuzzleAgentGeneration(
         }
 
         const difficultyLevel =
-          puzzle.difficultyLevel ||
-          output.metadata.difficultyLevel ||
-          level.label;
+          puzzle.difficultyLevel || output.metadata.difficultyLevel || level.label;
 
         return {
           ...output,
@@ -250,6 +260,7 @@ export async function runPuzzleAgentGeneration(
             qualityScore: quality.overall,
             qualityVerdict: quality.verdict,
             funScore: quality.funScore ?? output.metadata.funScore,
+            visualStyleId: puzzle.visual?.styleId ?? output.metadata.visualStyleId,
             generationAttempts: attempt,
             thinkingSummary:
               output.metadata.thinkingSummary ??

--- a/apps/web/src/ai/puzzle-agent/schemas.ts
+++ b/apps/web/src/ai/puzzle-agent/schemas.ts
@@ -1,16 +1,14 @@
 import { z } from "zod";
+import { PuzzleVisualSchema } from "./visual/composition";
 
-export const DifficultyTierLabelSchema = z.enum([
-  "Hard",
-  "Difficult",
-  "Evil",
-  "Impossible",
-]);
+export const DifficultyTierLabelSchema = z.enum(["Hard", "Difficult", "Evil", "Impossible"]);
 
 /** Final puzzle shape returned by the Eve / ToolLoop puzzle agent. */
 export const PuzzleAgentResultSchema = z.object({
   puzzle: z.object({
-    rebusPuzzle: z.string().describe("Visual / prompt content shown to the player"),
+    rebusPuzzle: z
+      .string()
+      .describe("Unicode/share fallback — must match visual.unicodeFallback when visual is set"),
     answer: z.string().min(1),
     difficulty: z.number().min(1).max(10),
     difficultyLevel: DifficultyTierLabelSchema.describe("Canonical tier label"),
@@ -18,6 +16,8 @@ export const PuzzleAgentResultSchema = z.object({
     category: z.string().min(1),
     hints: z.array(z.string()).min(3).max(6),
     techniqueId: z.string().optional(),
+    /** Generative board (custom pictograms, text layers, optional images) */
+    visual: PuzzleVisualSchema.optional(),
   }),
   metadata: z.object({
     fingerprint: z.string(),
@@ -29,6 +29,7 @@ export const PuzzleAgentResultSchema = z.object({
     funScore: z.number().optional(),
     generationAttempts: z.number().optional(),
     thinkingSummary: z.string().optional(),
+    visualStyleId: z.string().optional(),
   }),
   status: z.enum(["success", "retry", "failed"]),
   recommendations: z.array(z.string()).default([]),

--- a/apps/web/src/ai/puzzle-agent/tool-impl.ts
+++ b/apps/web/src/ai/puzzle-agent/tool-impl.ts
@@ -15,10 +15,10 @@ import {
 } from "../services/uniqueness-tracker";
 import {
   DIFFICULTY_LEVELS,
+  type DifficultyTier,
   getDifficultyLevelByTier,
   getDifficultyLevelForScore,
   isDifficultyInBand,
-  type DifficultyTier,
   snapToDifficultyBand,
 } from "./difficulty-levels";
 import type { CandidatePuzzle } from "./schemas";
@@ -118,9 +118,7 @@ export async function listRecentAnswers(input: { lookbackDays?: number; limit?: 
       category: String(p.category ?? ""),
       difficulty: typeof p.difficulty === "number" ? p.difficulty : null,
       tier:
-        typeof p.difficulty === "number"
-          ? getDifficultyLevelForScore(p.difficulty).label
-          : null,
+        typeof p.difficulty === "number" ? getDifficultyLevelForScore(p.difficulty).label : null,
       preview: String(
         (p as { rebusPuzzle?: string; puzzle?: string }).rebusPuzzle ?? p.puzzle ?? ""
       ).slice(0, 80),
@@ -162,8 +160,9 @@ export function proposeConceptSeeds(input: {
       workingTitle: "Space means meaning",
       answerDirection: "Positional/prepositional phrase",
       category: "positional",
-      techniqueId: techniques.find((t) => t.id.includes("positional") || t.id.includes("spatial"))
-        ?.id ?? "basic_positional",
+      techniqueId:
+        techniques.find((t) => t.id.includes("positional") || t.id.includes("spatial"))?.id ??
+        "basic_positional",
       whyItFitsTier: level.blurb,
     },
   ].filter((s) => !avoid.has(s.workingTitle.toLowerCase()));
@@ -209,7 +208,7 @@ export function assembleVisualComponents(input: {
     issues.push("Answer text appears in the visual — hide it");
   }
 
-  if (emojiCount === 0 && !/[↑↓←→\/+\-×÷]/.test(input.rebusPuzzle)) {
+  if (emojiCount === 0 && !/[↑↓←→/+\-×÷]/.test(input.rebusPuzzle)) {
     tips.push("Add emoji or spatial/math symbols so it feels like a rebus");
   }
 
@@ -385,7 +384,7 @@ export async function calibratePuzzleDifficulty(
 
   let calibratedDifficulty: number;
   let method: "type_config" | "ai" = "type_config";
-  let profile: unknown = undefined;
+  let profile: unknown;
 
   if (config.difficulty?.calculate) {
     calibratedDifficulty = config.difficulty.calculate(input as never);
@@ -423,14 +422,22 @@ export async function calibratePuzzleDifficulty(
 
 /** Fast heuristic quality score (no extra model call). */
 export function scorePuzzleQuality(
-  input: CandidatePuzzle & { targetDifficulty?: number; techniqueId?: string }
+  input: CandidatePuzzle & {
+    targetDifficulty?: number;
+    techniqueId?: string;
+    visual?: {
+      mode?: string;
+      layers?: Array<{ kind: string; svg?: string; src?: string }>;
+      unicodeFallback?: string;
+    };
+  }
 ) {
   const issues: string[] = [];
   const strengths: string[] = [];
   const target = input.targetDifficulty ?? input.difficulty;
   const level = getDifficultyLevelForScore(target);
 
-  const puzzle = input.rebusPuzzle.trim();
+  const puzzle = (input.visual?.unicodeFallback || input.rebusPuzzle).trim();
   const answer = input.answer.trim();
 
   if (!puzzle) issues.push("Empty puzzle display");
@@ -469,7 +476,26 @@ export function scorePuzzleQuality(
     strengths.push(`Component budget fits ${level.label}`);
   }
 
-  if (assembly.funScore >= 70) strengths.push("High fun / visual energy");
+  const pictogramCount =
+    input.visual?.layers?.filter((l) => l.kind === "pictogram" && l.svg).length ?? 0;
+  const textLayerCount = input.visual?.layers?.filter((l) => l.kind === "text").length ?? 0;
+  const composedVisual = Boolean(input.visual && (pictogramCount > 0 || textLayerCount > 0));
+  if (composedVisual) {
+    strengths.push(
+      pictogramCount > 0
+        ? `Generative Ink Pictograms (${pictogramCount})`
+        : "Styled generative text layers"
+    );
+  }
+
+  const funScore = Math.max(
+    assembly.funScore,
+    composedVisual
+      ? Math.min(100, assembly.funScore + 8 + Math.min(16, pictogramCount * 6))
+      : assembly.funScore
+  );
+
+  if (funScore >= 70) strengths.push("High fun / visual energy");
 
   const hasEmoji = /[\p{Emoji}]/u.test(puzzle);
   if (hasEmoji) strengths.push("Uses visual emoji elements");
@@ -477,9 +503,10 @@ export function scorePuzzleQuality(
   let score = 72;
   score -= issues.length * 11;
   score += Math.min(12, strengths.length * 3);
-  score += Math.round((assembly.funScore - 50) / 10);
-  // Small visual bonus only — technique already weighted in funScore
-  if (hasEmoji && input.techniqueId) score += 2;
+  score += Math.round((funScore - 50) / 10);
+  // Prefer generative boards over emoji salad
+  if (composedVisual && input.techniqueId) score += 6;
+  else if (hasEmoji && input.techniqueId) score += 2;
   score = Math.max(0, Math.min(100, score));
 
   const verdict =
@@ -498,7 +525,7 @@ export function scorePuzzleQuality(
     verdict,
     strengths,
     issues,
-    funScore: assembly.funScore,
+    funScore,
     tier: level.label,
     publishable: score >= 70 && issues.length === 0 && Boolean(input.techniqueId),
   };
@@ -545,5 +572,9 @@ export function fingerprintCandidate(
 export function stableId(...parts: string[]) {
   return createHash("sha256").update(parts.join("::")).digest("hex").slice(0, 16);
 }
+
+export { composePuzzleVisual } from "./visual/compose-visual";
+export { generateImageTile } from "./visual/generate-image-tile";
+export { generatePictogram } from "./visual/generate-pictogram";
 
 export type { TechniqueId };

--- a/apps/web/src/ai/puzzle-agent/tools.ts
+++ b/apps/web/src/ai/puzzle-agent/tools.ts
@@ -2,14 +2,16 @@
  * AI SDK tools for the in-process puzzle ToolLoopAgent.
  */
 
-import { tool, type ToolSet } from "ai";
+import { type ToolSet, tool } from "ai";
 import { z } from "zod";
 import { CandidatePuzzleSchema } from "./schemas";
 import {
   assembleVisualComponents,
   calibratePuzzleDifficulty,
   checkUniqueness,
+  composePuzzleVisual,
   craftHintLadder,
+  generatePictogram,
   getDifficultyBrief,
   getPuzzleTypeSpec,
   listRecentAnswers,
@@ -19,6 +21,7 @@ import {
   stressTestSolvability,
   validatePuzzleCandidate,
 } from "./tool-impl";
+import { VisualLayerSchema } from "./visual/composition";
 
 const withType = CandidatePuzzleSchema.extend({
   puzzleType: z.string().optional(),
@@ -28,8 +31,7 @@ const withType = CandidatePuzzleSchema.extend({
 
 export const puzzleAgentTools: ToolSet = {
   get_puzzle_type_spec: tool({
-    description:
-      "Load generation rules and the target difficulty tier for a puzzle type.",
+    description: "Load generation rules and the target difficulty tier for a puzzle type.",
     inputSchema: z.object({
       puzzleType: z.string(),
       targetDifficulty: z.number().optional(),
@@ -79,7 +81,7 @@ export const puzzleAgentTools: ToolSet = {
 
   assemble_visual_components: tool({
     description:
-      "Analyze a candidate visual: component count vs tier budget, technique tips, fun score.",
+      "Legacy analyzer for a unicode rebus string. Prefer compose_puzzle_visual for generative boards.",
     inputSchema: z.object({
       answer: z.string(),
       rebusPuzzle: z.string(),
@@ -87,6 +89,33 @@ export const puzzleAgentTools: ToolSet = {
       targetDifficulty: z.number(),
     }),
     execute: async (input) => assembleVisualComponents(input),
+  }),
+
+  generate_pictogram: tool({
+    description:
+      "Generate one Rebuzzle Ink Pictogram v1 SVG (custom emoji) for a concept. Consistent brand style.",
+    inputSchema: z.object({
+      concept: z.string(),
+      role: z.string().optional(),
+      emojiFallback: z.string().optional(),
+    }),
+    execute: async (input) => generatePictogram(input),
+  }),
+
+  compose_puzzle_visual: tool({
+    description:
+      "Build a generative puzzle board from layers (pictogram / text / operator / optional image). Generates custom SVGs, scores budget + fun. Set rebusPuzzle = unicodeFallback in the final result.",
+    inputSchema: z.object({
+      answer: z.string(),
+      targetDifficulty: z.number(),
+      techniqueId: z.string().optional(),
+      layout: z.enum(["row", "stack", "grid", "overlay"]).optional(),
+      layers: z.array(VisualLayerSchema).min(1).max(12),
+      unicodeFallback: z.string().optional(),
+      caption: z.string().optional(),
+      renderImages: z.boolean().optional(),
+    }),
+    execute: async (input) => composePuzzleVisual(input),
   }),
 
   craft_hint_ladder: tool({
@@ -103,8 +132,7 @@ export const puzzleAgentTools: ToolSet = {
   }),
 
   stress_test_solvability: tool({
-    description:
-      "Fairness check: would a clever player solve this with the hint ladder?",
+    description: "Fairness check: would a clever player solve this with the hint ladder?",
     inputSchema: withType,
     execute: async (input) => stressTestSolvability(input),
   }),
@@ -129,8 +157,7 @@ export const puzzleAgentTools: ToolSet = {
   }),
 
   score_quality: tool({
-    description:
-      "Score quality + fun. Aim for overall ≥ 70, publishable, correct tier fit.",
+    description: "Score quality + fun. Aim for overall ≥ 70, publishable, correct tier fit.",
     inputSchema: withType,
     execute: async (input) => scorePuzzleQuality(input),
   }),

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/composition.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/composition.test.ts
@@ -1,0 +1,64 @@
+import { buildUnicodeFallback, countVisualParts, PuzzleVisualSchema } from "../composition";
+import { sanitizePictogramSvg } from "../sanitize-svg";
+
+describe("puzzle visual composition", () => {
+  it("counts non-operator layers as parts", () => {
+    const visual = PuzzleVisualSchema.parse({
+      styleId: "ink-pictogram-v1",
+      mode: "composed",
+      layout: "row",
+      unicodeFallback: "🐝 + FORE",
+      layers: [
+        { kind: "pictogram", concept: "bee", emojiFallback: "🐝" },
+        { kind: "operator", symbol: "+" },
+        { kind: "text", content: "FORE", emphasis: "normal" },
+      ],
+    });
+    expect(countVisualParts(visual)).toBe(2);
+  });
+
+  it("builds unicode fallback from mixed layers", () => {
+    const fallback = buildUnicodeFallback([
+      { kind: "pictogram", concept: "sun", emojiFallback: "☀️" },
+      { kind: "operator", symbol: "+" },
+      { kind: "text", content: "FLOWER", emphasis: "large" },
+      { kind: "image", prompt: "a daisy field", alt: "flowers" },
+    ]);
+    expect(fallback).toContain("☀️");
+    expect(fallback).toContain("FLOWER");
+    expect(fallback).toContain("+");
+  });
+
+  it("stacks text characters in fallback", () => {
+    const fallback = buildUnicodeFallback([{ kind: "text", content: "HI", emphasis: "stacked" }]);
+    expect(fallback).toBe("H\nI");
+  });
+});
+
+describe("sanitizePictogramSvg", () => {
+  it("accepts a clean ink pictogram", () => {
+    const raw = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="20" fill="none" stroke="#1a1f1c" stroke-width="2.25"/></svg>`;
+    const out = sanitizePictogramSvg(raw);
+    expect(out).toContain("<svg");
+    expect(out).toContain('viewBox="0 0 64 64"');
+  });
+
+  it("strips scripts and event handlers", () => {
+    const raw = `<svg viewBox="0 0 64 64" onclick="alert(1)"><script>alert(1)</script><circle cx="10" cy="10" r="5"/></svg>`;
+    const out = sanitizePictogramSvg(raw);
+    expect(out).not.toBeNull();
+    expect(out).not.toMatch(/script/i);
+    expect(out).not.toMatch(/onclick/i);
+  });
+
+  it("rejects non-svg payloads", () => {
+    expect(sanitizePictogramSvg("just text")).toBeNull();
+    expect(sanitizePictogramSvg("<div>nope</div>")).toBeNull();
+  });
+
+  it("unwraps fenced markdown svg", () => {
+    const raw = '```svg\n<svg viewBox="0 0 64 64"><rect width="10" height="10"/></svg>\n```';
+    const out = sanitizePictogramSvg(raw);
+    expect(out).toContain("<rect");
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/visual/compose-visual.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/compose-visual.ts
@@ -1,0 +1,229 @@
+/**
+ * Compose a full generative puzzle visual from Eve's layer plan.
+ * Fills pictogram SVGs (+ optional image tiles) and validates budget/style.
+ */
+
+import { getDifficultyLevelForScore } from "../difficulty-levels";
+import { getTechniques } from "../technique-library";
+import {
+  buildUnicodeFallback,
+  countVisualParts,
+  type PuzzleVisual,
+  PuzzleVisualSchema,
+  type VisualLayer,
+} from "./composition";
+import { generateImageTile } from "./generate-image-tile";
+import { generatePictogram } from "./generate-pictogram";
+import { INK_PICTOGRAM_STYLE_ID } from "./style";
+
+export type ComposePuzzleVisualInput = {
+  answer: string;
+  targetDifficulty: number;
+  techniqueId?: string;
+  layout?: PuzzleVisual["layout"];
+  layers: VisualLayer[];
+  unicodeFallback?: string;
+  caption?: string;
+  /** When true, generate AI image tiles for image layers */
+  renderImages?: boolean;
+};
+
+export type ComposePuzzleVisualResult = {
+  visual: PuzzleVisual;
+  totalParts: number;
+  withinBudget: boolean;
+  componentBudget: { min: number; max: number };
+  funScore: number;
+  issues: string[];
+  tips: string[];
+  generated: {
+    pictograms: number;
+    images: number;
+    failedPictograms: number;
+    failedImages: number;
+  };
+};
+
+export async function composePuzzleVisual(
+  input: ComposePuzzleVisualInput
+): Promise<ComposePuzzleVisualResult> {
+  const level = getDifficultyLevelForScore(input.targetDifficulty);
+  const issues: string[] = [];
+  const tips: string[] = [];
+  const generated = {
+    pictograms: 0,
+    images: 0,
+    failedPictograms: 0,
+    failedImages: 0,
+  };
+
+  const filledLayers: VisualLayer[] = [];
+
+  for (const layer of input.layers) {
+    if (layer.kind === "pictogram") {
+      if (layer.svg && layer.svg.includes("<svg")) {
+        filledLayers.push(layer);
+        generated.pictograms += 1;
+        continue;
+      }
+      const pic = await generatePictogram({
+        concept: layer.concept,
+        role: layer.role,
+        emojiFallback: layer.emojiFallback,
+      });
+      if (pic.ok && pic.svg) {
+        filledLayers.push({
+          ...layer,
+          svg: pic.svg,
+          emojiFallback: pic.emojiFallback,
+        });
+        generated.pictograms += 1;
+      } else {
+        generated.failedPictograms += 1;
+        filledLayers.push({
+          ...layer,
+          emojiFallback: pic.emojiFallback || layer.emojiFallback,
+        });
+        tips.push(`Pictogram fallback used for "${layer.concept}" — unicode emoji only`);
+      }
+      continue;
+    }
+
+    if (layer.kind === "image") {
+      if (layer.src) {
+        filledLayers.push(layer);
+        generated.images += 1;
+        continue;
+      }
+      if (input.renderImages !== false) {
+        const tile = await generateImageTile({
+          prompt: layer.prompt,
+          alt: layer.alt,
+        });
+        if (tile.ok && tile.src) {
+          filledLayers.push({ ...layer, src: tile.src });
+          generated.images += 1;
+        } else {
+          generated.failedImages += 1;
+          tips.push(`Image tile skipped (${tile.error ?? "failed"}) — board still playable`);
+          // Drop failed image layers rather than showing broken media
+        }
+      } else {
+        tips.push("Image layer planned but renderImages=false");
+      }
+      continue;
+    }
+
+    filledLayers.push(layer);
+  }
+
+  if (filledLayers.length === 0) {
+    issues.push("No renderable layers after generation");
+  }
+
+  const unicodeFallback =
+    input.unicodeFallback?.trim() || buildUnicodeFallback(filledLayers) || "◆";
+
+  const parsed = PuzzleVisualSchema.safeParse({
+    styleId: INK_PICTOGRAM_STYLE_ID,
+    mode: filledLayers.some((l) => l.kind === "image" && l.src)
+      ? "hybrid"
+      : filledLayers.some((l) => l.kind === "pictogram" && l.svg)
+        ? "composed"
+        : "unicode",
+    layout: input.layout ?? "row",
+    layers: filledLayers,
+    unicodeFallback,
+    caption: input.caption,
+  });
+
+  const visual: PuzzleVisual = parsed.success
+    ? parsed.data
+    : {
+        styleId: INK_PICTOGRAM_STYLE_ID,
+        mode: "unicode",
+        layout: "row",
+        layers: filledLayers.length
+          ? filledLayers
+          : [
+              {
+                kind: "text",
+                content: unicodeFallback,
+                emphasis: "normal",
+              },
+            ],
+        unicodeFallback,
+      };
+
+  if (!parsed.success) {
+    issues.push(`Visual schema issues: ${parsed.error.issues[0]?.message ?? "invalid"}`);
+  }
+
+  const totalParts = countVisualParts(visual);
+  const withinBudget =
+    totalParts >= level.componentBudget.min && totalParts <= level.componentBudget.max;
+
+  if (totalParts < level.componentBudget.min) {
+    issues.push(
+      `Too sparse for ${level.label}: have ${totalParts} parts, want ≥ ${level.componentBudget.min}`
+    );
+  }
+  if (totalParts > level.componentBudget.max) {
+    issues.push(
+      `Too dense for ${level.label}: have ${totalParts} parts, want ≤ ${level.componentBudget.max}`
+    );
+  }
+
+  const answerLower = input.answer.toLowerCase().trim();
+  if (answerLower.length > 3 && unicodeFallback.toLowerCase().includes(answerLower)) {
+    issues.push("Answer text appears in the visual fallback — hide it");
+  }
+  for (const layer of visual.layers) {
+    if (
+      layer.kind === "text" &&
+      layer.content.toLowerCase().includes(answerLower) &&
+      answerLower.length > 3
+    ) {
+      issues.push("Answer text appears in a text layer — hide it");
+    }
+  }
+
+  let techniqueBonus = -10;
+  if (input.techniqueId) {
+    const technique = getTechniques([input.techniqueId])[0];
+    if (technique) {
+      techniqueBonus = 20;
+      tips.push(...technique.howToAssemble.slice(0, 2));
+    } else {
+      issues.push(`Unknown techniqueId: ${input.techniqueId}`);
+    }
+  }
+
+  const pictogramBonus = Math.min(24, generated.pictograms * 8);
+  const textLayers = visual.layers.filter((l) => l.kind === "text").length;
+  const textBonus = Math.min(12, textLayers * 4);
+  const imageBonus = Math.min(10, generated.images * 5);
+
+  const funScore = Math.max(
+    0,
+    Math.min(
+      100,
+      48 + pictogramBonus + textBonus + imageBonus + techniqueBonus - issues.length * 12
+    )
+  );
+
+  if (generated.pictograms === 0 && textLayers === 0) {
+    tips.push("Prefer at least one custom pictogram or styled text layer for a generative board");
+  }
+
+  return {
+    visual,
+    totalParts,
+    withinBudget,
+    componentBudget: level.componentBudget,
+    funScore,
+    issues,
+    tips,
+    generated,
+  };
+}

--- a/apps/web/src/ai/puzzle-agent/visual/composition.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/composition.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { INK_PICTOGRAM_STYLE_ID } from "./style";
+
+/** A custom pictogram ("our emoji") — SVG preferred, unicode fallback required. */
+export const PictogramLayerSchema = z.object({
+  kind: z.literal("pictogram"),
+  /** Concept key used for generation / caching */
+  concept: z.string().min(1).max(48),
+  /** Role in the rebus, e.g. "homophone-bee" */
+  role: z.string().optional(),
+  /** Generated SVG markup (Ink Pictogram v1) */
+  svg: z.string().optional(),
+  /** Unicode emoji fallback for share text / older clients */
+  emojiFallback: z.string().min(1).max(8),
+});
+
+/** Styled text used as a visual device (size, case, strike, stack). */
+export const TextLayerSchema = z.object({
+  kind: z.literal("text"),
+  content: z.string().min(1).max(40),
+  emphasis: z.enum(["normal", "large", "small", "strike", "stacked", "tiny"]).default("normal"),
+});
+
+/** Math / spatial operator between pieces. */
+export const OperatorLayerSchema = z.object({
+  kind: z.literal("operator"),
+  symbol: z.string().min(1).max(4),
+});
+
+/** Optional AI-illustrated tile for techniques that need a scene. */
+export const ImageLayerSchema = z.object({
+  kind: z.literal("image"),
+  /** Generation prompt (style guide is appended server-side) */
+  prompt: z.string().min(8).max(400),
+  alt: z.string().min(1).max(120),
+  /** data:image/...;base64,... or https URL after persist */
+  src: z.string().optional(),
+});
+
+export const VisualLayerSchema = z.discriminatedUnion("kind", [
+  PictogramLayerSchema,
+  TextLayerSchema,
+  OperatorLayerSchema,
+  ImageLayerSchema,
+]);
+
+export const PuzzleVisualSchema = z.object({
+  styleId: z.literal(INK_PICTOGRAM_STYLE_ID).default(INK_PICTOGRAM_STYLE_ID),
+  mode: z.enum(["composed", "unicode", "hybrid"]).default("composed"),
+  layout: z.enum(["row", "stack", "grid", "overlay"]).default("row"),
+  layers: z.array(VisualLayerSchema).min(1).max(12),
+  /** Plain-text / emoji share string — always required */
+  unicodeFallback: z.string().min(1).max(200),
+  /** Optional caption under the board (never the answer) */
+  caption: z.string().max(80).optional(),
+});
+
+export type PictogramLayer = z.infer<typeof PictogramLayerSchema>;
+export type TextLayer = z.infer<typeof TextLayerSchema>;
+export type OperatorLayer = z.infer<typeof OperatorLayerSchema>;
+export type ImageLayer = z.infer<typeof ImageLayerSchema>;
+export type VisualLayer = z.infer<typeof VisualLayerSchema>;
+export type PuzzleVisual = z.infer<typeof PuzzleVisualSchema>;
+
+/** Count "parts" for difficulty budgets (pictogram/text/image = 1, operators free). */
+export function countVisualParts(visual: PuzzleVisual): number {
+  return visual.layers.filter((l) => l.kind !== "operator").length;
+}
+
+/** Build a unicode/share string from layers when agent omits one. */
+export function buildUnicodeFallback(layers: VisualLayer[]): string {
+  const chunks: string[] = [];
+  for (const layer of layers) {
+    if (layer.kind === "pictogram") chunks.push(layer.emojiFallback);
+    else if (layer.kind === "text") {
+      if (layer.emphasis === "stacked") chunks.push(layer.content.split("").join("\n"));
+      else chunks.push(layer.content);
+    } else if (layer.kind === "operator") chunks.push(layer.symbol);
+    else if (layer.kind === "image") chunks.push("🖼️");
+  }
+  // Collapse horizontal runs of spaces, but keep intentional stacked newlines
+  return chunks
+    .join(" ")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ ?\n ?/g, "\n")
+    .trim();
+}

--- a/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
@@ -1,0 +1,80 @@
+/**
+ * Optional AI image tile for hybrid rebus boards.
+ * Uses Vercel AI Gateway image models with a locked Rebuzzle illustration style.
+ */
+
+import { gateway } from "@ai-sdk/gateway";
+import { generateImage } from "ai";
+import { ensureGatewayKey } from "@/ai/client";
+import { IMAGE_TILE_STYLE_GUIDE } from "./style";
+
+export type GenerateImageTileInput = {
+  prompt: string;
+  alt: string;
+};
+
+export type GenerateImageTileResult = {
+  ok: boolean;
+  src?: string;
+  alt: string;
+  model?: string;
+  error?: string;
+};
+
+const IMAGE_MODEL_CHAIN = [
+  process.env.REBUZZLE_IMAGE_MODEL,
+  "google/imagen-4.0-fast-generate-001",
+  "openai/gpt-image-1",
+  "black-forest-labs/flux-1.1-pro",
+].filter((m): m is string => Boolean(m));
+
+export async function generateImageTile(
+  input: GenerateImageTileInput
+): Promise<GenerateImageTileResult> {
+  const alt = input.alt.trim().slice(0, 120) || "Puzzle illustration";
+  const prompt = [
+    IMAGE_TILE_STYLE_GUIDE,
+    "",
+    input.prompt.trim().slice(0, 400),
+    "",
+    "Square tile, single subject, no text in the image.",
+  ].join("\n");
+
+  ensureGatewayKey();
+
+  let lastError = "no_model";
+  for (const modelId of IMAGE_MODEL_CHAIN) {
+    try {
+      const result = await generateImage({
+        model: gateway.image(modelId),
+        prompt,
+        aspectRatio: "1:1",
+      });
+
+      const file = result.image;
+      if (!file) {
+        lastError = "empty_image";
+        continue;
+      }
+
+      const mediaType = file.mediaType || "image/png";
+      const base64 = file.base64;
+      if (!base64 || base64.length > 400_000) {
+        // Keep Mongo documents sane — skip oversized tiles
+        lastError = "image_too_large";
+        continue;
+      }
+
+      return {
+        ok: true,
+        src: `data:${mediaType};base64,${base64}`,
+        alt,
+        model: modelId,
+      };
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : "generate_failed";
+    }
+  }
+
+  return { ok: false, alt, error: lastError };
+}

--- a/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
@@ -1,0 +1,137 @@
+/**
+ * Generate a single Ink Pictogram v1 SVG ("our emoji") for a concept.
+ */
+
+import { generateAIText } from "@/ai/client";
+import { sanitizePictogramSvg } from "./sanitize-svg";
+import { INK_PICTOGRAM_PALETTE, INK_PICTOGRAM_STYLE_GUIDE, INK_PICTOGRAM_STYLE_ID } from "./style";
+
+export type GeneratePictogramInput = {
+  concept: string;
+  role?: string;
+  emojiFallback?: string;
+};
+
+export type GeneratePictogramResult = {
+  styleId: typeof INK_PICTOGRAM_STYLE_ID;
+  concept: string;
+  role?: string;
+  svg: string | null;
+  emojiFallback: string;
+  ok: boolean;
+  error?: string;
+};
+
+function guessEmojiFallback(concept: string): string {
+  const c = concept.toLowerCase();
+  const map: Record<string, string> = {
+    bee: "🐝",
+    eye: "👁️",
+    clock: "🕐",
+    sun: "☀️",
+    moon: "🌙",
+    star: "⭐",
+    heart: "❤️",
+    fire: "🔥",
+    water: "💧",
+    tree: "🌳",
+    fish: "🐟",
+    bird: "🐦",
+    dog: "🐕",
+    cat: "🐱",
+    book: "📖",
+    key: "🔑",
+    lock: "🔒",
+    house: "🏠",
+    car: "🚗",
+    boat: "⛵",
+    train: "🚂",
+    apple: "🍎",
+    cake: "🎂",
+    music: "🎵",
+    phone: "📱",
+    brain: "🧠",
+    skull: "💀",
+    ghost: "👻",
+    rocket: "🚀",
+    crown: "👑",
+    money: "💰",
+    light: "💡",
+    puzzle: "🧩",
+  };
+  for (const [k, v] of Object.entries(map)) {
+    if (c.includes(k)) return v;
+  }
+  return "◆";
+}
+
+export async function generatePictogram(
+  input: GeneratePictogramInput
+): Promise<GeneratePictogramResult> {
+  const concept = input.concept.trim().slice(0, 48);
+  const emojiFallback = input.emojiFallback?.trim() || guessEmojiFallback(concept);
+
+  if (!concept) {
+    return {
+      styleId: INK_PICTOGRAM_STYLE_ID,
+      concept,
+      role: input.role,
+      svg: null,
+      emojiFallback,
+      ok: false,
+      error: "concept_required",
+    };
+  }
+
+  try {
+    const response = await generateAIText({
+      modelType: "creative",
+      temperature: 0.4,
+      system: [
+        INK_PICTOGRAM_STYLE_GUIDE,
+        "",
+        "Return ONLY a single <svg>...</svg> element. No markdown, no commentary.",
+        `Palette: ink=${INK_PICTOGRAM_PALETTE.ink}, canvas=${INK_PICTOGRAM_PALETTE.canvas}, accent=${INK_PICTOGRAM_PALETTE.accent}, mist=${INK_PICTOGRAM_PALETTE.mist}.`,
+      ].join("\n"),
+      prompt: [
+        `Draw an Ink Pictogram for: "${concept}"`,
+        input.role ? `Role in rebus: ${input.role}` : "",
+        "Keep it iconic and instantly readable.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    });
+
+    const svg = sanitizePictogramSvg(response.text);
+    if (!svg) {
+      return {
+        styleId: INK_PICTOGRAM_STYLE_ID,
+        concept,
+        role: input.role,
+        svg: null,
+        emojiFallback,
+        ok: false,
+        error: "invalid_svg",
+      };
+    }
+
+    return {
+      styleId: INK_PICTOGRAM_STYLE_ID,
+      concept,
+      role: input.role,
+      svg,
+      emojiFallback,
+      ok: true,
+    };
+  } catch (error) {
+    return {
+      styleId: INK_PICTOGRAM_STYLE_ID,
+      concept,
+      role: input.role,
+      svg: null,
+      emojiFallback,
+      ok: false,
+      error: error instanceof Error ? error.message : "generate_failed",
+    };
+  }
+}

--- a/apps/web/src/ai/puzzle-agent/visual/index.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/index.ts
@@ -1,0 +1,33 @@
+export {
+  type ComposePuzzleVisualInput,
+  type ComposePuzzleVisualResult,
+  composePuzzleVisual,
+} from "./compose-visual";
+export {
+  buildUnicodeFallback,
+  countVisualParts,
+  type ImageLayer,
+  type OperatorLayer,
+  type PictogramLayer,
+  type PuzzleVisual,
+  PuzzleVisualSchema,
+  type TextLayer,
+  type VisualLayer,
+  VisualLayerSchema,
+} from "./composition";
+export {
+  type GenerateImageTileInput,
+  type GenerateImageTileResult,
+  generateImageTile,
+} from "./generate-image-tile";
+export {
+  type GeneratePictogramInput,
+  type GeneratePictogramResult,
+  generatePictogram,
+} from "./generate-pictogram";
+export {
+  IMAGE_TILE_STYLE_GUIDE,
+  INK_PICTOGRAM_PALETTE,
+  INK_PICTOGRAM_STYLE_GUIDE,
+  INK_PICTOGRAM_STYLE_ID,
+} from "./style";

--- a/apps/web/src/ai/puzzle-agent/visual/sanitize-svg.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/sanitize-svg.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal SVG sanitizer for LLM-generated pictograms.
+ * Strips scripts, event handlers, and external references.
+ */
+
+export function sanitizePictogramSvg(raw: string): string | null {
+  if (!raw || typeof raw !== "string") return null;
+
+  let svg = raw.trim();
+  const fenced = svg.match(/```(?:svg)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) svg = fenced[1].trim();
+
+  const start = svg.indexOf("<svg");
+  const end = svg.lastIndexOf("</svg>");
+  if (start === -1 || end === -1) return null;
+  svg = svg.slice(start, end + "</svg>".length);
+
+  // Nuke dangerous constructs
+  const banned = [
+    /<script[\s\S]*?>[\s\S]*?<\/script>/gi,
+    /<foreignObject[\s\S]*?>[\s\S]*?<\/foreignObject>/gi,
+    /\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi,
+    /javascript:/gi,
+    /data:/gi,
+    /xlink:href\s*=\s*("|')\s*https?:/gi,
+    /href\s*=\s*("|')\s*https?:/gi,
+  ];
+  for (const re of banned) {
+    svg = svg.replace(re, "");
+  }
+
+  if (!svg.includes("viewBox")) {
+    svg = svg.replace("<svg", '<svg viewBox="0 0 64 64"');
+  }
+  if (!/\bxmlns=/.test(svg)) {
+    svg = svg.replace("<svg", '<svg xmlns="http://www.w3.org/2000/svg"');
+  }
+
+  // Size hints for inline display
+  if (!/\bwidth=/.test(svg)) {
+    svg = svg.replace("<svg", '<svg width="64" height="64"');
+  }
+
+  if (svg.length > 12_000) return null;
+  return svg;
+}

--- a/apps/web/src/ai/puzzle-agent/visual/style.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/style.ts
@@ -1,0 +1,53 @@
+/**
+ * Rebuzzle Ink Pictogram v1 — locked visual language for generative puzzle art.
+ *
+ * Every custom emoji / pictogram must follow this style so the daily board
+ * feels like one designed product, not a random emoji salad.
+ */
+
+export const INK_PICTOGRAM_STYLE_ID = "ink-pictogram-v1" as const;
+
+export const INK_PICTOGRAM_PALETTE = {
+  /** Primary ink — matches app foreground */
+  ink: "#1a1f1c",
+  /** Soft canvas fill */
+  canvas: "#f4f6f3",
+  /** Muted secondary stroke */
+  mist: "#6b756f",
+  /** Accent (sparingly — never purple) */
+  accent: "#2f6f5e",
+  /** Danger / strike emphasis */
+  strike: "#b23a2d",
+} as const;
+
+/** System prompt fragment injected into pictogram + image generators. */
+export const INK_PICTOGRAM_STYLE_GUIDE = `
+You are designing Rebuzzle Ink Pictogram v1 tiles.
+
+LOCKED STYLE (non-negotiable):
+- Flat, crisp, editorial pictograms — like a modern rebus board, not clipart
+- ViewBox 0 0 64 64, single SVG root, no external fonts or images
+- Stroke-first: 2.25px rounded strokes in ${INK_PICTOGRAM_PALETTE.ink}
+- Optional soft fill ${INK_PICTOGRAM_PALETTE.canvas}; accent ${INK_PICTOGRAM_PALETTE.accent} only for one focal detail
+- No gradients, no drop shadows, no 3D, no photorealism, no purple, no glow
+- Centered subject, generous padding (~6px), readable at 48–96px
+- Family-friendly; no text letters inside the SVG unless the concept IS a letter
+- Prefer simple silhouettes that read instantly in a rebus
+`.trim();
+
+export const IMAGE_TILE_STYLE_GUIDE = `
+Rebuzzle hybrid image tile style:
+- Soft ink illustration on paper-like canvas, muted teal accent only
+- Single clear subject, no collage, no watermark, no text overlays
+- Square composition, centered, high contrast silhouettes
+- Matches flat pictogram language — not photoreal stock photography
+`.trim();
+
+export type PictogramConcept = {
+  /** Stable id, e.g. "bee", "clock-broken" */
+  id: string;
+  /** What to draw */
+  concept: string;
+  /** Optional mood / role in the rebus */
+  role?: string;
+};

--- a/apps/web/src/ai/services/master-puzzle-orchestrator.ts
+++ b/apps/web/src/ai/services/master-puzzle-orchestrator.ts
@@ -10,6 +10,7 @@ import {
   runPuzzleAgentGeneration,
 } from "../puzzle-agent/run-generation";
 import type { PuzzleAgentResult } from "../puzzle-agent/schemas";
+import type { PuzzleVisual } from "../puzzle-agent/visual/composition";
 
 export type MasterGenerationParams = PuzzleGenerationParams;
 
@@ -23,6 +24,8 @@ export interface GeneratedPuzzleResult {
     category: string;
     hints: string[];
     techniqueId?: string;
+    /** Generative board (Ink Pictograms / text / optional images) */
+    visual?: PuzzleVisual;
   };
   metadata: {
     fingerprint: string;
@@ -65,6 +68,7 @@ function toGeneratedResult(
       category: result.puzzle.category,
       hints: result.puzzle.hints,
       techniqueId: result.puzzle.techniqueId,
+      visual: result.puzzle.visual,
     },
     metadata: {
       fingerprint: result.metadata.fingerprint,

--- a/apps/web/src/app/actions/gameActions.ts
+++ b/apps/web/src/app/actions/gameActions.ts
@@ -5,7 +5,7 @@ import { db } from "@/db";
 import { isAdmin } from "@/lib/admin-auth";
 import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
 import { verifyToken } from "@/lib/jwt";
-import type { GameData, PuzzleMetadata, PuzzleType } from "../../lib/gameSettings";
+import type { GameData, PuzzleMetadata, PuzzleType, PuzzleVisual } from "../../lib/gameSettings";
 import { getTodaysPuzzle } from "./puzzleGenerationActions";
 
 const AUTH_COOKIE = "rebuzzle_auth";
@@ -24,6 +24,7 @@ type TodaysPuzzle = {
   keyword?: string;
   category?: string;
   relevanceScore?: number;
+  visual?: PuzzleVisual;
 };
 
 /**
@@ -127,10 +128,7 @@ export async function fetchGameOverSolution(): Promise<{
   locked: boolean;
 }> {
   try {
-    const [userId, puzzleResult] = await Promise.all([
-      getCurrentUserId(),
-      getTodaysPuzzle(),
-    ]);
+    const [userId, puzzleResult] = await Promise.all([getCurrentUserId(), getTodaysPuzzle()]);
     const puzzle = (puzzleResult.success ? puzzleResult.puzzle : null) as TodaysPuzzle | null;
 
     if (!puzzle) {
@@ -190,9 +188,13 @@ export async function fetchGameData(_isPreview = false): Promise<PublicGameData>
       explanation: "", // revealed after lock via /api/puzzles/guess
       difficulty: toDifficulty(puzzle.difficulty),
       hints: puzzle.hints || [],
+      visual: puzzle.visual,
       leaderboard: [],
       isCompleted: false,
-      metadata,
+      metadata: {
+        ...metadata,
+        visualStyleId: puzzle.visual?.styleId,
+      },
       blogPost: null,
     };
   } catch (error) {

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -27,7 +27,7 @@ function getTodayDateString(date?: Date): string {
  */
 function calculateDailyDifficulty(date?: Date): number {
   const dateToUse = date || new Date();
-  const dayOfWeek = dateToUse.getUTCDay();  // Use UTC day for consistent behavior across all platforms
+  const dayOfWeek = dateToUse.getUTCDay(); // Use UTC day for consistent behavior across all platforms
   // Sunday = 5 (moderate), Wednesday = 7 (hardest), balanced across week
   // Hard 4–5 · Difficult 6 · Evil 7 · Impossible 8 — rotate across the week
   const difficulties = [5, 4, 6, 8, 7, 5, 4]; // Sun–Sat
@@ -221,6 +221,11 @@ async function getOrGenerateDailyPuzzle(
       }
     }
 
+    const visual = result.puzzle.visual;
+    if (visual?.unicodeFallback) {
+      puzzleDisplay = visual.unicodeFallback;
+    }
+
     // Persist first — clients must receive a real DB id for /api/puzzles/guess
     const persisted = await persistDailyPuzzle({
       dateString,
@@ -233,9 +238,13 @@ async function getOrGenerateDailyPuzzle(
       hints: result.puzzle.hints || [],
       aiGenerated: true,
       rebusPuzzle: typeToUse === "rebus" ? puzzleDisplay : undefined,
+      visual,
       metadataExtra: {
         qualityScore: result.metadata.qualityMetrics?.scores?.overall,
         uniquenessScore: result.metadata.uniquenessScore,
+        funScore: result.metadata.qualityMetrics?.scores?.fun,
+        techniqueId: result.puzzle.techniqueId,
+        visualStyleId: visual?.styleId,
       },
     });
 
@@ -257,8 +266,7 @@ async function getOrGenerateDailyPuzzle(
         }
       } catch (embeddingError) {
         logger.warn("Failed to generate embedding (non-critical)", {
-          error:
-            embeddingError instanceof Error ? embeddingError.message : String(embeddingError),
+          error: embeddingError instanceof Error ? embeddingError.message : String(embeddingError),
         });
       }
     })();
@@ -272,6 +280,7 @@ async function getOrGenerateDailyPuzzle(
       answer: result.puzzle.answer,
       explanation: result.puzzle.explanation,
       hints: result.puzzle.hints,
+      visual,
       date: dateString,
       topic: result.puzzle.category,
       category: result.puzzle.category,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -542,6 +542,17 @@
   line-height: 1.3;
 }
 
+/* Generative Ink Pictogram tiles — scale SVG to the board slot */
+.puzzle-pictogram svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.puzzle-visual-board .puzzle-image-tile {
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--foreground) 12%, transparent);
+}
+
 /* Monospace puzzles (number-sequence, caesar-cipher) */
 .puzzle-monospace-sm {
   font-size: clamp(1rem, 3vh, 1.5rem);

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -781,6 +781,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                   <PuzzleMinimal
                     puzzle={puzzleDisplay}
                     puzzleType={puzzleType}
+                    visual={gameData.visual}
                     className="w-full max-w-2xl"
                   />
                   {/* Show last guess attempt in collapsed view */}
@@ -822,6 +823,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                       <PuzzleDisplay
                         puzzle={puzzleDisplay}
                         puzzleType={puzzleType}
+                        visual={gameData.visual}
                         size={
                           puzzleType === "riddle" ||
                           puzzleType === "trivia" ||

--- a/apps/web/src/components/PuzzleDisplay.tsx
+++ b/apps/web/src/components/PuzzleDisplay.tsx
@@ -6,8 +6,9 @@
  */
 
 import { useMemo } from "react";
-import type { PuzzleType } from "@/lib/gameSettings";
+import type { PuzzleType, PuzzleVisual } from "@/lib/gameSettings";
 import { cn } from "@/lib/utils";
+import { hasComposedVisual, PuzzleVisualBoard } from "./PuzzleVisualBoard";
 
 type DisplaySize = "small" | "medium" | "large";
 
@@ -16,6 +17,8 @@ interface PuzzleDisplayProps {
   puzzleType?: PuzzleType | string;
   className?: string;
   size?: DisplaySize;
+  /** Generative composed board (Ink Pictograms / text / images) */
+  visual?: PuzzleVisual;
 }
 
 /** Puzzle type categories for styling */
@@ -79,13 +82,36 @@ export function PuzzleDisplay({
   puzzleType = "rebus",
   className,
   size = "large",
+  visual,
 }: PuzzleDisplayProps) {
   const category = useMemo(() => getPuzzleCategory(puzzleType), [puzzleType]);
+  const composed = hasComposedVisual(visual);
 
   const isTextBased = category === "text";
   const isMonospace = category === "monospace";
   const isVisual = category === "visual";
   const isRebus = puzzleType === "rebus";
+
+  const inlineStyles = useMemo(
+    () => ({
+      fontFeatureSettings: isVisual ? '"liga" 1, "calt" 1' : undefined,
+      lineHeight: LINE_HEIGHT[category],
+      overflowWrap: "anywhere" as const,
+      wordBreak: (isRebus ? "break-all" : "break-word") as "break-all" | "break-word",
+    }),
+    [category, isVisual, isRebus]
+  );
+
+  if (composed && visual) {
+    return (
+      <PuzzleVisualBoard
+        visual={visual}
+        fallback={puzzle || visual.unicodeFallback}
+        size={size}
+        className={cn("select-text max-w-full", className)}
+      />
+    );
+  }
 
   const baseClasses = cn(
     // Base text color — the puzzle is the loudest ink on the page
@@ -114,16 +140,6 @@ export function PuzzleDisplay({
     isTextBased && "mx-auto max-w-prose",
     // Custom
     className
-  );
-
-  const inlineStyles = useMemo(
-    () => ({
-      fontFeatureSettings: isVisual ? '"liga" 1, "calt" 1' : undefined,
-      lineHeight: LINE_HEIGHT[category],
-      overflowWrap: "anywhere" as const,
-      wordBreak: (isRebus ? "break-all" : "break-word") as "break-all" | "break-word",
-    }),
-    [category, isVisual, isRebus]
   );
 
   return (

--- a/apps/web/src/components/PuzzleMinimal.tsx
+++ b/apps/web/src/components/PuzzleMinimal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import type { PuzzleVisual } from "@/lib/gameSettings";
 import { cn } from "@/lib/utils";
+import { hasComposedVisual, PuzzleVisualBoard } from "./PuzzleVisualBoard";
 
 interface PuzzleMinimalProps {
   /**
@@ -11,6 +13,10 @@ interface PuzzleMinimalProps {
    * The type of puzzle (affects how content is displayed)
    */
   puzzleType: string;
+  /**
+   * Generative composed board when available
+   */
+  visual?: PuzzleVisual;
   /**
    * Additional CSS classes
    */
@@ -32,7 +38,7 @@ interface PuzzleMinimalProps {
  * )}
  * ```
  */
-export function PuzzleMinimal({ puzzle, puzzleType, className }: PuzzleMinimalProps) {
+export function PuzzleMinimal({ puzzle, puzzleType, visual, className }: PuzzleMinimalProps) {
   /**
    * Get the minimal content based on puzzle type.
    * - Visual puzzles (rebus, emoji): Show full puzzle in smaller size
@@ -95,21 +101,31 @@ export function PuzzleMinimal({ puzzle, puzzleType, className }: PuzzleMinimalPr
           "overflow-hidden"
         )}
       >
-        <span
-          className={cn(
-            fontSizeClass,
-            "font-medium",
-            "text-foreground/80",
-            "whitespace-pre-wrap",
-            "break-words"
-          )}
-          style={{
-            // Ensure emojis and special characters render correctly
-            fontFamily: '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif',
-          }}
-        >
-          {content}
-        </span>
+        {hasComposedVisual(visual) && visual ? (
+          <PuzzleVisualBoard
+            visual={visual}
+            fallback={content}
+            compact
+            size="small"
+            className="text-foreground/90"
+          />
+        ) : (
+          <span
+            className={cn(
+              fontSizeClass,
+              "font-medium",
+              "text-foreground/80",
+              "whitespace-pre-wrap",
+              "break-words"
+            )}
+            style={{
+              // Ensure emojis and special characters render correctly
+              fontFamily: '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif',
+            }}
+          >
+            {content}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/PuzzleVisualBoard.tsx
+++ b/apps/web/src/components/PuzzleVisualBoard.tsx
@@ -143,8 +143,8 @@ function ImageTile({
 
   if (!safe) return null;
 
+  // data: URLs from AI Gateway aren't a fit for next/image
   return (
-    // eslint-disable-next-line @next/next/no-img-element -- generative data URLs / gateway tiles
     <img
       src={src}
       alt={layer.alt}

--- a/apps/web/src/components/PuzzleVisualBoard.tsx
+++ b/apps/web/src/components/PuzzleVisualBoard.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { type CSSProperties, useMemo } from "react";
+import { sanitizePictogramSvg } from "@/ai/puzzle-agent/visual/sanitize-svg";
+import type { PuzzleVisual, PuzzleVisualLayer } from "@/lib/gameSettings";
+import { cn } from "@/lib/utils";
+
+type BoardSize = "small" | "medium" | "large";
+
+interface PuzzleVisualBoardProps {
+  visual: PuzzleVisual;
+  /** Unicode fallback when layers can't render */
+  fallback: string;
+  size?: BoardSize;
+  className?: string;
+  /** Compact keyboard-aware strip */
+  compact?: boolean;
+}
+
+const SIZE_PX: Record<BoardSize, { tile: number; text: string; gap: string }> = {
+  small: { tile: 36, text: "text-lg", gap: "gap-1.5" },
+  medium: { tile: 52, text: "text-2xl", gap: "gap-2" },
+  large: { tile: 72, text: "text-[clamp(1.75rem,5vw,2.75rem)]", gap: "gap-2.5 sm:gap-3" },
+};
+
+function textEmphasisClass(emphasis?: string): string {
+  switch (emphasis) {
+    case "large":
+      return "text-[1.35em] font-bold tracking-tight";
+    case "small":
+      return "text-[0.72em] font-semibold tracking-wide";
+    case "tiny":
+      return "text-[0.55em] font-semibold tracking-[0.12em] uppercase opacity-90";
+    case "strike":
+      return "line-through decoration-[0.12em] decoration-[var(--rb-strike,#b23a2d)] font-bold";
+    case "stacked":
+      return "font-bold leading-[0.95] tracking-[0.08em]";
+    default:
+      return "font-semibold tracking-tight";
+  }
+}
+
+function PictogramTile({
+  layer,
+  sizePx,
+  index,
+}: {
+  layer: Extract<PuzzleVisualLayer, { kind: "pictogram" }>;
+  sizePx: number;
+  index: number;
+}) {
+  const safeSvg = useMemo(() => (layer.svg ? sanitizePictogramSvg(layer.svg) : null), [layer.svg]);
+
+  if (safeSvg) {
+    return (
+      <span
+        className="puzzle-pictogram inline-flex shrink-0 items-center justify-center animate-in fade-in zoom-in-95 duration-500 fill-mode-both motion-reduce:animate-none"
+        style={{
+          width: sizePx,
+          height: sizePx,
+          animationDelay: `${Math.min(index, 6) * 45}ms`,
+        }}
+        role="img"
+        aria-label={layer.concept}
+        // Sanitized Ink Pictogram SVG only
+        dangerouslySetInnerHTML={{ __html: safeSvg }}
+      />
+    );
+  }
+
+  return (
+    <span
+      className="inline-flex shrink-0 items-center justify-center leading-none"
+      style={{ width: sizePx, height: sizePx, fontSize: sizePx * 0.72 }}
+      role="img"
+      aria-label={layer.concept}
+    >
+      {layer.emojiFallback}
+    </span>
+  );
+}
+
+function TextTile({
+  layer,
+  sizeClass,
+  index,
+}: {
+  layer: Extract<PuzzleVisualLayer, { kind: "text" }>;
+  sizeClass: string;
+  index: number;
+}) {
+  const stacked = layer.emphasis === "stacked";
+  const content = stacked ? layer.content.split("").join("\n") : layer.content;
+
+  return (
+    <span
+      className={cn(
+        "puzzle-text-layer inline-block text-foreground animate-in fade-in slide-in-from-bottom-1 duration-500 fill-mode-both motion-reduce:animate-none",
+        sizeClass,
+        textEmphasisClass(layer.emphasis),
+        stacked && "whitespace-pre text-center"
+      )}
+      style={{ animationDelay: `${Math.min(index, 6) * 45}ms` }}
+    >
+      {content}
+    </span>
+  );
+}
+
+function OperatorTile({
+  layer,
+  sizeClass,
+}: {
+  layer: Extract<PuzzleVisualLayer, { kind: "operator" }>;
+  sizeClass: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center text-subtle opacity-80",
+        sizeClass,
+        "font-medium"
+      )}
+      aria-hidden
+    >
+      {layer.symbol}
+    </span>
+  );
+}
+
+function ImageTile({
+  layer,
+  sizePx,
+  index,
+}: {
+  layer: Extract<PuzzleVisualLayer, { kind: "image" }>;
+  sizePx: number;
+  index: number;
+}) {
+  const src = layer.src;
+  const safe =
+    typeof src === "string" && (src.startsWith("data:image/") || src.startsWith("https://"));
+
+  if (!safe) return null;
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- generative data URLs / gateway tiles
+    <img
+      src={src}
+      alt={layer.alt}
+      width={sizePx}
+      height={sizePx}
+      className="puzzle-image-tile inline-block shrink-0 rounded-md object-cover animate-in fade-in zoom-in-95 duration-700 fill-mode-both motion-reduce:animate-none"
+      style={{
+        width: sizePx,
+        height: sizePx,
+        animationDelay: `${Math.min(index, 6) * 45}ms`,
+      }}
+      draggable={false}
+    />
+  );
+}
+
+function LayerView({
+  layer,
+  index,
+  size,
+}: {
+  layer: PuzzleVisualLayer;
+  index: number;
+  size: BoardSize;
+}) {
+  const dims = SIZE_PX[size];
+  if (layer.kind === "pictogram") {
+    return <PictogramTile layer={layer} sizePx={dims.tile} index={index} />;
+  }
+  if (layer.kind === "text") {
+    return <TextTile layer={layer} sizeClass={dims.text} index={index} />;
+  }
+  if (layer.kind === "operator") {
+    return <OperatorTile layer={layer} sizeClass={dims.text} />;
+  }
+  if (layer.kind === "image") {
+    return <ImageTile layer={layer} sizePx={dims.tile} index={index} />;
+  }
+  return null;
+}
+
+/**
+ * Renders a generative Rebuzzle board (Ink Pictograms, text devices, operators, images).
+ * Falls back to unicode string when layers are empty / unicode-only mode.
+ */
+export function PuzzleVisualBoard({
+  visual,
+  fallback,
+  size = "large",
+  className,
+  compact = false,
+}: PuzzleVisualBoardProps) {
+  const dims = SIZE_PX[compact ? "small" : size];
+  const layers = visual.layers ?? [];
+  const hasRenderable = layers.some((l) => {
+    if (l.kind === "pictogram") return Boolean(l.svg || l.emojiFallback);
+    if (l.kind === "image") return Boolean(l.src);
+    return true;
+  });
+
+  if (!hasRenderable || visual.mode === "unicode") {
+    return (
+      <div
+        className={cn(
+          "text-center text-foreground font-semibold whitespace-pre-wrap break-words",
+          dims.text,
+          className
+        )}
+      >
+        {fallback || visual.unicodeFallback}
+      </div>
+    );
+  }
+
+  const layoutClass =
+    visual.layout === "stack"
+      ? "flex-col items-center"
+      : visual.layout === "grid"
+        ? "flex-wrap justify-center max-w-[22rem]"
+        : visual.layout === "overlay"
+          ? "relative flex-wrap justify-center"
+          : "flex-row flex-wrap justify-center items-center";
+
+  return (
+    <div
+      className={cn("puzzle-visual-board flex w-full max-w-full", layoutClass, dims.gap, className)}
+      style={
+        {
+          "--rb-ink": "#1a1f1c",
+          "--rb-canvas": "#f4f6f3",
+          "--rb-accent": "#2f6f5e",
+          "--rb-strike": "#b23a2d",
+        } as CSSProperties
+      }
+      role="img"
+      aria-label={fallback || visual.unicodeFallback}
+    >
+      {layers.map((layer, index) => (
+        <LayerView
+          // Layers are ordered composition — index is stable for a given board
+          key={`${layer.kind}-${index}`}
+          layer={layer}
+          index={index}
+          size={compact ? "small" : size}
+        />
+      ))}
+      {visual.caption ? (
+        <p className="basis-full mt-2 text-center text-sm text-subtle animate-in fade-in duration-700 delay-200 motion-reduce:animate-none">
+          {visual.caption}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** True when the visual has something richer than a plain emoji string. */
+export function hasComposedVisual(visual?: PuzzleVisual | null): boolean {
+  if (!visual?.layers?.length) return false;
+  if (visual.mode === "unicode") return false;
+  return visual.layers.some(
+    (l) =>
+      (l.kind === "pictogram" && (l.svg || l.emojiFallback)) ||
+      l.kind === "text" ||
+      (l.kind === "image" && l.src) ||
+      l.kind === "operator"
+  );
+}

--- a/apps/web/src/db/models.ts
+++ b/apps/web/src/db/models.ts
@@ -70,6 +70,40 @@ export interface UserStats {
   lastBonusDate?: Date; // Date of last bonus
 }
 
+/** Generative board layers (Ink Pictogram v1 + text + optional images). */
+export type PuzzleVisualLayer =
+  | {
+      kind: "pictogram";
+      concept: string;
+      role?: string;
+      svg?: string;
+      emojiFallback: string;
+    }
+  | {
+      kind: "text";
+      content: string;
+      emphasis?: "normal" | "large" | "small" | "strike" | "stacked" | "tiny";
+    }
+  | {
+      kind: "operator";
+      symbol: string;
+    }
+  | {
+      kind: "image";
+      prompt: string;
+      alt: string;
+      src?: string;
+    };
+
+export interface PuzzleVisual {
+  styleId: "ink-pictogram-v1";
+  mode: "composed" | "unicode" | "hybrid";
+  layout: "row" | "stack" | "grid" | "overlay";
+  layers: PuzzleVisualLayer[];
+  unicodeFallback: string;
+  caption?: string;
+}
+
 export interface Puzzle {
   _id?: string;
   id: string;
@@ -84,6 +118,8 @@ export interface Puzzle {
   createdAt: Date;
   active: boolean;
   embedding?: number[]; // Vector embedding for semantic search
+  /** Generative composed visual (custom pictograms / text / images) */
+  visual?: PuzzleVisual;
   metadata?: {
     topic?: string;
     keyword?: string;
@@ -100,6 +136,9 @@ export interface Puzzle {
     generatedAt?: string;
     hints?: string[];
     puzzleType?: string; // Store puzzle type in metadata too
+    techniqueId?: string;
+    visualStyleId?: string;
+    funScore?: number;
   };
   // Legacy field for backward compatibility (will be populated from puzzle field)
   rebusPuzzle?: string;
@@ -367,6 +406,7 @@ export interface NewPuzzle {
   createdAt: Date;
   active: boolean;
   embedding?: number[]; // Vector embedding for semantic search
+  visual?: PuzzleVisual;
   metadata?: Record<string, unknown>;
   // Legacy field for backward compatibility
   rebusPuzzle?: string;

--- a/apps/web/src/lib/cache/daily-puzzle.ts
+++ b/apps/web/src/lib/cache/daily-puzzle.ts
@@ -1,6 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
-import type { Puzzle } from "@/db/models";
+import type { Puzzle, PuzzleVisual } from "@/db/models";
 import { logger } from "@/lib/logger";
 
 export type CachedDailyPuzzle = {
@@ -20,6 +20,8 @@ export type CachedDailyPuzzle = {
   seoMetadata: Record<string, unknown>;
   aiGenerated: boolean;
   fromDatabase: true;
+  /** Generative composed board when Eve built custom pictograms */
+  visual?: PuzzleVisual;
 };
 
 function formatPuzzleFromDb(puzzle: Puzzle, dateString: string): CachedDailyPuzzle {
@@ -35,7 +37,7 @@ function formatPuzzleFromDb(puzzle: Puzzle, dateString: string): CachedDailyPuzz
       (puzzle.metadata as { clues?: string[] } | undefined)?.clues &&
       Array.isArray((puzzle.metadata as { clues?: string[] }).clues)
     ) {
-      puzzleDisplay = ((puzzle.metadata as { clues: string[] }).clues).join("\n\n");
+      puzzleDisplay = (puzzle.metadata as { clues: string[] }).clues.join("\n\n");
     } else {
       puzzleDisplay = "A logic grid puzzle. Use deductive reasoning to solve the relationships.";
     }
@@ -67,6 +69,7 @@ function formatPuzzleFromDb(puzzle: Puzzle, dateString: string): CachedDailyPuzz
     seoMetadata: (puzzle.metadata?.seoMetadata as Record<string, unknown>) || {},
     aiGenerated: true,
     fromDatabase: true,
+    visual: puzzle.visual,
   };
 }
 

--- a/apps/web/src/lib/game/persist-daily-puzzle.ts
+++ b/apps/web/src/lib/game/persist-daily-puzzle.ts
@@ -4,6 +4,7 @@
 
 import { revalidateTag } from "next/cache";
 import { db } from "@/db";
+import type { PuzzleVisual } from "@/db/models";
 import { logger } from "@/lib/logger";
 
 export type PersistDailyPuzzleInput = {
@@ -17,6 +18,7 @@ export type PersistDailyPuzzleInput = {
   hints: string[];
   aiGenerated: boolean;
   rebusPuzzle?: string;
+  visual?: PuzzleVisual;
   metadataExtra?: Record<string, unknown>;
 };
 
@@ -54,18 +56,19 @@ export async function persistDailyPuzzle(input: PersistDailyPuzzleInput): Promis
     publishedAt,
     createdAt: new Date(),
     active: true,
+    visual: input.visual,
     metadata: {
       topic: input.category,
       category: input.category,
       puzzleType: input.puzzleType,
       aiGenerated: input.aiGenerated,
       generatedAt: new Date().toISOString(),
+      visualStyleId: input.visual?.styleId,
       // Intentionally omit keyword (= answer) from metadata
       ...input.metadataExtra,
     },
     rebusPuzzle:
-      input.rebusPuzzle ??
-      (input.puzzleType === "rebus" ? input.puzzleDisplay : undefined),
+      input.rebusPuzzle ?? (input.puzzleType === "rebus" ? input.puzzleDisplay : undefined),
   });
 
   revalidateTag("daily-puzzle", "max");

--- a/apps/web/src/lib/gameSettings.ts
+++ b/apps/web/src/lib/gameSettings.ts
@@ -12,6 +12,8 @@ export type {
   LeaderboardEntry,
   PuzzleMetadata,
   PuzzleType,
+  PuzzleVisual,
+  PuzzleVisualLayer,
 } from "@rebuzzle/config";
 // Re-export all types and constants from shared config
 export {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -41,6 +41,43 @@ export interface PuzzleMetadata {
     keywords?: string[];
   };
   qualityScore?: number;
+  techniqueId?: string;
+  visualStyleId?: string;
+  funScore?: number;
+}
+
+/** Generative board (custom pictograms / text / optional images). */
+export type PuzzleVisualLayer =
+  | {
+      kind: "pictogram";
+      concept: string;
+      role?: string;
+      svg?: string;
+      emojiFallback: string;
+    }
+  | {
+      kind: "text";
+      content: string;
+      emphasis?: "normal" | "large" | "small" | "strike" | "stacked" | "tiny";
+    }
+  | {
+      kind: "operator";
+      symbol: string;
+    }
+  | {
+      kind: "image";
+      prompt: string;
+      alt: string;
+      src?: string;
+    };
+
+export interface PuzzleVisual {
+  styleId: "ink-pictogram-v1";
+  mode: "composed" | "unicode" | "hybrid";
+  layout: "row" | "stack" | "grid" | "overlay";
+  layers: PuzzleVisualLayer[];
+  unicodeFallback: string;
+  caption?: string;
 }
 
 export interface BlogPostReference {
@@ -69,6 +106,8 @@ export interface GameData {
   leaderboard: LeaderboardEntry[];
   /** Progressive hints */
   hints?: string[];
+  /** Generative composed visual when Eve built a custom board */
+  visual?: PuzzleVisual;
   /** Additional puzzle metadata */
   metadata?: PuzzleMetadata & {
     publishedAt?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades Eve’s daily puzzle generator from stock-emoji boards to a **generative visual system** with a locked Rebuzzle style (Ink Pictogram v1).

- Custom SVG “emojis” (pictograms) in a consistent stroke/palette language
- Styled text layers when size/case/strike/stack *is* the joke
- Optional AI image tiles for rare scene-based techniques
- Unicode fallback always kept for share/legacy clients
- End-to-end: compose → persist → `fetchGameData` → play board render

## Design choices

| Layer | When to use |
| --- | --- |
| Pictogram | Default “our emoji” — generated SVG, brand-locked |
| Text | When emphasis itself is the clue |
| Image | Sparingly, when a scene can’t be a pictogram |
| Operator | `+` `/` `→` between parts |

Text is included intentionally: it’s a classic rebus device, not filler copy.

## Testing
- `npm test -- --testPathPatterns=puzzle-agent/visual` — pass (sanitize + composition)
- Existing unicode puzzles still render; composed `visual` takes over when present
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

