### PR TITLE
Fix Dev Mode “Unauthenticated” AI Gateway errors on puzzle regenerate

### DIFF
--- a/apps/web/src/ai/__tests__/gateway-auth.test.ts
+++ b/apps/web/src/ai/__tests__/gateway-auth.test.ts
@@ -1,8 +1,17 @@
-import { ensureGatewayKey, getGatewayApiKey, looksLikeJwt } from "../gateway-auth";
+import {
+  ensureGatewayKey,
+  formatGatewayAuthError,
+  getGatewayApiKey,
+  getGatewayAuthDiagnostics,
+  isGatewayAuthError,
+  looksLikeJwt,
+} from "../gateway-auth";
 
 describe("AI Gateway auth sanitization", () => {
   const originalKey = process.env.AI_GATEWAY_API_KEY;
   const originalOidc = process.env.VERCEL_OIDC_TOKEN;
+  const originalVercel = process.env.VERCEL;
+  const originalVercelEnv = process.env.VERCEL_ENV;
 
   afterEach(() => {
     if (originalKey === undefined) {
@@ -14,6 +23,16 @@ describe("AI Gateway auth sanitization", () => {
       delete process.env.VERCEL_OIDC_TOKEN;
     } else {
       process.env.VERCEL_OIDC_TOKEN = originalOidc;
+    }
+    if (originalVercel === undefined) {
+      delete process.env.VERCEL;
+    } else {
+      process.env.VERCEL = originalVercel;
+    }
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
     }
   });
 
@@ -42,5 +61,40 @@ describe("AI Gateway auth sanitization", () => {
     expect(getGatewayApiKey()).toBeUndefined();
     expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();
     expect(process.env.VERCEL_OIDC_TOKEN).toBe(jwt);
+  });
+
+  it("reports missing auth off Vercel without a key", () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    delete process.env.VERCEL_OIDC_TOKEN;
+    delete process.env.VERCEL;
+    const d = getGatewayAuthDiagnostics();
+    expect(d.authPath).toBe("missing");
+    expect(d.likelyConfigured).toBe(false);
+    expect(formatGatewayAuthError(d)).toMatch(/AI_GATEWAY_API_KEY/);
+    expect(formatGatewayAuthError(d)).toMatch(/\.env\.local/);
+  });
+
+  it("points at Vercel project env when on Vercel without a key", () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    delete process.env.VERCEL_OIDC_TOKEN;
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "production";
+    const d = getGatewayAuthDiagnostics();
+    expect(d.authPath).toBe("oidc");
+    expect(d.likelyConfigured).toBe(true);
+    expect(formatGatewayAuthError({ ...d, apiKeyPresent: false })).toMatch(
+      /Project Settings/
+    );
+  });
+
+  it("detects gateway auth errors", () => {
+    expect(
+      isGatewayAuthError(
+        new Error(
+          "Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module."
+        )
+      )
+    ).toBe(true);
+    expect(isGatewayAuthError(new Error("Quality below threshold"))).toBe(false);
   });
 });

--- a/apps/web/src/ai/client.ts
+++ b/apps/web/src/ai/client.ts
@@ -12,12 +12,24 @@ import { generateText, type LanguageModel, Output, streamText } from "ai";
 import type { z } from "zod";
 import { AI_CONFIG, validateApiKeys } from "./config";
 import { AIError, AIProviderError, parseAIError, QuotaExceededError } from "./errors";
-import { ensureGatewayKey, getGatewayApiKey } from "./gateway-auth";
+import {
+  assertGatewayAuthConfigured,
+  ensureGatewayKey,
+  getGatewayApiKey,
+} from "./gateway-auth";
 import { enforceQuota } from "./quota-manager";
 
 export type ModelTier = "fast" | "smart" | "creative";
 
-export { ensureGatewayKey, getGatewayApiKey } from "./gateway-auth";
+export {
+  assertGatewayAuthConfigured,
+  ensureGatewayKey,
+  formatGatewayAuthError,
+  getGatewayApiKey,
+  getGatewayAuthDiagnostics,
+  isGatewayAuthError,
+  probeGatewayAuth,
+} from "./gateway-auth";
 
 /** Shared gateway provider — API key when present, else OIDC on Vercel. */
 export function getAiGateway() {
@@ -28,6 +40,7 @@ export function getAiGateway() {
 /** Resolve a gateway language model for a tier (primary only). */
 export function getGatewayModel(tier: ModelTier = "smart"): LanguageModel {
   ensureGatewayKey();
+  assertGatewayAuthConfigured();
   const validation = validateApiKeys();
   if (!validation.valid) {
     throw new Error(`Missing API keys: ${validation.missing.join(", ")}`);
@@ -92,6 +105,7 @@ export async function generateAIText(params: {
 }> {
   await enforceQuota();
   ensureGatewayKey();
+  assertGatewayAuthConfigured();
 
   const tier = params.modelType ?? "smart";
   const modelsToTry = getGatewayModelChain(tier);
@@ -141,6 +155,7 @@ export async function generateAIObject<T>(params: {
 }): Promise<T> {
   await enforceQuota();
   ensureGatewayKey();
+  assertGatewayAuthConfigured();
 
   const tier = params.modelType ?? "smart";
   const modelsToTry = getGatewayModelChain(tier);

--- a/apps/web/src/ai/errors.ts
+++ b/apps/web/src/ai/errors.ts
@@ -76,6 +76,25 @@ export function parseAIError(error: unknown): AIError {
   // Extract error message for quota detection
   const errorMessage = error instanceof Error ? error.message : String(error);
   const errorObj = error && typeof error === "object" ? (error as Record<string, unknown>) : null;
+  const errorName = error instanceof Error ? error.name : "";
+
+  // AI Gateway auth — surface actionable remediation (production wraps this as GatewayError)
+  if (
+    errorName === "GatewayAuthenticationError" ||
+    errorName === "GatewayError" ||
+    /unauthenticated/i.test(errorMessage) ||
+    /ai_gateway_api_key/i.test(errorMessage)
+  ) {
+    const onVercel = Boolean(process.env.VERCEL);
+    const remediation = onVercel
+      ? "Add AI_GATEWAY_API_KEY (vck_…) in Vercel → Project Settings → Environment Variables for Production and Preview, or enable Settings → Security → OIDC Federation."
+      : "Set AI_GATEWAY_API_KEY (vck_…) in apps/web/.env.local and restart the dev server.";
+    return new AIError(
+      `AI Gateway Unauthenticated. ${remediation} Learn more: https://ai-sdk.dev/unauthenticated-ai-gateway`,
+      "AUTH_ERROR",
+      401
+    );
+  }
 
   // Check for model not found errors (should trigger fallback to next model)
   if (

--- a/apps/web/src/ai/gateway-auth.ts
+++ b/apps/web/src/ai/gateway-auth.ts
@@ -4,7 +4,26 @@
  * Important: never promote VERCEL_OIDC_TOKEN into AI_GATEWAY_API_KEY.
  * The SDK authenticates API keys with authMethod "api-key" and OIDC with
  * authMethod "oidc". Stuffing a JWT into AI_GATEWAY_API_KEY breaks production.
+ *
+ * Production auth options:
+ * 1. Set AI_GATEWAY_API_KEY (vck_…) in Vercel Project Settings → Environment
+ *    Variables for Production AND Preview
+ * 2. Or enable Settings → Security → OIDC Federation (x-vercel-oidc-token)
+ *
+ * Local .env.local is NOT available on the live deployment.
  */
+
+export type GatewayAuthPath = "api-key" | "oidc" | "missing";
+
+export interface GatewayAuthDiagnostics {
+  apiKeyPresent: boolean;
+  oidcEnvPresent: boolean;
+  onVercel: boolean;
+  vercelEnv: string | null;
+  authPath: GatewayAuthPath;
+  /** True when we expect a gateway call to be able to authenticate. */
+  likelyConfigured: boolean;
+}
 
 /** True when a value looks like a JWT (OIDC), not a gateway API key. */
 export function looksLikeJwt(value: string): boolean {
@@ -37,4 +56,119 @@ export function getGatewayApiKey(): string | undefined {
   const key = process.env.AI_GATEWAY_API_KEY?.trim();
   if (!key || key === "undefined" || looksLikeJwt(key)) return undefined;
   return key;
+}
+
+export function getGatewayAuthDiagnostics(): GatewayAuthDiagnostics {
+  ensureGatewayKey();
+  const apiKey = getGatewayApiKey();
+  const onVercel = Boolean(process.env.VERCEL);
+  const oidcEnvPresent = Boolean(
+    process.env.VERCEL_OIDC_TOKEN && process.env.VERCEL_OIDC_TOKEN !== "undefined"
+  );
+  const authPath: GatewayAuthPath = apiKey ? "api-key" : onVercel ? "oidc" : "missing";
+
+  return {
+    apiKeyPresent: Boolean(apiKey),
+    oidcEnvPresent,
+    onVercel,
+    vercelEnv: process.env.VERCEL_ENV ?? null,
+    authPath,
+    // On Vercel, OIDC may arrive via x-vercel-oidc-token even when the env var
+    // is absent — treat onVercel without an api key as "maybe ok, probe later".
+    likelyConfigured: Boolean(apiKey) || onVercel,
+  };
+}
+
+/** User-facing remediation when gateway auth is missing or rejected. */
+export function formatGatewayAuthError(diagnostics?: GatewayAuthDiagnostics): string {
+  const d = diagnostics ?? getGatewayAuthDiagnostics();
+
+  if (!d.apiKeyPresent && !d.onVercel) {
+    return (
+      "AI Gateway is not authenticated. Set AI_GATEWAY_API_KEY (vck_…) in apps/web/.env.local " +
+      "and restart the dev server. Learn more: https://ai-sdk.dev/unauthenticated-ai-gateway"
+    );
+  }
+
+  if (!d.apiKeyPresent && d.onVercel) {
+    return (
+      "AI Gateway Unauthenticated on this Vercel deployment. " +
+      "Add AI_GATEWAY_API_KEY (vck_…) in Vercel → Project Settings → Environment Variables " +
+      "for Production and Preview (local .env.local is not used here), " +
+      "or enable Settings → Security → OIDC Federation. " +
+      "Learn more: https://ai-sdk.dev/unauthenticated-ai-gateway"
+    );
+  }
+
+  return (
+    "AI Gateway authentication failed. The configured AI_GATEWAY_API_KEY may be invalid or revoked, " +
+    "or OIDC Federation may be disabled. Check Vercel → AI Gateway → API Keys and " +
+    "Project Settings → Environment Variables. " +
+    "Learn more: https://ai-sdk.dev/unauthenticated-ai-gateway"
+  );
+}
+
+export function isGatewayAuthError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : "";
+  return (
+    name === "GatewayAuthenticationError" ||
+    name === "GatewayError" ||
+    /unauthenticated/i.test(message) ||
+    /ai_gateway_api_key/i.test(message) ||
+    /oidc token/i.test(message) ||
+    /x-vercel-oidc-token/i.test(message)
+  );
+}
+
+/**
+ * Throw a clear, actionable error when auth is obviously missing
+ * (no API key and not running on Vercel).
+ */
+export function assertGatewayAuthConfigured(): void {
+  const d = getGatewayAuthDiagnostics();
+  if (!d.likelyConfigured) {
+    throw new Error(formatGatewayAuthError(d));
+  }
+}
+
+export type GatewayAuthProbeResult =
+  | { ok: true; diagnostics: GatewayAuthDiagnostics; balance?: string }
+  | { ok: false; diagnostics: GatewayAuthDiagnostics; error: string };
+
+/**
+ * Live probe via gateway.getCredits(). Call before expensive generation in Dev Mode.
+ */
+export async function probeGatewayAuth(): Promise<GatewayAuthProbeResult> {
+  const diagnostics = getGatewayAuthDiagnostics();
+
+  if (!diagnostics.likelyConfigured) {
+    return {
+      ok: false,
+      diagnostics,
+      error: formatGatewayAuthError(diagnostics),
+    };
+  }
+
+  try {
+    // Lazy import avoids circular dependency with client.ts
+    const { getAiGateway } = await import("./client");
+    const credits = await getAiGateway().getCredits();
+    return {
+      ok: true,
+      diagnostics,
+      balance: credits.balance,
+    };
+  } catch (error) {
+    const base = isGatewayAuthError(error)
+      ? formatGatewayAuthError(diagnostics)
+      : error instanceof Error
+        ? error.message
+        : "AI Gateway probe failed";
+    return {
+      ok: false,
+      diagnostics,
+      error: base,
+    };
+  }
 }

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -8,7 +8,12 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Output, stepCountIs, ToolLoopAgent } from "ai";
-import { ensureGatewayKey, getAiGateway, getGatewayModelChain } from "../client";
+import {
+  assertGatewayAuthConfigured,
+  ensureGatewayKey,
+  getAiGateway,
+  getGatewayModelChain,
+} from "../client";
 import { AI_CONFIG } from "../config";
 import { enforceQuota } from "../quota-manager";
 import { getDifficultyLevelForScore } from "./difficulty-levels";
@@ -159,6 +164,7 @@ export async function runPuzzleAgentGeneration(
   params: PuzzleGenerationParams
 ): Promise<PuzzleAgentResult> {
   ensureGatewayKey();
+  assertGatewayAuthConfigured();
   await enforceQuota();
 
   const start = Date.now();

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -79,10 +79,11 @@ const FALLBACK_PUZZLES = [
 async function getOrGenerateDailyPuzzle(
   dateString: string,
   puzzleType?: string,
-  options?: { allowAiGenerate?: boolean }
+  options?: { allowAiGenerate?: boolean; failOnAiError?: boolean }
 ) {
   const allowAiGenerate = options?.allowAiGenerate !== false;
-  logger.info("Getting puzzle for date", { dateString, allowAiGenerate });
+  const failOnAiError = options?.failOnAiError === true;
+  logger.info("Getting puzzle for date", { dateString, allowAiGenerate, failOnAiError });
 
   // STEP 1: Cross-request cached DB read via Cache Components ("use cache")
   try {
@@ -300,6 +301,11 @@ async function getOrGenerateDailyPuzzle(
       }
     );
 
+    // Admin / Dev regenerate: surface the real failure instead of seeding a fallback.
+    if (failOnAiError) {
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+
     // STEP 4: AI failed — persist a deterministic fallback so guessing still works
     const [y, m, d] = dateString.split("-").map(Number);
     const dayOfYear = Math.floor(
@@ -358,7 +364,7 @@ async function getOrGenerateDailyPuzzle(
 export async function getTodaysPuzzle(
   puzzleType?: string,
   dateString?: string,
-  options?: { allowAiGenerate?: boolean }
+  options?: { allowAiGenerate?: boolean; failOnAiError?: boolean }
 ) {
   try {
     // Use provided date string or get today's date
@@ -379,6 +385,11 @@ export async function getTodaysPuzzle(
       "Error in getTodaysPuzzle",
       error instanceof Error ? error : new Error(String(error))
     );
+
+    // Dev/admin regenerate must not paper over AI Gateway auth failures.
+    if (options?.failOnAiError) {
+      throw error instanceof Error ? error : new Error(String(error));
+    }
 
     // Last resort — still persist so /api/puzzles/guess can resolve the id
     const lastResortPuzzle = FALLBACK_PUZZLES[0]!;

--- a/apps/web/src/app/actions/regeneratePuzzleActions.ts
+++ b/apps/web/src/app/actions/regeneratePuzzleActions.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { revalidateTag } from "next/cache";
+import { formatGatewayAuthError, isGatewayAuthError, probeGatewayAuth } from "@/ai/client";
+import { generateMasterPuzzle } from "@/ai/services/master-puzzle-orchestrator";
 import type { Puzzle } from "@/db/models";
 import { getCollection } from "@/db/mongodb";
 import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
-import { getTodaysPuzzle } from "./puzzleGenerationActions";
+import { persistDailyPuzzle } from "@/lib/game/persist-daily-puzzle";
 
 /**
  * Delete today's puzzle from the database (UTC day window only).
@@ -48,44 +50,97 @@ export async function deleteTodaysPuzzle(): Promise<{
   }
 }
 
+function calculateDailyDifficulty(date: Date): number {
+  const dayOfWeek = date.getUTCDay();
+  const difficulties = [5, 4, 6, 8, 7, 5, 4];
+  return difficulties[dayOfWeek] || 5;
+}
+
 /**
  * Regenerate today's puzzle (admin path only — callers must authorize).
+ * Generates via AI Gateway first; only swaps the DB row after a successful result.
  */
 export async function regenerateTodaysPuzzle(
   puzzleType?: string
 ): Promise<{ success: boolean; message: string; puzzle?: unknown }> {
   try {
+    const authProbe = await probeGatewayAuth();
+    if (!authProbe.ok) {
+      return {
+        success: false,
+        message: authProbe.error,
+      };
+    }
+
+    const dateKey = getUtcPuzzleDate();
+    const typeToUse = puzzleType || process.env.DEFAULT_PUZZLE_TYPE || "rebus";
+    const difficulty = calculateDailyDifficulty(new Date(`${dateKey}T00:00:00Z`));
+
+    // Generate BEFORE deleting so a failed run keeps the current daily puzzle.
+    const result = await generateMasterPuzzle({
+      targetDifficulty: difficulty,
+      requireNovelty: true,
+      qualityThreshold: 70,
+      maxAttempts: 4,
+      puzzleType: typeToUse,
+    });
+
+    const puzzleDisplay =
+      result.puzzle.visual?.unicodeFallback?.trim() || result.puzzle.rebusPuzzle;
+
     const deleteResult = await deleteTodaysPuzzle();
     if (!deleteResult.success) {
       return {
         success: false,
-        message: `Failed to delete old puzzle: ${deleteResult.message}`,
+        message: `Generated OK but failed to delete old puzzle: ${deleteResult.message}`,
       };
     }
 
-    const puzzleResult = await getTodaysPuzzle(puzzleType);
-
-    if (!(puzzleResult.success && puzzleResult.puzzle)) {
-      return {
-        success: false,
-        message: `Failed to generate new puzzle: ${
-          "error" in puzzleResult ? puzzleResult.error : "Unknown error"
-        }`,
-      };
-    }
-
-    const typeUsed = puzzleType || process.env.DEFAULT_PUZZLE_TYPE || "rebus";
+    const persisted = await persistDailyPuzzle({
+      dateString: dateKey,
+      puzzleDisplay,
+      puzzleType: typeToUse,
+      answer: result.puzzle.answer,
+      difficulty: result.puzzle.difficulty,
+      category: result.puzzle.category,
+      explanation: result.puzzle.explanation,
+      hints: result.puzzle.hints,
+      aiGenerated: true,
+      rebusPuzzle: typeToUse === "rebus" ? puzzleDisplay : undefined,
+      visual: result.puzzle.visual,
+      metadataExtra: {
+        regeneratedAt: new Date().toISOString(),
+        techniqueId: result.puzzle.techniqueId,
+        qualityScore: result.metadata.qualityMetrics?.scores?.overall,
+      },
+    });
 
     return {
       success: true,
-      message: `Successfully regenerated today's puzzle (type: ${typeUsed})`,
-      puzzle: puzzleResult.puzzle,
+      message: `Successfully regenerated today's puzzle (type: ${typeToUse})`,
+      puzzle: {
+        id: persisted.id,
+        puzzle: puzzleDisplay,
+        rebusPuzzle: typeToUse === "rebus" ? puzzleDisplay : undefined,
+        puzzleType: typeToUse,
+        difficulty: result.puzzle.difficulty,
+        answer: result.puzzle.answer,
+        explanation: result.puzzle.explanation,
+        hints: result.puzzle.hints,
+        visual: result.puzzle.visual,
+        date: dateKey,
+        aiGenerated: true,
+      },
     };
   } catch (error) {
     console.error("Error regenerating today's puzzle:", error);
     return {
       success: false,
-      message: error instanceof Error ? error.message : "Unknown error",
+      message: isGatewayAuthError(error)
+        ? formatGatewayAuthError()
+        : error instanceof Error
+          ? error.message
+          : "Unknown error",
     };
   }
 }

--- a/apps/web/src/app/api/dev/session/route.ts
+++ b/apps/web/src/app/api/dev/session/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { getGatewayAuthDiagnostics, probeGatewayAuth } from "@/ai/client";
 import { regenerateTodaysPuzzle } from "@/app/actions/regeneratePuzzleActions";
 import { db } from "@/db";
 import { getAuthenticatedUser } from "@/lib/auth-middleware";
@@ -36,6 +37,7 @@ export async function GET(request: Request) {
         })
       : null,
     lock,
+    gateway: getGatewayAuthDiagnostics(),
   });
 }
 
@@ -112,11 +114,31 @@ export async function POST(request: Request) {
     }
 
     if (action === "regenerate") {
+      // Fail fast with an actionable message before deleting today's puzzle
+      const authProbe = await probeGatewayAuth();
+      if (!authProbe.ok) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: authProbe.error,
+            gateway: authProbe.diagnostics,
+          },
+          { status: 503 }
+        );
+      }
+
       // Clear personal lock so the new puzzle is immediately playable
       await db.puzzleAttemptOps.clearAttemptsForDate(userId, puzzleDate);
       const result = await regenerateTodaysPuzzle(body.puzzleType || undefined);
       if (!result.success) {
-        return NextResponse.json({ success: false, error: result.message }, { status: 500 });
+        return NextResponse.json(
+          {
+            success: false,
+            error: result.message,
+            gateway: getGatewayAuthDiagnostics(),
+          },
+          { status: 500 }
+        );
       }
 
       return NextResponse.json({
@@ -126,6 +148,7 @@ export async function POST(request: Request) {
         puzzle: result.puzzle
           ? toPublicPuzzle(result.puzzle as Record<string, unknown>)
           : undefined,
+        gateway: authProbe.diagnostics,
       });
     }
 

--- a/apps/web/src/app/api/dev/visual-lab/route.ts
+++ b/apps/web/src/app/api/dev/visual-lab/route.ts
@@ -4,7 +4,12 @@
  */
 
 import { NextResponse } from "next/server";
-import { ensureGatewayKey, getGatewayApiKey } from "@/ai/client";
+import {
+  formatGatewayAuthError,
+  getGatewayAuthDiagnostics,
+  isGatewayAuthError,
+  probeGatewayAuth,
+} from "@/ai/client";
 import {
   isVisualLabMode,
   VISUAL_LAB_MODE_META,
@@ -19,21 +24,11 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: false, allowed: false }, { status: 401 });
   }
 
-  ensureGatewayKey();
-  const apiKey = getGatewayApiKey();
-
   return NextResponse.json({
     success: true,
     allowed: true,
     modes: VISUAL_LAB_MODES.map((id) => VISUAL_LAB_MODE_META[id]),
-    gateway: {
-      apiKeyPresent: Boolean(apiKey),
-      oidcEnvPresent: Boolean(process.env.VERCEL_OIDC_TOKEN),
-      onVercel: Boolean(process.env.VERCEL),
-      vercelEnv: process.env.VERCEL_ENV ?? null,
-      /** Prefer api key locally; on Vercel OIDC works without a key */
-      authPath: apiKey ? "api-key" : process.env.VERCEL ? "oidc" : "missing",
-    },
+    gateway: getGatewayAuthDiagnostics(),
   });
 }
 
@@ -65,6 +60,18 @@ export async function POST(request: Request) {
       );
     }
 
+    const authProbe = await probeGatewayAuth();
+    if (!authProbe.ok) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: authProbe.error,
+          gateway: authProbe.diagnostics,
+        },
+        { status: 503 }
+      );
+    }
+
     const difficulty =
       typeof body.difficulty === "number" && Number.isFinite(body.difficulty)
         ? body.difficulty
@@ -83,15 +90,23 @@ export async function POST(request: Request) {
       /** Explicit: never writes to the daily puzzle catalog */
       published: false,
       result,
+      gateway: authProbe.diagnostics,
     });
   } catch (error) {
     console.error("[dev/visual-lab]", error);
+    const diagnostics = getGatewayAuthDiagnostics();
+    const message = isGatewayAuthError(error)
+      ? formatGatewayAuthError(diagnostics)
+      : error instanceof Error
+        ? error.message
+        : "Visual lab generation failed";
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : "Visual lab generation failed",
+        error: message,
+        gateway: diagnostics,
       },
-      { status: 500 }
+      { status: isGatewayAuthError(error) ? 503 : 500 }
     );
   }
 }

--- a/apps/web/src/components/DevToolsPanel.tsx
+++ b/apps/web/src/components/DevToolsPanel.tsx
@@ -37,6 +37,7 @@ export function DevToolsPanel() {
   const [busy, setBusy] = useState<string | null>(null);
   const [status, setStatus] = useState<string>("");
   const [lockInfo, setLockInfo] = useState<string>("");
+  const [gatewayInfo, setGatewayInfo] = useState<string>("");
 
   useEffect(() => {
     const sync = () => setEnabled(isDevModeEnabled());
@@ -61,10 +62,17 @@ export function DevToolsPanel() {
         lock?: { hasAttempt?: boolean; wasSuccessful?: boolean };
         puzzle?: { id?: string; puzzle?: string };
         puzzleDate?: string;
+        gateway?: {
+          authPath?: string;
+          apiKeyPresent?: boolean;
+          onVercel?: boolean;
+          likelyConfigured?: boolean;
+        };
       };
       if (!res.ok || !data.allowed) {
         setAllowed(false);
         setLockInfo("Sign in as guest or account to use Dev Mode actions");
+        setGatewayInfo("");
         return;
       }
       setAllowed(true);
@@ -78,9 +86,20 @@ export function DevToolsPanel() {
           data.puzzle?.id ? ` · ${data.puzzle.id.slice(0, 8)}…` : " · no puzzle"
         }`
       );
+      if (data.gateway) {
+        const g = data.gateway;
+        setGatewayInfo(
+          g.likelyConfigured
+            ? `AI Gateway · ${g.authPath ?? "?"}${g.apiKeyPresent ? " · key" : ""}${
+                g.onVercel ? " · vercel" : ""
+              }`
+            : "AI Gateway · NOT CONFIGURED — set AI_GATEWAY_API_KEY on Vercel"
+        );
+      }
     } catch {
       setAllowed(false);
       setLockInfo("Could not reach Dev API");
+      setGatewayInfo("");
     }
   }, []);
 
@@ -165,6 +184,18 @@ export function DevToolsPanel() {
           <p className="rounded-md bg-muted/80 px-2 py-1.5 font-mono text-[10px] text-foreground/80">
             {lockInfo || (allowed === null ? "Checking access…" : "—")}
           </p>
+          {gatewayInfo && (
+            <p
+              className={cn(
+                "rounded-md px-2 py-1.5 font-mono text-[10px]",
+                gatewayInfo.includes("NOT CONFIGURED")
+                  ? "bg-destructive/10 text-destructive"
+                  : "bg-muted/60 text-foreground/70"
+              )}
+            >
+              {gatewayInfo}
+            </p>
+          )}
 
           {allowed === false && (
             <p className="text-destructive text-[11px]">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Dev Mode **Generate new puzzle** fails on the live site with:

```
Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module.
```

Root cause: the deployed Vercel environment is not authenticating to AI Gateway. Local `.env.local` has a working `AI_GATEWAY_API_KEY` (`vck_…`, credits probe OK), but that file is not available on Production/Preview. OIDC only works if Project Settings → Security → OIDC Federation is enabled.

## Code changes

- Gateway auth diagnostics + live `getCredits()` probe before Dev regenerate / Visual Lab
- Actionable error text that points at Vercel Project env vars (not local `.env.local`)
- Regenerate now **generates first, then swaps** the daily row (failed runs no longer delete today’s puzzle)
- Dev Mode panel shows gateway auth status
- Auth failures are classified in `parseAIError` with remediation

## Required ops step (needed for the live site)

In **Vercel → Project → Settings → Environment Variables**, set for **Production** and **Preview**:

```
AI_GATEWAY_API_KEY=<your vck_ key from AI Gateway>
```

Or enable **Settings → Security → OIDC Federation**.

I could not set this from the agent (Vercel MCP needs desktop auth; no `VERCEL_TOKEN` in the environment).

## Test plan

- [x] `pnpm test -- src/ai/__tests__/gateway-auth.test.ts`
- [x] Local gateway `getCredits()` succeeds with `.env.local` key
- [ ] After merge + setting the Vercel env var: Dev Mode → Generate new puzzle on production
- [ ] Visual Lab AI modes still work when key is present

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

