### PR TITLE
Dev Mode Visual Lab for generative puzzle previews

### DIFF
--- a/apps/web/src/ai/__tests__/gateway-auth.test.ts
+++ b/apps/web/src/ai/__tests__/gateway-auth.test.ts
@@ -1,0 +1,46 @@
+import { ensureGatewayKey, getGatewayApiKey, looksLikeJwt } from "../gateway-auth";
+
+describe("AI Gateway auth sanitization", () => {
+  const originalKey = process.env.AI_GATEWAY_API_KEY;
+  const originalOidc = process.env.VERCEL_OIDC_TOKEN;
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.AI_GATEWAY_API_KEY;
+    } else {
+      process.env.AI_GATEWAY_API_KEY = originalKey;
+    }
+    if (originalOidc === undefined) {
+      delete process.env.VERCEL_OIDC_TOKEN;
+    } else {
+      process.env.VERCEL_OIDC_TOKEN = originalOidc;
+    }
+  });
+
+  it("detects JWTs vs gateway keys", () => {
+    expect(looksLikeJwt("vck_test_key_1234567890")).toBe(false);
+    expect(
+      looksLikeJwt(
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturepart"
+      )
+    ).toBe(true);
+  });
+
+  it("keeps real gateway API keys", () => {
+    process.env.AI_GATEWAY_API_KEY = "vck_test_key_1234567890";
+    delete process.env.VERCEL_OIDC_TOKEN;
+    ensureGatewayKey();
+    expect(getGatewayApiKey()).toBe("vck_test_key_1234567890");
+  });
+
+  it("does not treat OIDC JWTs as API keys", () => {
+    const jwt =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturepart";
+    process.env.AI_GATEWAY_API_KEY = jwt;
+    delete process.env.VERCEL_OIDC_TOKEN;
+    ensureGatewayKey();
+    expect(getGatewayApiKey()).toBeUndefined();
+    expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();
+    expect(process.env.VERCEL_OIDC_TOKEN).toBe(jwt);
+  });
+});

--- a/apps/web/src/ai/client.ts
+++ b/apps/web/src/ai/client.ts
@@ -2,7 +2,9 @@
  * AI Client — Vercel AI Gateway only
  *
  * All model calls route through AI Gateway (`provider/model` ids).
- * Auth: `AI_GATEWAY_API_KEY` locally, or Vercel OIDC on Vercel.
+ * Auth: `AI_GATEWAY_API_KEY` (vck_…) locally, or Vercel OIDC on Vercel.
+ * Never promote OIDC JWTs into AI_GATEWAY_API_KEY — that forces api-key
+ * auth and causes "Unauthenticated" on production.
  */
 
 import { createGateway, gateway } from "@ai-sdk/gateway";
@@ -10,16 +12,17 @@ import { generateText, type LanguageModel, Output, streamText } from "ai";
 import type { z } from "zod";
 import { AI_CONFIG, validateApiKeys } from "./config";
 import { AIError, AIProviderError, parseAIError, QuotaExceededError } from "./errors";
+import { ensureGatewayKey, getGatewayApiKey } from "./gateway-auth";
 import { enforceQuota } from "./quota-manager";
 
 export type ModelTier = "fast" | "smart" | "creative";
 
-/** Ensure gateway auth env is set (OIDC token → AI_GATEWAY_API_KEY). */
-export function ensureGatewayKey(): void {
-  const key = AI_CONFIG.gateway.apiKey;
-  if (key && !process.env.AI_GATEWAY_API_KEY) {
-    process.env.AI_GATEWAY_API_KEY = key;
-  }
+export { ensureGatewayKey, getGatewayApiKey } from "./gateway-auth";
+
+/** Shared gateway provider — API key when present, else OIDC on Vercel. */
+export function getAiGateway() {
+  const apiKey = getGatewayApiKey();
+  return apiKey ? createGateway({ apiKey }) : gateway;
 }
 
 /** Resolve a gateway language model for a tier (primary only). */
@@ -29,7 +32,7 @@ export function getGatewayModel(tier: ModelTier = "smart"): LanguageModel {
   if (!validation.valid) {
     throw new Error(`Missing API keys: ${validation.missing.join(", ")}`);
   }
-  return gateway(AI_CONFIG.models.gateway[tier]);
+  return getAiGateway()(AI_CONFIG.models.gateway[tier]);
 }
 
 /** Primary + fallback gateway model ids for a tier. */
@@ -100,7 +103,7 @@ export async function generateAIText(params: {
 
     try {
       const result = await generateText({
-        model: gateway(modelId),
+        model: getAiGateway()(modelId),
         prompt: params.prompt,
         system: params.system,
         temperature: params.temperature ?? AI_CONFIG.generation.temperature.balanced,
@@ -149,7 +152,7 @@ export async function generateAIObject<T>(params: {
 
     try {
       const result = await generateText({
-        model: gateway(modelId),
+        model: getAiGateway()(modelId),
         prompt: params.prompt,
         system: params.system,
         temperature: params.temperature ?? AI_CONFIG.generation.temperature.balanced,
@@ -209,10 +212,8 @@ export function getAIProvider(): {
   getAllModels: (tier?: ModelTier) => string[];
   getModelInstance: (tier?: ModelTier) => LanguageModel;
 } {
-  ensureGatewayKey();
-  const gw = createGateway({
-    apiKey: AI_CONFIG.gateway.apiKey || undefined,
-  });
+  const apiKey = getGatewayApiKey();
+  const gw = apiKey ? createGateway({ apiKey }) : createGateway();
   return {
     getName: () => "gateway" as const,
     getProvider: () => gw,
@@ -220,7 +221,7 @@ export function getAIProvider(): {
     getFallbackModels: (tier: ModelTier = "smart") =>
       AI_CONFIG.models.fallbacks.gateway[tier] ?? [],
     getAllModels: (tier: ModelTier = "smart") => getGatewayModelChain(tier),
-    getModelInstance: (tier: ModelTier = "smart") => gateway(AI_CONFIG.models.gateway[tier]),
+    getModelInstance: (tier: ModelTier = "smart") => gw(AI_CONFIG.models.gateway[tier]),
   };
 }
 

--- a/apps/web/src/ai/config.ts
+++ b/apps/web/src/ai/config.ts
@@ -9,7 +9,12 @@ export const AI_CONFIG = {
   defaultProvider: "gateway" as const,
 
   gateway: {
-    apiKey: process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN,
+    /**
+     * API key only (`vck_…`). Do NOT put VERCEL_OIDC_TOKEN here —
+     * the gateway SDK must authenticate OIDC with authMethod "oidc",
+     * and stuffing a JWT into AI_GATEWAY_API_KEY breaks production auth.
+     */
+    apiKey: process.env.AI_GATEWAY_API_KEY,
   },
 
   models: {

--- a/apps/web/src/ai/gateway-auth.ts
+++ b/apps/web/src/ai/gateway-auth.ts
@@ -1,0 +1,40 @@
+/**
+ * AI Gateway auth helpers.
+ *
+ * Important: never promote VERCEL_OIDC_TOKEN into AI_GATEWAY_API_KEY.
+ * The SDK authenticates API keys with authMethod "api-key" and OIDC with
+ * authMethod "oidc". Stuffing a JWT into AI_GATEWAY_API_KEY breaks production.
+ */
+
+/** True when a value looks like a JWT (OIDC), not a gateway API key. */
+export function looksLikeJwt(value: string): boolean {
+  if (value.startsWith("vck_")) return false;
+  const parts = value.split(".");
+  return parts.length === 3 && parts.every((p) => p.length > 4);
+}
+
+/**
+ * Sanitize gateway auth env before SDK calls.
+ * - Keep real API keys in AI_GATEWAY_API_KEY
+ * - Move misplaced OIDC JWTs out of AI_GATEWAY_API_KEY so the SDK uses OIDC
+ */
+export function ensureGatewayKey(): void {
+  const key = process.env.AI_GATEWAY_API_KEY?.trim();
+  if (key && looksLikeJwt(key)) {
+    const oidc = process.env.VERCEL_OIDC_TOKEN?.trim();
+    if (!oidc || oidc === "undefined") {
+      process.env.VERCEL_OIDC_TOKEN = key;
+    }
+    // delete — assigning undefined becomes the string "undefined" in Node
+    // biome-ignore lint/performance/noDelete: must remove env key entirely
+    delete process.env.AI_GATEWAY_API_KEY;
+  }
+}
+
+/** Runtime gateway API key (never an OIDC JWT). */
+export function getGatewayApiKey(): string | undefined {
+  ensureGatewayKey();
+  const key = process.env.AI_GATEWAY_API_KEY?.trim();
+  if (!key || key === "undefined" || looksLikeJwt(key)) return undefined;
+  return key;
+}

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -7,9 +7,8 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { gateway } from "@ai-sdk/gateway";
 import { Output, stepCountIs, ToolLoopAgent } from "ai";
-import { ensureGatewayKey, getGatewayModelChain } from "../client";
+import { ensureGatewayKey, getAiGateway, getGatewayModelChain } from "../client";
 import { AI_CONFIG } from "../config";
 import { enforceQuota } from "../quota-manager";
 import { getDifficultyLevelForScore } from "./difficulty-levels";
@@ -178,7 +177,7 @@ export async function runPuzzleAgentGeneration(
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         const agent = new ToolLoopAgent({
-          model: gateway(modelId),
+          model: getAiGateway()(modelId),
           instructions: loadInstructions(),
           tools: puzzleAgentTools,
           temperature: AI_CONFIG.generation.temperature.creative,

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/lab-recipes.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/lab-recipes.test.ts
@@ -1,0 +1,29 @@
+import { buildLabLayers, guessEmoji, isVisualLabMode, VISUAL_LAB_MODES } from "../lab-recipes";
+
+describe("visual lab recipes", () => {
+  it("recognizes all lab modes", () => {
+    for (const mode of VISUAL_LAB_MODES) {
+      expect(isVisualLabMode(mode)).toBe(true);
+    }
+    expect(isVisualLabMode("nope")).toBe(false);
+  });
+
+  it("builds text layers with emphasis devices", () => {
+    const plan = buildLabLayers("text", { concept: "bee", answer: "headline" });
+    expect(plan.layers.some((l) => l.kind === "text" && l.emphasis === "stacked")).toBe(true);
+    expect(plan.layers.some((l) => l.kind === "operator")).toBe(true);
+  });
+
+  it("builds composed pictogram layers", () => {
+    const plan = buildLabLayers("composed", { concept: "bee", answer: "before" });
+    const pictograms = plan.layers.filter((l) => l.kind === "pictogram");
+    expect(pictograms.length).toBeGreaterThanOrEqual(2);
+    expect(guessEmoji("bee")).toBe("🐝");
+  });
+
+  it("builds hybrid with an image layer", () => {
+    const plan = buildLabLayers("hybrid", { concept: "sun", answer: "sunshine" });
+    expect(plan.layers.some((l) => l.kind === "image")).toBe(true);
+    expect(plan.layers.some((l) => l.kind === "pictogram")).toBe(true);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
@@ -3,9 +3,8 @@
  * Uses Vercel AI Gateway image models with a locked Rebuzzle illustration style.
  */
 
-import { gateway } from "@ai-sdk/gateway";
 import { generateImage } from "ai";
-import { ensureGatewayKey } from "@/ai/client";
+import { ensureGatewayKey, getAiGateway } from "@/ai/client";
 import { IMAGE_TILE_STYLE_GUIDE } from "./style";
 
 export type GenerateImageTileInput = {
@@ -46,7 +45,7 @@ export async function generateImageTile(
   for (const modelId of IMAGE_MODEL_CHAIN) {
     try {
       const result = await generateImage({
-        model: gateway.image(modelId),
+        model: getAiGateway().image(modelId),
         prompt,
         aspectRatio: "1:1",
       });

--- a/apps/web/src/ai/puzzle-agent/visual/index.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/index.ts
@@ -26,6 +26,16 @@ export {
   generatePictogram,
 } from "./generate-pictogram";
 export {
+  buildLabLayers,
+  guessEmoji,
+  isVisualLabMode,
+  VISUAL_LAB_MODE_META,
+  VISUAL_LAB_MODES,
+  type VisualLabMode,
+  type VisualLabModeMeta,
+} from "./lab-recipes";
+export { type RunVisualLabInput, type RunVisualLabResult, runVisualLab } from "./run-visual-lab";
+export {
   IMAGE_TILE_STYLE_GUIDE,
   INK_PICTOGRAM_PALETTE,
   INK_PICTOGRAM_STYLE_GUIDE,

--- a/apps/web/src/ai/puzzle-agent/visual/lab-recipes.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/lab-recipes.ts
@@ -1,0 +1,199 @@
+/**
+ * Fixed recipes for the Dev Mode Visual Lab.
+ * Lets us exercise every generative visual path without publishing today's puzzle.
+ */
+
+import type { VisualLayer } from "./composition";
+
+export const VISUAL_LAB_MODES = [
+  "pictogram",
+  "text",
+  "unicode",
+  "image",
+  "hybrid",
+  "composed",
+  "full-puzzle",
+] as const;
+
+export type VisualLabMode = (typeof VISUAL_LAB_MODES)[number];
+
+export type VisualLabModeMeta = {
+  id: VisualLabMode;
+  label: string;
+  description: string;
+  /** Hits AI Gateway for SVG / image / full Eve agent */
+  usesAi: boolean;
+  estimatedCost: "free" | "low" | "medium" | "high";
+};
+
+export const VISUAL_LAB_MODE_META: Record<VisualLabMode, VisualLabModeMeta> = {
+  pictogram: {
+    id: "pictogram",
+    label: "Custom pictogram",
+    description: "Generate one Ink Pictogram v1 SVG (our branded emoji).",
+    usesAi: true,
+    estimatedCost: "low",
+  },
+  text: {
+    id: "text",
+    label: "Text devices",
+    description: "Styled text layers — large, strike, stacked, tiny (no AI).",
+    usesAi: false,
+    estimatedCost: "free",
+  },
+  unicode: {
+    id: "unicode",
+    label: "Unicode emoji",
+    description: "Stock emoji + operators board (legacy unicode path, no AI).",
+    usesAi: false,
+    estimatedCost: "free",
+  },
+  image: {
+    id: "image",
+    label: "Image tile",
+    description: "Single AI-illustrated square tile via image models.",
+    usesAi: true,
+    estimatedCost: "medium",
+  },
+  hybrid: {
+    id: "hybrid",
+    label: "Hybrid board",
+    description: "Pictogram + text + optional image tile together.",
+    usesAi: true,
+    estimatedCost: "high",
+  },
+  composed: {
+    id: "composed",
+    label: "Composed rebus",
+    description: "Multi-layer Ink Pictogram rebus with operators (no image).",
+    usesAi: true,
+    estimatedCost: "medium",
+  },
+  "full-puzzle": {
+    id: "full-puzzle",
+    label: "Full Eve puzzle",
+    description: "Run the full ToolLoopAgent once — preview only, not published.",
+    usesAi: true,
+    estimatedCost: "high",
+  },
+};
+
+export function isVisualLabMode(value: unknown): value is VisualLabMode {
+  return typeof value === "string" && (VISUAL_LAB_MODES as readonly string[]).includes(value);
+}
+
+/** Build layer plans for compose_puzzle_visual-style modes. */
+export function buildLabLayers(
+  mode: Exclude<VisualLabMode, "full-puzzle" | "pictogram" | "image">,
+  opts: { concept: string; answer: string }
+): { layers: VisualLayer[]; layout: "row" | "stack" | "grid"; caption?: string } {
+  const concept = opts.concept.trim() || "bee";
+  const answer = opts.answer.trim() || "before";
+
+  if (mode === "text") {
+    return {
+      layout: "row",
+      caption: "Text-device rebus (size / strike / stack)",
+      layers: [
+        { kind: "text", content: "HEAD", emphasis: "large" },
+        { kind: "operator", symbol: "+" },
+        { kind: "text", content: answer.slice(0, 4).toUpperCase() || "LINE", emphasis: "strike" },
+        { kind: "operator", symbol: "/" },
+        { kind: "text", content: "OVER", emphasis: "stacked" },
+      ],
+    };
+  }
+
+  if (mode === "unicode") {
+    return {
+      layout: "row",
+      caption: "Unicode emoji fallback board",
+      layers: [
+        {
+          kind: "pictogram",
+          concept,
+          role: "unicode-only",
+          emojiFallback: guessEmoji(concept),
+          // Pre-set empty svg skip: compose will try AI — we handle unicode in runner
+        },
+        { kind: "operator", symbol: "+" },
+        { kind: "text", content: "4", emphasis: "large" },
+      ],
+    };
+  }
+
+  if (mode === "hybrid") {
+    return {
+      layout: "row",
+      caption: "Hybrid: pictogram + text + image",
+      layers: [
+        {
+          kind: "pictogram",
+          concept,
+          role: "primary",
+          emojiFallback: guessEmoji(concept),
+        },
+        { kind: "operator", symbol: "+" },
+        { kind: "text", content: "TIME", emphasis: "small" },
+        { kind: "operator", symbol: "→" },
+        {
+          kind: "image",
+          prompt: `A single clear ${concept} as a soft ink illustration for a rebus puzzle`,
+          alt: `${concept} illustration`,
+        },
+      ],
+    };
+  }
+
+  // composed
+  return {
+    layout: "row",
+    caption: "Composed Ink Pictogram rebus",
+    layers: [
+      {
+        kind: "pictogram",
+        concept,
+        role: "homophone-or-icon",
+        emojiFallback: guessEmoji(concept),
+      },
+      { kind: "operator", symbol: "+" },
+      {
+        kind: "pictogram",
+        concept: "clock",
+        role: "secondary",
+        emojiFallback: "🕐",
+      },
+      { kind: "operator", symbol: "/" },
+      { kind: "text", content: answer.slice(0, 6).toUpperCase() || "WORD", emphasis: "tiny" },
+    ],
+  };
+}
+
+export function guessEmoji(concept: string): string {
+  const c = concept.toLowerCase();
+  const map: Record<string, string> = {
+    bee: "🐝",
+    eye: "👁️",
+    clock: "🕐",
+    sun: "☀️",
+    moon: "🌙",
+    star: "⭐",
+    heart: "❤️",
+    fire: "🔥",
+    water: "💧",
+    tree: "🌳",
+    fish: "🐟",
+    bird: "🐦",
+    book: "📖",
+    key: "🔑",
+    house: "🏠",
+    light: "💡",
+    puzzle: "🧩",
+    brain: "🧠",
+    rocket: "🚀",
+  };
+  for (const [k, v] of Object.entries(map)) {
+    if (c.includes(k)) return v;
+  }
+  return "◆";
+}

--- a/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
@@ -1,0 +1,303 @@
+/**
+ * Dev Visual Lab runner — exercises generative visual paths without publishing.
+ */
+
+import { generateMasterPuzzle } from "@/ai/services/master-puzzle-orchestrator";
+import { composePuzzleVisual } from "./compose-visual";
+import { buildUnicodeFallback, type PuzzleVisual, type VisualLayer } from "./composition";
+import { generateImageTile } from "./generate-image-tile";
+import { generatePictogram } from "./generate-pictogram";
+import {
+  buildLabLayers,
+  guessEmoji,
+  VISUAL_LAB_MODE_META,
+  type VisualLabMode,
+} from "./lab-recipes";
+import { INK_PICTOGRAM_STYLE_ID } from "./style";
+
+export type RunVisualLabInput = {
+  mode: VisualLabMode;
+  concept?: string;
+  answer?: string;
+  difficulty?: number;
+  /** Override: skip AI images even in hybrid/image modes */
+  renderImages?: boolean;
+};
+
+export type RunVisualLabResult = {
+  mode: VisualLabMode;
+  meta: {
+    label: string;
+    description: string;
+    durationMs: number;
+    usesAi: boolean;
+    estimatedCost: string;
+  };
+  /** Composed board when applicable */
+  visual?: PuzzleVisual;
+  /** Single pictogram probe */
+  pictogram?: {
+    ok: boolean;
+    concept: string;
+    svg: string | null;
+    emojiFallback: string;
+    error?: string;
+  };
+  /** Single image tile probe */
+  image?: {
+    ok: boolean;
+    alt: string;
+    src?: string;
+    model?: string;
+    error?: string;
+  };
+  /** Full Eve puzzle preview (not persisted) */
+  puzzle?: {
+    rebusPuzzle: string;
+    answer: string;
+    difficulty: number;
+    difficultyLevel: string;
+    explanation: string;
+    category: string;
+    hints: string[];
+    techniqueId?: string;
+    visual?: PuzzleVisual;
+    qualityScore?: number;
+    funScore?: number;
+  };
+  compose?: {
+    funScore: number;
+    totalParts: number;
+    withinBudget: boolean;
+    issues: string[];
+    tips: string[];
+    generated: {
+      pictograms: number;
+      images: number;
+      failedPictograms: number;
+      failedImages: number;
+    };
+  };
+};
+
+function unicodeOnlyVisual(layers: VisualLayer[], caption?: string): PuzzleVisual {
+  const withFallback = layers.map((layer) => {
+    if (layer.kind === "pictogram") {
+      return {
+        ...layer,
+        svg: undefined,
+        emojiFallback: layer.emojiFallback || guessEmoji(layer.concept),
+      };
+    }
+    return layer;
+  });
+  return {
+    styleId: INK_PICTOGRAM_STYLE_ID,
+    mode: "unicode",
+    layout: "row",
+    layers: withFallback,
+    unicodeFallback: buildUnicodeFallback(withFallback),
+    caption,
+  };
+}
+
+export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualLabResult> {
+  const start = Date.now();
+  const mode = input.mode;
+  const modeMeta = VISUAL_LAB_MODE_META[mode];
+  const concept = (input.concept || "bee").trim().slice(0, 48) || "bee";
+  const answer = (input.answer || "before").trim().slice(0, 64) || "before";
+  const difficulty = Math.max(4, Math.min(9, input.difficulty ?? 5));
+  const renderImages = input.renderImages !== false;
+
+  const baseMeta = {
+    label: modeMeta.label,
+    description: modeMeta.description,
+    usesAi: modeMeta.usesAi,
+    estimatedCost: modeMeta.estimatedCost,
+  };
+
+  if (mode === "pictogram") {
+    const pictogram = await generatePictogram({
+      concept,
+      role: "dev-lab",
+      emojiFallback: guessEmoji(concept),
+    });
+    const layers: VisualLayer[] = [
+      {
+        kind: "pictogram",
+        concept: pictogram.concept,
+        role: "dev-lab",
+        svg: pictogram.svg ?? undefined,
+        emojiFallback: pictogram.emojiFallback,
+      },
+    ];
+    return {
+      mode,
+      meta: { ...baseMeta, durationMs: Date.now() - start },
+      pictogram: {
+        ok: pictogram.ok,
+        concept: pictogram.concept,
+        svg: pictogram.svg,
+        emojiFallback: pictogram.emojiFallback,
+        error: pictogram.error,
+      },
+      visual: {
+        styleId: INK_PICTOGRAM_STYLE_ID,
+        mode: pictogram.svg ? "composed" : "unicode",
+        layout: "row",
+        layers,
+        unicodeFallback: pictogram.emojiFallback,
+        caption: `Pictogram probe: ${concept}`,
+      },
+    };
+  }
+
+  if (mode === "image") {
+    const image = await generateImageTile({
+      prompt: `A single clear ${concept} as a soft ink illustration for a rebus puzzle tile`,
+      alt: `${concept} illustration`,
+    });
+    const layers: VisualLayer[] =
+      image.ok && image.src
+        ? [
+            {
+              kind: "image",
+              prompt: `illustration of ${concept}`,
+              alt: image.alt,
+              src: image.src,
+            },
+          ]
+        : [
+            {
+              kind: "text",
+              content: image.error || "image failed",
+              emphasis: "small",
+            },
+          ];
+    return {
+      mode,
+      meta: { ...baseMeta, durationMs: Date.now() - start },
+      image: {
+        ok: image.ok,
+        alt: image.alt,
+        src: image.src,
+        model: image.model,
+        error: image.error,
+      },
+      visual: {
+        styleId: INK_PICTOGRAM_STYLE_ID,
+        mode: image.ok ? "hybrid" : "unicode",
+        layout: "row",
+        layers,
+        unicodeFallback: image.ok ? "🖼️" : "◆",
+        caption: `Image tile probe: ${concept}`,
+      },
+    };
+  }
+
+  if (mode === "unicode") {
+    const plan = buildLabLayers("unicode", { concept, answer });
+    const visual = unicodeOnlyVisual(plan.layers, plan.caption);
+    return {
+      mode,
+      meta: { ...baseMeta, durationMs: Date.now() - start },
+      visual,
+      compose: {
+        funScore: 55,
+        totalParts: visual.layers.filter((l) => l.kind !== "operator").length,
+        withinBudget: true,
+        issues: [],
+        tips: ["Unicode path skips AI — emojiFallback only"],
+        generated: {
+          pictograms: 0,
+          images: 0,
+          failedPictograms: 0,
+          failedImages: 0,
+        },
+      },
+    };
+  }
+
+  if (mode === "text") {
+    const plan = buildLabLayers("text", { concept, answer });
+    const composed = await composePuzzleVisual({
+      answer,
+      targetDifficulty: difficulty,
+      techniqueId: "size_or_case_semantics",
+      layout: plan.layout,
+      layers: plan.layers,
+      caption: plan.caption,
+      renderImages: false,
+    });
+    return {
+      mode,
+      meta: { ...baseMeta, durationMs: Date.now() - start },
+      visual: composed.visual,
+      compose: {
+        funScore: composed.funScore,
+        totalParts: composed.totalParts,
+        withinBudget: composed.withinBudget,
+        issues: composed.issues,
+        tips: composed.tips,
+        generated: composed.generated,
+      },
+    };
+  }
+
+  if (mode === "composed" || mode === "hybrid") {
+    const plan = buildLabLayers(mode, { concept, answer });
+    const composed = await composePuzzleVisual({
+      answer,
+      targetDifficulty: difficulty,
+      techniqueId: mode === "hybrid" ? "multi_emoji_compound" : "single_homophone",
+      layout: plan.layout,
+      layers: plan.layers,
+      caption: plan.caption,
+      renderImages: mode === "hybrid" ? renderImages : false,
+    });
+    return {
+      mode,
+      meta: { ...baseMeta, durationMs: Date.now() - start },
+      visual: composed.visual,
+      compose: {
+        funScore: composed.funScore,
+        totalParts: composed.totalParts,
+        withinBudget: composed.withinBudget,
+        issues: composed.issues,
+        tips: composed.tips,
+        generated: composed.generated,
+      },
+    };
+  }
+
+  // full-puzzle — Eve agent, preview only
+  const result = await generateMasterPuzzle({
+    targetDifficulty: difficulty,
+    puzzleType: "rebus",
+    theme: concept,
+    category: "visual_wordplay",
+    requireNovelty: false,
+    maxAttempts: 1,
+    qualityThreshold: 60,
+  });
+
+  return {
+    mode,
+    meta: { ...baseMeta, durationMs: Date.now() - start },
+    visual: result.puzzle.visual,
+    puzzle: {
+      rebusPuzzle: result.puzzle.rebusPuzzle,
+      answer: result.puzzle.answer,
+      difficulty: result.puzzle.difficulty,
+      difficultyLevel: result.puzzle.difficultyLevel,
+      explanation: result.puzzle.explanation,
+      category: result.puzzle.category,
+      hints: result.puzzle.hints,
+      techniqueId: result.puzzle.techniqueId,
+      visual: result.puzzle.visual,
+      qualityScore: result.metadata.qualityMetrics.scores.overall,
+      funScore: result.metadata.qualityMetrics.scores.fun,
+    },
+  };
+}

--- a/apps/web/src/ai/services/embeddings.ts
+++ b/apps/web/src/ai/services/embeddings.ts
@@ -2,14 +2,13 @@
  * Embeddings Service — Vercel AI Gateway only
  */
 
-import { gateway } from "@ai-sdk/gateway";
 import { embed } from "ai";
-import { getAIProvider, withRetry } from "../client";
+import { getAIProvider, getAiGateway, withRetry } from "../client";
 import { AI_CONFIG } from "../config";
 
 function getEmbeddingModel() {
   const embeddingModelId = AI_CONFIG.embeddings.gateway || "google/gemini-embedding-001";
-  return gateway.embeddingModel(embeddingModelId);
+  return getAiGateway().embeddingModel(embeddingModelId);
 }
 
 /**

--- a/apps/web/src/app/api/dev/visual-lab/route.ts
+++ b/apps/web/src/app/api/dev/visual-lab/route.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { ensureGatewayKey, getGatewayApiKey } from "@/ai/client";
 import {
   isVisualLabMode,
   VISUAL_LAB_MODE_META,
@@ -18,10 +19,21 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: false, allowed: false }, { status: 401 });
   }
 
+  ensureGatewayKey();
+  const apiKey = getGatewayApiKey();
+
   return NextResponse.json({
     success: true,
     allowed: true,
     modes: VISUAL_LAB_MODES.map((id) => VISUAL_LAB_MODE_META[id]),
+    gateway: {
+      apiKeyPresent: Boolean(apiKey),
+      oidcEnvPresent: Boolean(process.env.VERCEL_OIDC_TOKEN),
+      onVercel: Boolean(process.env.VERCEL),
+      vercelEnv: process.env.VERCEL_ENV ?? null,
+      /** Prefer api key locally; on Vercel OIDC works without a key */
+      authPath: apiKey ? "api-key" : process.env.VERCEL ? "oidc" : "missing",
+    },
   });
 }
 

--- a/apps/web/src/app/api/dev/visual-lab/route.ts
+++ b/apps/web/src/app/api/dev/visual-lab/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Dev Mode Visual Lab API — generate visual variants without publishing.
+ * Auth: any signed-in user (guest OK), same gate as /api/dev/session.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  isVisualLabMode,
+  VISUAL_LAB_MODE_META,
+  VISUAL_LAB_MODES,
+} from "@/ai/puzzle-agent/visual/lab-recipes";
+import { runVisualLab } from "@/ai/puzzle-agent/visual/run-visual-lab";
+import { getAuthenticatedUser } from "@/lib/auth-middleware";
+
+export async function GET(request: Request) {
+  const authUser = await getAuthenticatedUser(request);
+  if (!authUser) {
+    return NextResponse.json({ success: false, allowed: false }, { status: 401 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    allowed: true,
+    modes: VISUAL_LAB_MODES.map((id) => VISUAL_LAB_MODE_META[id]),
+  });
+}
+
+export async function POST(request: Request) {
+  try {
+    const authUser = await getAuthenticatedUser(request);
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, error: "Sign in (guest or account) to use the Visual Lab" },
+        { status: 401 }
+      );
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      mode?: unknown;
+      concept?: unknown;
+      answer?: unknown;
+      difficulty?: unknown;
+      renderImages?: unknown;
+    };
+
+    if (!isVisualLabMode(body.mode)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `mode required — one of: ${VISUAL_LAB_MODES.join(", ")}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const difficulty =
+      typeof body.difficulty === "number" && Number.isFinite(body.difficulty)
+        ? body.difficulty
+        : undefined;
+
+    const result = await runVisualLab({
+      mode: body.mode,
+      concept: typeof body.concept === "string" ? body.concept : undefined,
+      answer: typeof body.answer === "string" ? body.answer : undefined,
+      difficulty,
+      renderImages: body.renderImages !== false,
+    });
+
+    return NextResponse.json({
+      success: true,
+      /** Explicit: never writes to the daily puzzle catalog */
+      published: false,
+      result,
+    });
+  } catch (error) {
+    console.error("[dev/visual-lab]", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Visual lab generation failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/dev/visual-lab/page.tsx
+++ b/apps/web/src/app/dev/visual-lab/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { DevVisualLab } from "@/components/DevVisualLab";
+import Layout from "@/components/Layout";
+
+export const metadata: Metadata = {
+  title: "Visual Lab · Dev Mode",
+  robots: { index: false, follow: false },
+};
+
+export default function DevVisualLabPage() {
+  return (
+    <Layout>
+      <DevVisualLab />
+    </Layout>
+  );
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -14,7 +14,6 @@ import {
   Trash2,
   Trophy,
 } from "lucide-react";
-// Palette already imported for Appearance + Visual Lab link
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   Trash2,
   Trophy,
 } from "lucide-react";
+// Palette already imported for Appearance + Visual Lab link
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
@@ -343,9 +344,10 @@ export default function SettingsPage() {
                   Enable testing tools
                 </Label>
                 <p className="text-muted-foreground text-sm">
-                  Shows a floating panel on every page: regenerate today&apos;s puzzle, unlock/replay
-                  the daily gate, and jump between play → locked → win/lose screens. Works for
-                  guests and signed-in accounts while this temporary tooling is enabled.
+                  Shows a floating panel on every page: regenerate today&apos;s puzzle, open the
+                  Visual Lab (pictogram / text / image / hybrid previews), unlock/replay the daily
+                  gate, and jump between play → locked → win/lose screens. Works for guests and
+                  signed-in accounts while this temporary tooling is enabled.
                 </p>
               </div>
               <Switch
@@ -364,6 +366,17 @@ export default function SettingsPage() {
                 }}
               />
             </div>
+            {devMode && (
+              <div className="mt-4 border-amber-500/20 border-t pt-4">
+                <Link
+                  className="inline-flex items-center gap-2 text-amber-800 text-sm underline-offset-2 hover:underline dark:text-amber-300"
+                  href="/dev/visual-lab"
+                >
+                  <Palette className="h-4 w-4" />
+                  Open Visual Lab — test pictogram / text / image generation
+                </Link>
+              </div>
+            )}
           </Card>
 
           {/* Gameplay */}

--- a/apps/web/src/components/DevToolsPanel.tsx
+++ b/apps/web/src/components/DevToolsPanel.tsx
@@ -10,6 +10,7 @@ import {
   ChevronUp,
   FlaskConical,
   Loader2,
+  Palette,
   RefreshCw,
   Trophy,
   Unlock,
@@ -190,6 +191,16 @@ export function DevToolsPanel() {
               Generate new puzzle
             </Button>
             <Button
+              className="h-8 w-full justify-start gap-2 border-amber-500/30 text-xs"
+              disabled={!!busy}
+              onClick={() => go("/dev/visual-lab")}
+              size="sm"
+              variant="outline"
+            >
+              <Palette className="h-3.5 w-3.5" />
+              Visual Lab (pictogram / text / image)
+            </Button>
+            <Button
               className="h-8 w-full justify-start gap-2 text-xs"
               disabled={!!busy || allowed === false}
               onClick={() => void runAction("clear-attempts", "/")}
@@ -259,6 +270,7 @@ export function DevToolsPanel() {
                 [
                   ["/", "Home"],
                   ["/?preview=true", "Preview"],
+                  ["/dev/visual-lab", "Visual Lab"],
                   ["/game-over", "Game over"],
                   ["/leaderboard", "Board"],
                   ["/settings", "Settings"],

--- a/apps/web/src/components/DevVisualLab.tsx
+++ b/apps/web/src/components/DevVisualLab.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+/**
+ * Dev Mode Visual Lab — generate and preview every visual generation path.
+ * Preview only; never publishes today's puzzle.
+ */
+
+import { FlaskConical, Loader2, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { PuzzleContainer, PuzzleDisplay } from "@/components/PuzzleDisplay";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { isDevModeEnabled } from "@/lib/dev-mode";
+import type { PuzzleVisual } from "@/lib/gameSettings";
+import { cn } from "@/lib/utils";
+
+type ModeMeta = {
+  id: string;
+  label: string;
+  description: string;
+  usesAi: boolean;
+  estimatedCost: string;
+};
+
+type LabResult = {
+  mode: string;
+  meta: {
+    label: string;
+    description: string;
+    durationMs: number;
+    usesAi: boolean;
+    estimatedCost: string;
+  };
+  visual?: PuzzleVisual;
+  pictogram?: {
+    ok: boolean;
+    concept: string;
+    svg: string | null;
+    emojiFallback: string;
+    error?: string;
+  };
+  image?: {
+    ok: boolean;
+    alt: string;
+    src?: string;
+    model?: string;
+    error?: string;
+  };
+  puzzle?: {
+    rebusPuzzle: string;
+    answer: string;
+    difficulty: number;
+    difficultyLevel: string;
+    explanation: string;
+    category: string;
+    hints: string[];
+    techniqueId?: string;
+    visual?: PuzzleVisual;
+    qualityScore?: number;
+    funScore?: number;
+  };
+  compose?: {
+    funScore: number;
+    totalParts: number;
+    withinBudget: boolean;
+    issues: string[];
+    tips: string[];
+    generated: {
+      pictograms: number;
+      images: number;
+      failedPictograms: number;
+      failedImages: number;
+    };
+  };
+};
+
+const FALLBACK_MODES: ModeMeta[] = [
+  {
+    id: "pictogram",
+    label: "Custom pictogram",
+    description: "Generate one Ink Pictogram v1 SVG (our branded emoji).",
+    usesAi: true,
+    estimatedCost: "low",
+  },
+  {
+    id: "text",
+    label: "Text devices",
+    description: "Styled text layers — large, strike, stacked, tiny (no AI).",
+    usesAi: false,
+    estimatedCost: "free",
+  },
+  {
+    id: "unicode",
+    label: "Unicode emoji",
+    description: "Stock emoji + operators board (legacy unicode path, no AI).",
+    usesAi: false,
+    estimatedCost: "free",
+  },
+  {
+    id: "image",
+    label: "Image tile",
+    description: "Single AI-illustrated square tile via image models.",
+    usesAi: true,
+    estimatedCost: "medium",
+  },
+  {
+    id: "hybrid",
+    label: "Hybrid board",
+    description: "Pictogram + text + optional image tile together.",
+    usesAi: true,
+    estimatedCost: "high",
+  },
+  {
+    id: "composed",
+    label: "Composed rebus",
+    description: "Multi-layer Ink Pictogram rebus with operators (no image).",
+    usesAi: true,
+    estimatedCost: "medium",
+  },
+  {
+    id: "full-puzzle",
+    label: "Full Eve puzzle",
+    description: "Run the full ToolLoopAgent once — preview only, not published.",
+    usesAi: true,
+    estimatedCost: "high",
+  },
+];
+
+export function DevVisualLab() {
+  const [devOn, setDevOn] = useState(false);
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [modes, setModes] = useState<ModeMeta[]>(FALLBACK_MODES);
+  const [mode, setMode] = useState("pictogram");
+  const [concept, setConcept] = useState("bee");
+  const [answer, setAnswer] = useState("before");
+  const [difficulty, setDifficulty] = useState(5);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<LabResult | null>(null);
+
+  useEffect(() => {
+    setDevOn(isDevModeEnabled());
+  }, []);
+
+  const loadModes = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dev/visual-lab", { credentials: "include" });
+      const data = (await res.json()) as {
+        allowed?: boolean;
+        modes?: ModeMeta[];
+        error?: string;
+      };
+      if (!res.ok || !data.allowed) {
+        setAllowed(false);
+        return;
+      }
+      setAllowed(true);
+      if (data.modes?.length) setModes(data.modes);
+    } catch {
+      setAllowed(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (devOn) void loadModes();
+  }, [devOn, loadModes]);
+
+  const generate = async (nextMode?: string) => {
+    const selected = nextMode || mode;
+    setMode(selected);
+    setBusy(true);
+    setError("");
+    setResult(null);
+    try {
+      const res = await fetch("/api/dev/visual-lab", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: selected,
+          concept,
+          answer,
+          difficulty,
+          renderImages: true,
+        }),
+      });
+      const data = (await res.json()) as {
+        success?: boolean;
+        result?: LabResult;
+        error?: string;
+      };
+      if (!res.ok || !data.success || !data.result) {
+        throw new Error(data.error || "Generation failed");
+      }
+      setResult(data.result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Generation failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!devOn) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+        <FlaskConical className="mx-auto mb-3 h-8 w-8 text-amber-600" />
+        <h1 className="font-semibold text-lg">Visual Lab</h1>
+        <p className="mt-2 text-muted-foreground text-sm">
+          Turn on Dev Mode in Settings to use the generative visual playground.
+        </p>
+        <Button asChild className="mt-6" variant="secondary">
+          <Link href="/settings">Open Settings</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const previewVisual = result?.visual || result?.puzzle?.visual;
+  const previewFallback = result?.puzzle?.rebusPuzzle || result?.visual?.unicodeFallback || concept;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      <div className="mb-8">
+        <div className="mb-2 flex items-center gap-2">
+          <FlaskConical className="h-5 w-5 text-amber-600" />
+          <h1 className="font-semibold text-base md:text-lg">Visual Lab</h1>
+          <span className="rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-[10px] text-amber-800 uppercase tracking-wide dark:text-amber-300">
+            Dev · preview only
+          </span>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          Exercise every generative path — custom pictograms, text devices, unicode emoji, image
+          tiles, hybrid boards, composed rebuses, or a full Eve puzzle. Nothing here replaces
+          today&apos;s published puzzle.
+        </p>
+      </div>
+
+      {allowed === false && (
+        <p className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive text-sm">
+          Sign in as guest or account to run generation.
+        </p>
+      )}
+
+      <div className="mb-6 grid gap-3 sm:grid-cols-2">
+        {modes.map((m) => {
+          const selected = mode === m.id;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              disabled={busy || allowed === false}
+              onClick={() => setMode(m.id)}
+              className={cn(
+                "rounded-lg border p-3 text-left transition-colors",
+                "hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                selected ? "border-amber-500/60 bg-amber-500/5" : "border-border bg-card"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-sm">{m.label}</span>
+                <span className="ml-auto text-[10px] uppercase tracking-wide text-subtle">
+                  {m.estimatedCost}
+                </span>
+              </div>
+              <p className="mt-1 text-muted-foreground text-xs leading-snug">{m.description}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mb-6 grid gap-4 sm:grid-cols-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="lab-concept">Concept</Label>
+          <Input
+            id="lab-concept"
+            value={concept}
+            onChange={(e) => setConcept(e.target.value)}
+            placeholder="bee"
+            disabled={busy}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="lab-answer">Sample answer</Label>
+          <Input
+            id="lab-answer"
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            placeholder="before"
+            disabled={busy}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="lab-difficulty">Difficulty (4–9)</Label>
+          <Input
+            id="lab-difficulty"
+            type="number"
+            min={4}
+            max={9}
+            value={difficulty}
+            onChange={(e) => setDifficulty(Number(e.target.value) || 5)}
+            disabled={busy}
+          />
+        </div>
+      </div>
+
+      <div className="mb-8 flex flex-wrap gap-2">
+        <Button
+          disabled={busy || allowed === false}
+          onClick={() => void generate()}
+          className="gap-2"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+          Generate {modes.find((m) => m.id === mode)?.label ?? mode}
+        </Button>
+        <Button asChild variant="outline" disabled={busy}>
+          <Link href="/">Back to game</Link>
+        </Button>
+      </div>
+
+      {error && (
+        <p className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive text-sm">
+          {error}
+        </p>
+      )}
+
+      {result && (
+        <div className="space-y-6">
+          <section>
+            <h2 className="mb-3 font-medium text-sm">Board preview</h2>
+            <PuzzleContainer>
+              <PuzzleDisplay
+                puzzle={previewFallback}
+                puzzleType="rebus"
+                visual={previewVisual}
+                size="large"
+              />
+            </PuzzleContainer>
+          </section>
+
+          <section className="grid gap-3 sm:grid-cols-2 text-xs">
+            <MetaCard
+              title="Run"
+              lines={[
+                `${result.meta.label} · ${result.meta.durationMs}ms`,
+                `AI: ${result.meta.usesAi ? "yes" : "no"} · cost ${result.meta.estimatedCost}`,
+                result.visual
+                  ? `visual.mode=${result.visual.mode} · layout=${result.visual.layout}`
+                  : "no composed visual",
+              ]}
+            />
+            {result.compose && (
+              <MetaCard
+                title="Compose score"
+                lines={[
+                  `funScore ${result.compose.funScore} · parts ${result.compose.totalParts}`,
+                  `budget ${result.compose.withinBudget ? "ok" : "off"}`,
+                  `pictograms ${result.compose.generated.pictograms} · images ${result.compose.generated.images}`,
+                  ...(result.compose.issues.length
+                    ? [`issues: ${result.compose.issues.join("; ")}`]
+                    : []),
+                ]}
+              />
+            )}
+            {result.pictogram && (
+              <MetaCard
+                title="Pictogram"
+                lines={[
+                  `${result.pictogram.ok ? "ok" : "failed"} · ${result.pictogram.concept}`,
+                  `fallback ${result.pictogram.emojiFallback}`,
+                  result.pictogram.error || (result.pictogram.svg ? "svg ready" : "no svg"),
+                ]}
+              />
+            )}
+            {result.image && (
+              <MetaCard
+                title="Image tile"
+                lines={[
+                  `${result.image.ok ? "ok" : "failed"} · ${result.image.alt}`,
+                  result.image.model || "no model",
+                  result.image.error || (result.image.src ? "src ready" : "no src"),
+                ]}
+              />
+            )}
+            {result.puzzle && (
+              <MetaCard
+                title="Eve puzzle (preview)"
+                lines={[
+                  `answer: ${result.puzzle.answer}`,
+                  `${result.puzzle.difficultyLevel} · d=${result.puzzle.difficulty}`,
+                  `q=${result.puzzle.qualityScore ?? "—"} · fun=${result.puzzle.funScore ?? "—"}`,
+                  result.puzzle.techniqueId || "no technique",
+                  result.puzzle.rebusPuzzle,
+                ]}
+              />
+            )}
+          </section>
+
+          {result.puzzle?.explanation && (
+            <section className="rounded-lg border border-border bg-inset p-4 text-sm">
+              <p className="mb-1 font-medium text-xs uppercase tracking-wide text-subtle">
+                Explanation
+              </p>
+              <p>{result.puzzle.explanation}</p>
+              {result.puzzle.hints?.length ? (
+                <ul className="mt-3 list-disc space-y-1 pl-5 text-muted-foreground text-xs">
+                  {result.puzzle.hints.map((h) => (
+                    <li key={h}>{h}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          )}
+
+          <details className="rounded-lg border border-border bg-muted/30 p-3 text-xs">
+            <summary className="cursor-pointer font-medium">Raw JSON</summary>
+            <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-all font-mono text-[10px] leading-relaxed">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </details>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetaCard({ title, lines }: { title: string; lines: string[] }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <p className="mb-1.5 font-medium text-[10px] uppercase tracking-wide text-subtle">{title}</p>
+      <ul className="space-y-1 text-foreground/85">
+        {lines.map((line) => (
+          <li key={line} className="break-words">
+            {line}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Dev Mode Visual Lab** so you can test every generative visual path without replacing today’s published puzzle.

### How to use
1. Settings → enable **Dev Mode**
2. Open **Visual Lab** from the floating panel, Settings link, or `/dev/visual-lab`
3. Pick a mode → Generate → preview the board

### Modes
| Mode | What it tests |
| --- | --- |
| Custom pictogram | Ink Pictogram v1 SVG (“our emoji”) |
| Text devices | large / strike / stacked / tiny (no AI) |
| Unicode emoji | Legacy stock-emoji board (no AI) |
| Image tile | AI Gateway image model tile |
| Hybrid board | Pictogram + text + image |
| Composed rebus | Multi-layer pictogram rebus |
| Full Eve puzzle | One ToolLoopAgent run — **preview only** |

### API
- `GET/POST /api/dev/visual-lab` — guest/signed-in OK (same gate as other Dev Mode actions)
- Response always `published: false`

### Testing
- `npm test -- --testPathPatterns=lab-recipes`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

