### PR TITLE
Fix guest session errors on answer submit + signup CTA

### DIFF
--- a/apps/web/src/app/actions/gameActions.ts
+++ b/apps/web/src/app/actions/gameActions.ts
@@ -3,12 +3,11 @@
 import { cookies } from "next/headers";
 import { db } from "@/db";
 import { isAdmin } from "@/lib/admin-auth";
+import { AUTH_COOKIE_NAME, LEGACY_AUTH_COOKIE_NAME } from "@/lib/cookies";
 import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
 import { verifyToken } from "@/lib/jwt";
 import type { GameData, PuzzleMetadata, PuzzleType, PuzzleVisual } from "../../lib/gameSettings";
 import { getTodaysPuzzle } from "./puzzleGenerationActions";
-
-const AUTH_COOKIE = "rebuzzle_auth";
 
 /** Shape returned by getTodaysPuzzle (cached DB hit or generated/fallback). */
 type TodaysPuzzle = {
@@ -33,7 +32,8 @@ type TodaysPuzzle = {
 async function getCurrentUserId(): Promise<string | null> {
   try {
     const cookieStore = await cookies();
-    const authToken = cookieStore.get(AUTH_COOKIE)?.value;
+    const authToken =
+      cookieStore.get(AUTH_COOKIE_NAME)?.value || cookieStore.get(LEGACY_AUTH_COOKIE_NAME)?.value;
 
     if (!authToken) {
       return null;

--- a/apps/web/src/app/api/auth/guest/lazy/route.ts
+++ b/apps/web/src/app/api/auth/guest/lazy/route.ts
@@ -13,7 +13,8 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { userOps, userStatsOps } from "@/db/operations";
-import { signToken } from "@/lib/jwt";
+import { AUTH_COOKIE_NAME, LEGACY_AUTH_COOKIE_NAME, setAuthCookie } from "@/lib/cookies";
+import { signToken, verifyToken } from "@/lib/jwt";
 import { rateLimiters } from "@/lib/middleware/rate-limit";
 import {
   extractClientIp,
@@ -23,7 +24,6 @@ import {
 } from "@/lib/services/guest-identification";
 
 const GUEST_TOKEN_COOKIE = "rebuzzle_guest_token";
-const AUTH_COOKIE = "rebuzzle_auth";
 
 export async function POST(request: Request) {
   try {
@@ -36,15 +36,31 @@ export async function POST(request: Request) {
     }
 
     const cookieStore = await cookies();
-    const existingAuthToken = cookieStore.get(AUTH_COOKIE)?.value;
+    const existingAuthToken =
+      cookieStore.get(AUTH_COOKIE_NAME)?.value || cookieStore.get(LEGACY_AUTH_COOKIE_NAME)?.value;
 
-    // If user has an auth token, verify and return existing user
+    // Valid existing session → return the user (don't fail the client)
     if (existingAuthToken) {
-      return NextResponse.json({
-        success: false,
-        message: "User is already authenticated",
-        isAuthenticated: true,
-      });
+      const payload = await verifyToken(existingAuthToken);
+      if (payload?.userId) {
+        const existingUser = await userOps.findById(payload.userId);
+        if (existingUser) {
+          const isGuest = Boolean(
+            existingUser.isGuest || existingUser.email?.endsWith("@guest.rebuzzle.local")
+          );
+          return NextResponse.json({
+            success: true,
+            alreadyAuthenticated: true,
+            user: {
+              id: existingUser.id,
+              username: existingUser.username,
+              email: existingUser.email,
+              isGuest,
+            },
+          });
+        }
+      }
+      // Expired / invalid token — fall through and issue a fresh guest session
     }
 
     // Get identification inputs
@@ -82,11 +98,7 @@ export async function POST(request: Request) {
       // Create new guest user with IP binding
       const newGuestToken = crypto.randomUUID();
 
-      guestUser = await userOps.createGuestUserWithIp(
-        newGuestToken,
-        ipHash,
-        deviceId || undefined
-      );
+      guestUser = await userOps.createGuestUserWithIp(newGuestToken, ipHash, deviceId || undefined);
 
       // Initialize user stats for the guest
       await initializeGuestStats(guestUser.id);
@@ -121,13 +133,8 @@ export async function POST(request: Request) {
       path: "/",
     });
 
-    response.cookies.set(AUTH_COOKIE, jwt, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 60 * 60 * 24 * 365, // 1 year for guests
-      path: "/",
-    });
+    // Canonical auth cookie (also clears legacy auth_token)
+    setAuthCookie(response, jwt);
 
     return response;
   } catch (error) {

--- a/apps/web/src/app/api/auth/signup/route.ts
+++ b/apps/web/src/app/api/auth/signup/route.ts
@@ -5,14 +5,13 @@ import { analyticsEventOps } from "@/db/analytics-ops";
 import type { NewEmailSubscription } from "@/db/models";
 import { getCollection } from "@/db/mongodb";
 import { createOrUpdateUser } from "@/lib/auth";
-import { SESSION_DURATION_DAYS } from "@/lib/cookies";
+import { setAuthCookie } from "@/lib/cookies";
 import { signToken } from "@/lib/jwt";
 import { rateLimiters } from "@/lib/middleware/rate-limit";
 import { sendSignupWelcomeEmail } from "@/lib/notifications/email-service";
 import { hashPassword } from "@/lib/password";
 
 const GUEST_TOKEN_COOKIE = "rebuzzle_guest_token";
-const AUTH_COOKIE = "rebuzzle_auth";
 
 export async function POST(request: Request) {
   // Rate limit signup attempts to prevent spam
@@ -246,14 +245,8 @@ export async function POST(request: Request) {
       convertedFromGuest,
     });
 
-    // Set auth cookie
-    response.cookies.set(AUTH_COOKIE, jwt, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: SESSION_DURATION_DAYS * 24 * 60 * 60, // Use shared session duration
-      path: "/",
-    });
+    // Set canonical auth cookie (also clears legacy auth_token)
+    setAuthCookie(response, jwt);
 
     // Clear guest token cookie (no longer needed)
     response.cookies.delete(GUEST_TOKEN_COOKIE);

--- a/apps/web/src/app/game-over/game-over-client.tsx
+++ b/apps/web/src/app/game-over/game-over-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Flame, TrendingUp, X } from "lucide-react";
+import { Check, Flame, TrendingUp, UserPlus, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
@@ -52,7 +52,8 @@ interface GameOverClientProps {
 }
 
 export default function GameOverClient({ gameData, searchParams: params }: GameOverClientProps) {
-  const { userId } = useAuth();
+  const { userId, isGuest, isAuthenticated, isLoading: authLoading } = useAuth();
+  const showSignupCta = !authLoading && (!isAuthenticated || isGuest || !userId);
   const [loading, setLoading] = useState(false);
   const [streak, setStreak] = useState(0);
   const [displayScore, setDisplayScore] = useState(0);
@@ -372,6 +373,34 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
                 </Button>
               </Link>
             </div>
+
+            {/* Guest → account CTA (after play, never blocks the win) */}
+            {showSignupCta && (
+              <div className="rounded-xl border border-border bg-inset px-5 py-5 text-center space-y-3">
+                <div className="mx-auto flex h-9 w-9 items-center justify-center rounded-full bg-foreground/5">
+                  <UserPlus className="h-4 w-4 text-foreground" />
+                </div>
+                <div className="space-y-1">
+                  <p className="font-medium text-foreground text-sm">Keep your streak going</p>
+                  <p className="text-muted-foreground text-xs leading-5">
+                    Create a free account to save progress across devices. You already played as a
+                    guest — signing up won&apos;t lose today&apos;s solve.
+                  </p>
+                </div>
+                <Link href="/signup" className="block">
+                  <Button className="w-full">Create a free account</Button>
+                </Link>
+                <p className="text-muted-foreground text-xs">
+                  Already have one?{" "}
+                  <Link
+                    className="text-foreground underline-offset-2 hover:underline"
+                    href="/login"
+                  >
+                    Sign in
+                  </Link>
+                </p>
+              </div>
+            )}
 
             {/* Countdown */}
             <div className="border-border border-t pt-6 text-center">

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -494,6 +494,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       try {
         const response = await fetch("/api/puzzles/guess", {
           method: "POST",
+          credentials: "include",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             puzzleId: gameData.id,

--- a/apps/web/src/lib/__tests__/cookies.test.ts
+++ b/apps/web/src/lib/__tests__/cookies.test.ts
@@ -1,0 +1,40 @@
+import {
+  AUTH_COOKIE_NAME,
+  getAuthTokenFromRequest,
+  LEGACY_AUTH_COOKIE_NAME,
+  parseCookieHeader,
+} from "../cookies";
+
+describe("auth cookies", () => {
+  it("parses cookie headers with equals in values", () => {
+    const parsed = parseCookieHeader("a=1; token=abc=def; b=2");
+    expect(parsed.a).toBe("1");
+    expect(parsed.token).toBe("abc=def");
+    expect(parsed.b).toBe("2");
+  });
+
+  it("prefers rebuzzle_auth over legacy auth_token", () => {
+    const request = new Request("https://example.com", {
+      headers: {
+        cookie: `${LEGACY_AUTH_COOKIE_NAME}=legacy; ${AUTH_COOKIE_NAME}=canonical`,
+      },
+    });
+    expect(getAuthTokenFromRequest(request)).toBe("canonical");
+  });
+
+  it("falls back to legacy auth_token", () => {
+    const request = new Request("https://example.com", {
+      headers: {
+        cookie: `${LEGACY_AUTH_COOKIE_NAME}=legacy-only`,
+      },
+    });
+    expect(getAuthTokenFromRequest(request)).toBe("legacy-only");
+  });
+
+  it("returns null when no auth cookie is present", () => {
+    const request = new Request("https://example.com", {
+      headers: { cookie: "other=1" },
+    });
+    expect(getAuthTokenFromRequest(request)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/auth/get-server-session.ts
+++ b/apps/web/src/lib/auth/get-server-session.ts
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers";
+import { AUTH_COOKIE_NAME, LEGACY_AUTH_COOKIE_NAME } from "@/lib/cookies";
 import { verifyToken } from "@/lib/jwt";
-
-const AUTH_COOKIE = "rebuzzle_auth";
 
 export type ServerSessionUser = {
   id: string;
@@ -25,7 +24,8 @@ export type ServerSession = {
 export async function getServerSession(): Promise<ServerSession> {
   try {
     const cookieStore = await cookies();
-    const authToken = cookieStore.get(AUTH_COOKIE)?.value;
+    const authToken =
+      cookieStore.get(AUTH_COOKIE_NAME)?.value || cookieStore.get(LEGACY_AUTH_COOKIE_NAME)?.value;
 
     if (!authToken) {
       return { authenticated: false, user: null };

--- a/apps/web/src/lib/cookies.ts
+++ b/apps/web/src/lib/cookies.ts
@@ -1,12 +1,18 @@
 /**
  * Cookie Utilities
  *
- * Secure cookie management for authentication tokens
+ * Secure cookie management for authentication tokens.
+ * Canonical cookie name: rebuzzle_auth (guests, signup, server session).
+ * Legacy auth_token is still read during migration.
  */
 
 import type { NextResponse } from "next/server";
 
-const AUTH_COOKIE_NAME = "auth_token";
+/** Canonical auth cookie — used by guests, signup, and server session seed */
+export const AUTH_COOKIE_NAME = "rebuzzle_auth";
+/** Legacy cookie name from older login path — still accepted when reading */
+export const LEGACY_AUTH_COOKIE_NAME = "auth_token";
+
 /**
  * Session duration in days - shared across JWT and cookies
  * Update this single value to change session length everywhere
@@ -15,64 +21,42 @@ export const SESSION_DURATION_DAYS = 7;
 const COOKIE_MAX_AGE = SESSION_DURATION_DAYS * 24 * 60 * 60; // Convert to seconds
 const isProduction = process.env.NODE_ENV === "production";
 
+function cookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    secure: isProduction,
+    // Lax matches guest/signup cookies and still blocks most CSRF
+    sameSite: "lax" as const,
+    maxAge,
+    path: "/",
+  };
+}
+
 /**
  * Set authentication cookie with secure settings
  */
 export function setAuthCookie(response: NextResponse, token: string): NextResponse {
-  const cookieOptions = [
-    `${AUTH_COOKIE_NAME}=${token}`,
-    "Path=/",
-    `Max-Age=${COOKIE_MAX_AGE}`,
-    "SameSite=Strict",
-    "HttpOnly",
-  ];
-
-  // Only set Secure flag in production (HTTPS required)
-  if (isProduction) {
-    cookieOptions.push("Secure");
-  }
-
-  response.headers.set("Set-Cookie", cookieOptions.join("; "));
-
+  response.cookies.set(AUTH_COOKIE_NAME, token, cookieOptions(COOKIE_MAX_AGE));
+  // Drop legacy cookie so only one session source remains
+  response.cookies.set(LEGACY_AUTH_COOKIE_NAME, "", cookieOptions(0));
   return response;
 }
 
 /**
- * Clear authentication cookie
+ * Clear authentication cookie(s)
  */
 export function clearAuthCookie(response: NextResponse): NextResponse {
-  const cookieOptions = [
-    `${AUTH_COOKIE_NAME}=`,
-    "Path=/",
-    "Max-Age=0",
-    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
-    "SameSite=Strict",
-    "HttpOnly",
-  ];
-
-  // Only set Secure flag in production
-  if (isProduction) {
-    cookieOptions.push("Secure");
-  }
-
-  response.headers.set("Set-Cookie", cookieOptions.join("; "));
-
+  response.cookies.set(AUTH_COOKIE_NAME, "", cookieOptions(0));
+  response.cookies.set(LEGACY_AUTH_COOKIE_NAME, "", cookieOptions(0));
   return response;
 }
 
-/**
- * Get authentication token from request cookies
- */
-export function getAuthTokenFromRequest(request: Request): string | null {
-  const cookieHeader = request.headers.get("cookie");
-  if (!cookieHeader) {
-    return null;
-  }
-
-  const cookies = cookieHeader.split(";").reduce(
+/** Parse Cookie header into a map */
+export function parseCookieHeader(cookieHeader: string | null): Record<string, string> {
+  if (!cookieHeader) return {};
+  return cookieHeader.split(";").reduce(
     (acc, cookie) => {
       const trimmed = cookie.trim();
-      // Handle cookie values that contain "=" (e.g., base64 encoded values)
       const eqIndex = trimmed.indexOf("=");
       if (eqIndex > 0) {
         const key = trimmed.substring(0, eqIndex);
@@ -85,6 +69,13 @@ export function getAuthTokenFromRequest(request: Request): string | null {
     },
     {} as Record<string, string>
   );
+}
 
-  return cookies[AUTH_COOKIE_NAME] || null;
+/**
+ * Get authentication token from request cookies.
+ * Prefers rebuzzle_auth, falls back to legacy auth_token.
+ */
+export function getAuthTokenFromRequest(request: Request): string | null {
+  const cookies = parseCookieHeader(request.headers.get("cookie"));
+  return cookies[AUTH_COOKIE_NAME] || cookies[LEGACY_AUTH_COOKIE_NAME] || null;
 }

--- a/apps/web/src/lib/hooks/useLazyGuest.ts
+++ b/apps/web/src/lib/hooks/useLazyGuest.ts
@@ -33,9 +33,7 @@ export function useLazyGuest(): LazyGuestResult {
     try {
       // Get localStorage backup ID if available
       const localStorageGuestId =
-        typeof window !== "undefined"
-          ? localStorage.getItem("rebuzzle_guest_id")
-          : null;
+        typeof window !== "undefined" ? localStorage.getItem("rebuzzle_guest_id") : null;
 
       // Call the lazy guest creation endpoint
       const response = await fetch("/api/auth/guest/lazy", {
@@ -46,16 +44,29 @@ export function useLazyGuest(): LazyGuestResult {
       });
 
       if (response.ok) {
-        const data = await response.json();
+        const data = (await response.json()) as {
+          success?: boolean;
+          user?: { id: string };
+          alreadyAuthenticated?: boolean;
+          isAuthenticated?: boolean;
+          error?: string;
+        };
         if (data.success && data.user) {
           // Store backup in localStorage
           if (typeof window !== "undefined") {
             localStorage.setItem("rebuzzle_guest_id", data.user.id);
           }
-          // Refresh auth context to pick up new session
+          // Refresh auth context to pick up new / existing session
           await refreshAuth();
           return true;
         }
+        // Legacy response shape — cookie already present
+        if (data.alreadyAuthenticated || data.isAuthenticated) {
+          await refreshAuth();
+          return true;
+        }
+        setError(data.error || "Failed to create guest session");
+        return false;
       }
 
       setError("Failed to create guest session");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Guests could play the board but hit **Session error** on every answer submit. Root cause was a cookie name split: guests/signup wrote `rebuzzle_auth`, while guess/session auth only read `auth_token`.

## Fixes
- Canonical auth cookie is now `rebuzzle_auth` everywhere (login, signup, guest, guess)
- Still accepts legacy `auth_token` when reading
- Lazy guest returns `{ success: true, user }` for valid existing sessions instead of failing the client
- Guess fetch sends `credentials: "include"`
- Success screen shows a **Create a free account** CTA for guests / unsigned-in players (after share, before countdown)

## Testing
- `npm test -- --testPathPatterns=cookies.test`
- Manual: play as guest → submit guesses → should score; win → see signup CTA at bottom
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

