### PR TITLE
Menus: one item recipe, real touch targets, and a coherent 8-bit skin

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -153,10 +153,13 @@
     --accent: 0 0% 97%;
     --accent-foreground: 0 0% 21%;
 
-    --border: 0 0% 70%;
-    --border-strong: 0 0% 20%;
-    --input: 0 0% 70%;
-    --ring: 0 0% 40%;
+    /* Hairlines are the same ink as the chunky inset ring below. When they
+       were a mid grey, every raised element showed a grey 1px line sitting
+       just inside a black 2px ring — one muddy edge instead of one clean one. */
+    --border: 0 0% 15%;
+    --border-strong: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 15%;
 
     --link: 212 100% 42%;
     --link-deep: 212 100% 36%;
@@ -204,10 +207,10 @@
     --accent: 0 0% 27%;
     --accent-foreground: 0 0% 98%;
 
-    --border: 0 0% 45%;
-    --border-strong: 0 0% 80%;
-    --input: 0 0% 45%;
-    --ring: 0 0% 70%;
+    --border: 0 0% 92%;
+    --border-strong: 0 0% 92%;
+    --input: 0 0% 92%;
+    --ring: 0 0% 92%;
 
     --link: 212 100% 65%;
     --link-deep: 212 100% 72%;
@@ -246,11 +249,8 @@
     line-height: 1.4;
   }
 
-  html[data-skin="8bit"] :focus-visible {
-    outline-width: 3px;
-    outline-offset: 2px;
-    border-radius: 0;
-  }
+  /* The skin's focus treatment lives in the utilities layer instead — it has
+     to outrank `.focus-ring`, which is a utility. See "8-BIT SKIN OVERRIDES". */
 }
 
 @layer base {
@@ -382,6 +382,100 @@
   .focus-ring:focus-visible {
     outline: none;
     box-shadow: 0 0 0 1px var(--focus-edge), 0 0 0 4px var(--focus-halo);
+  }
+
+  /* ============================================================
+     OVERLAY ERGONOMICS
+     Menus, selects and their items, wherever they are portalled to.
+     ============================================================ */
+
+  /*
+   * Coarse pointers get real touch targets.
+   *
+   * These are matched on ARIA roles rather than component classes because the
+   * panels are portalled to <body>, so they sit outside any container a page
+   * could style, and every menu-like surface in the app already reports the
+   * right role.
+   */
+  @media (pointer: coarse) {
+    [role="menu"] [role="menuitem"],
+    [role="menu"] [role="menuitemcheckbox"],
+    [role="menu"] [role="menuitemradio"],
+    [role="listbox"] [role="option"] {
+      min-height: 44px;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+      font-size: 0.9375rem;
+    }
+
+    /* Separators need to read at arm's length, not at laptop distance. */
+    [role="menu"] [role="separator"],
+    [role="listbox"] [role="separator"] {
+      margin-top: 0.375rem;
+      margin-bottom: 0.375rem;
+    }
+  }
+
+  /* Momentum scrolling for the rare menu long enough to need it. */
+  [role="menu"],
+  [role="listbox"] {
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* ============================================================
+     8-BIT SKIN OVERRIDES
+     These have to live in the utilities layer: each one competes with a
+     single-class Tailwind utility, and layer order beats specificity, so the
+     same rules in @layer base would silently lose.
+     ============================================================ */
+
+  /*
+   * Square corners are the whole point of the skin, and `--radius: 0` alone
+   * does not get there: `rounded-full` avatars, the marketing pill and the
+   * `rounded-xl`/`2xl` card sizes are all fixed values that ignore the token.
+   * One rounded pill in a pixel UI reads as a bug, so the geometry is reset
+   * outright rather than chased value by value.
+   *
+   * Tracking goes with it. Press Start 2P is a fixed bitmap face that is
+   * already generously spaced; the display tracking and the mono-caps eyebrows
+   * both push it into overflowing its container.
+   */
+  html[data-skin="8bit"] *,
+  html[data-skin="8bit"] *::before,
+  html[data-skin="8bit"] *::after {
+    border-radius: 0 !important;
+    letter-spacing: 0 !important;
+  }
+
+  /* Restore the hard pixel outline in place of the soft halo. */
+  html[data-skin="8bit"] :focus-visible {
+    outline: 3px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
+  /*
+   * `.focus-ring` draws its ring as a box-shadow, so the halo has to be
+   * cleared for the outline above to be the only ring. Note the tight scope:
+   * clearing box-shadow on every `:focus-visible` element instead also erased
+   * the drop shadow of open menus, because Radix moves focus onto the panel.
+   */
+  html[data-skin="8bit"] .focus-ring:focus-visible {
+    outline: 3px solid hsl(var(--ring));
+    outline-offset: 2px;
+    box-shadow: none;
+  }
+
+  /*
+   * Press Start 2P runs roughly twice the advance width of Geist, so panels
+   * sized for a proportional face wrap every other row. Widths are in px on
+   * purpose: the skin drops the root font size to 12px, which would quietly
+   * shrink any rem-based minimum by a quarter.
+   */
+  html[data-skin="8bit"] [role="menu"],
+  html[data-skin="8bit"] [role="listbox"] {
+    width: auto;
+    min-width: 260px;
+    max-width: calc(100vw - 24px);
   }
 
   .shadow-border {

--- a/apps/web/src/components/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu.tsx
@@ -102,7 +102,7 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
             <ChevronDown className="h-3.5 w-3.5 text-subtle transition-transform group-data-[state=open]:rotate-180" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuContent align="end" className="w-64">
           <div className="flex items-center gap-3 px-2 py-3">
             <Avatar className="h-10 w-10">
               <AvatarFallback
@@ -147,13 +147,6 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
           >
             <Trophy className="h-4 w-4" />
             Leaderboard
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer gap-2"
-            onClick={() => router.push("/settings")}
-          >
-            <Settings className="h-4 w-4" />
-            Settings
           </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer gap-2"
@@ -204,7 +197,7 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
             <ChevronDown className="h-3.5 w-3.5 text-subtle transition-transform group-data-[state=open]:rotate-180" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuContent align="end" className="w-64">
           <div className="px-2 py-3">
             <p className="font-medium text-sm">Welcome</p>
             <p className="text-muted-foreground text-xs">Sign in to track your progress</p>
@@ -295,7 +288,7 @@ export function UserMenu({ isAuthenticated }: UserMenuProps) {
           <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent align="end" className="w-64">
         {/* User info header */}
         <div className="flex items-center gap-3 px-2 py-3">
           <div className="relative">

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -6,6 +6,41 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * One recipe for every row in a menu.
+ *
+ * Plain items, checkbox items, radio items and submenu triggers all share it,
+ * so a single menu can never end up mixing two text colours or two corner
+ * radii — which is exactly what happened while only some of these were
+ * restyled.
+ *
+ * `focus:` is the state Radix sets when a row is highlighted by keyboard or
+ * mouse. `active:` is there for touch: Radix drives highlighting from
+ * `pointermove`, which a finger never fires, so without it a tap gets no
+ * feedback at all between touching a row and the menu closing.
+ */
+const menuItemClass = cn(
+  "relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-muted-foreground text-sm outline-none transition-colors",
+  "focus:bg-muted focus:text-foreground",
+  "active:bg-muted active:text-foreground",
+  "data-[state=open]:bg-muted data-[state=open]:text-foreground",
+  "data-[disabled]:pointer-events-none data-[disabled]:opacity-40",
+  "[&>svg]:size-4 [&>svg]:shrink-0"
+);
+
+/**
+ * Shared chrome for the floating panel itself. `origin-*` makes the open/close
+ * zoom scale out of the trigger rather than the panel's own centre, and the
+ * available-height cap keeps a long menu scrollable instead of running off the
+ * bottom of a short viewport.
+ */
+const menuSurfaceClass = cn(
+  "z-50 min-w-[8rem] max-w-[calc(100vw-1.5rem)] overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-menu",
+  "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+  "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+  "data-[state=closed]:animate-out data-[state=open]:animate-in"
+);
+
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
@@ -25,16 +60,12 @@ const DropdownMenuSubTrigger = React.forwardRef<
   }
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
-    className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
-      className
-    )}
+    className={cn(menuItemClass, inset && "pl-8", className)}
     ref={ref}
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto" />
+    <ChevronRight className="ml-auto size-4 shrink-0 opacity-60" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
@@ -45,7 +76,8 @@ const DropdownMenuSubContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     className={cn(
-      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-menu data-[state=closed]:animate-out data-[state=open]:animate-in",
+      menuSurfaceClass,
+      "max-h-[var(--radix-dropdown-menu-content-available-height)] origin-[var(--radix-dropdown-menu-content-transform-origin)]",
       className
     )}
     ref={ref}
@@ -57,14 +89,15 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 6, collisionPadding = 12, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-menu",
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=open]:animate-in",
+        menuSurfaceClass,
+        "max-h-[var(--radix-dropdown-menu-content-available-height)] origin-[var(--radix-dropdown-menu-content-transform-origin)]",
         className
       )}
+      collisionPadding={collisionPadding}
       ref={ref}
       sideOffset={sideOffset}
       {...props}
@@ -80,16 +113,16 @@ const DropdownMenuItem = React.forwardRef<
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
-    className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-muted-foreground text-sm transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-40 [&>svg]:size-4 [&>svg]:shrink-0",
-      inset && "pl-8",
-      className
-    )}
+    className={cn(menuItemClass, inset && "pl-8", className)}
     ref={ref}
     {...props}
   />
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+/** The indicator gutter shared by checkbox and radio rows. */
+const indicatorSlotClass =
+  "absolute left-2 flex size-4 items-center justify-center text-foreground";
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
@@ -97,16 +130,13 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 >(({ className, children, checked, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
     checked={checked}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
+    className={cn(menuItemClass, "pr-2 pl-8 data-[state=checked]:text-foreground", className)}
     ref={ref}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className={indicatorSlotClass}>
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-4" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -119,16 +149,13 @@ const DropdownMenuRadioItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
+    className={cn(menuItemClass, "pr-2 pl-8 data-[state=checked]:text-foreground", className)}
     ref={ref}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className={indicatorSlotClass}>
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="size-2 fill-current" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -144,7 +171,7 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     className={cn(
-      "px-2 py-1.5 font-mono text-[11px] text-subtle uppercase tracking-[0.08em]",
+      "select-none px-2 pt-2 pb-1 font-mono text-[11px] text-subtle uppercase tracking-[0.08em]",
       inset && "pl-8",
       className
     )}
@@ -167,7 +194,10 @@ const DropdownMenuSeparator = React.forwardRef<
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
-  <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  <span
+    className={cn("ml-auto font-mono text-[11px] text-subtle tabular-nums", className)}
+    {...props}
+  />
 );
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -14,14 +14,15 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = "center", sideOffset = 6, collisionPadding = 12, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       align={align}
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-menu data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 max-w-[calc(100vw-1.5rem)] origin-[var(--radix-popover-content-transform-origin)] rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-menu data-[state=closed]:animate-out data-[state=open]:animate-in",
         className
       )}
+      collisionPadding={collisionPadding}
       ref={ref}
       sideOffset={sideOffset}
       {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -67,7 +67,7 @@ const SelectContent = React.forwardRef<
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-menu data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] max-w-[calc(100vw-1.5rem)] origin-[var(--radix-select-content-transform-origin)] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-menu data-[state=closed]:animate-out data-[state=open]:animate-in",
         position === "popper" &&
           "data-[side=left]:-translate-x-1 data-[side=top]:-translate-y-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1",
         className
@@ -98,7 +98,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     className={cn(
-      "px-2 py-1.5 font-mono text-[11px] text-subtle uppercase tracking-[0.08em]",
+      "select-none px-2 pt-2 pb-1 font-mono text-[11px] text-subtle uppercase tracking-[0.08em]",
       className
     )}
     ref={ref}
@@ -113,7 +113,9 @@ const SelectItem = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pr-8 pl-2 text-muted-foreground text-sm transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[state=checked]:text-foreground",
+      // Mirrors the dropdown item recipe, `active:` included — a select on a
+      // touch device has the same no-hover problem a menu does.
+      "relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pr-8 pl-2 text-muted-foreground text-sm outline-none transition-colors focus:bg-muted focus:text-foreground active:bg-muted active:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[state=checked]:text-foreground",
       className
     )}
     ref={ref}


### PR DESCRIPTION
## Dropdowns were half-restyled

`DropdownMenuItem` had been moved onto the system's recipe — `rounded-md`, `text-muted-foreground`, `focus:bg-muted`, `opacity-40` — but `SubTrigger`, `CheckboxItem` and `RadioItem` were left on shadcn's defaults: `rounded-sm`, `focus:bg-accent focus:text-accent-foreground`, `opacity-50`. A single menu could show two text colours and two corner radii at once, which is visible in the before shot below.

All four now share one `menuItemClass`, so this can't drift apart again. Checkbox and radio rows also pick up `data-[state=checked]:text-foreground`, matching how `SelectItem` already marked its selection.

## Menus behaved badly under a finger

- **No touch feedback at all.** Radix drives row highlighting from `pointermove`, which a finger never fires, so a tap went from "nothing" straight to "menu closed". Every row now carries an `active:` state alongside `focus:`.
- **32px rows.** Coarse pointers now get 44px targets and slightly larger type, matched on ARIA role rather than a class — the panels are portalled to `<body>`, so no page-level container can reach them.
- **Long menus clipped themselves.** Panels were `overflow-hidden` with no max-height; on a short viewport the bottom of the account menu was cut off and unreachable. They now cap to `--radix-*-content-available-height` and scroll. Verified at 390×420: previously clipped, now `scrollable: true` with nothing past the fold.
- Added `collisionPadding` and a `calc(100vw - 1.5rem)` max-width so a menu can't kiss the screen edge, and pinned the open/close zoom to the trigger via `--radix-*-content-transform-origin` instead of the panel's own centre.

`select.tsx` and `popover.tsx` got the same treatment so the three overlay surfaces stay in step.

## 8-bit skin

Four separate problems, all found by screenshotting the skin rather than reading it:

- **Focus was dead.** The skin set `outline-width: 3px`, but every control uses `.focus-ring`, which sets `outline: none` and draws a box-shadow. Focus rendered as a soft grey rounded halo on a square-cornered pixel UI. Now a hard ink outline.
- **`--radius: 0` never reached most of the chrome.** `rounded-full` avatars, the marketing pill and the fixed `xl`/`2xl` card radii don't derive from the token, so round elements survived in a pixel skin. Geometry is now reset outright, and tracking with it — Press Start 2P is already generously spaced, and the display tracking pushed labels out of their containers.
- **Muddy double edges.** Hairlines were mid grey (`0 0% 70%`) while the raised-element ring was ink, so every card showed a grey 1px line sitting just inside a black 2px ring. Both are ink now.
- **Menus wrapped every other row.** The pixel face runs roughly twice the advance width of Geist, so panels sized for a proportional face broke "Checkbox item" and "Submenu trigger" onto two lines. Menu widths in the skin are set in px on purpose — the skin drops the root to 12px, which would have quietly shrunk any rem minimum by a quarter.

## One bug worth calling out

My first pass wrote `html[data-skin="8bit"] :focus-visible { box-shadow: none }` to kill the halo. That also erased the drop shadow of every open menu, because Radix moves DOM focus onto the panel when it opens — the panel matched `:focus-visible`. Caught by probing computed styles (`menuShadow: "none"`), and the rule is now scoped to `.focus-ring` only, with a comment saying why.

## Also

Widened the account menu from `w-56` to `w-64` so the header and the three-column stats grid stop feeling cramped, and removed a duplicated **Settings** row from the guest menu.

## Verification

Production build compiles; `biome check` clean on all changed files. `tsc --noEmit` reports 94 errors, all pre-existing in `__tests__` files and none in anything touched here.

Screenshotted through a temporary harness route (deleted before commit) in both skins × light/dark × desktop/iPhone, with computed styles probed directly for the things a screenshot can't confirm — shadow composition, 44px row heights, and the scroll cap.

**Not verified:** no MongoDB in this sandbox, so these menus weren't exercised against a signed-in session with real stats. The shapes were reproduced from `UserMenu`'s markup rather than rendered from live data.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LM7suTxcGr9QWunHTTYWKD)_