### PR TITLE
Fix guest session failure when IP_HASH_SALT is missing

### DIFF
--- a/apps/web/src/app/api/auth/guest/lazy/route.ts
+++ b/apps/web/src/app/api/auth/guest/lazy/route.ts
@@ -138,9 +138,21 @@ export async function POST(request: Request) {
 
     return response;
   } catch (error) {
-    console.error("Lazy guest creation error:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Lazy guest creation error:", message, error);
     return NextResponse.json(
-      { success: false, error: "Failed to create guest session" },
+      {
+        success: false,
+        error: "Failed to create guest session",
+        // Surface a short hint in non-production / when clearly a config miss
+        detail:
+          process.env.NODE_ENV !== "production" ||
+          message.includes("IP_HASH_SALT") ||
+          message.includes("AUTH_SECRET") ||
+          message.includes("Mongo")
+            ? message.slice(0, 180)
+            : undefined,
+      },
       { status: 500 }
     );
   }

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -419,7 +419,8 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         if (!created) {
           toast({
             title: "Session error",
-            description: "Couldn't start your session. Please refresh and try again.",
+            description:
+              "Couldn't start your guest session. Check your connection, then refresh and try again.",
             variant: "destructive",
           });
           return;

--- a/apps/web/src/lib/services/__tests__/guest-identification.test.ts
+++ b/apps/web/src/lib/services/__tests__/guest-identification.test.ts
@@ -1,0 +1,31 @@
+import { hashIpAddress } from "../guest-identification";
+
+describe("hashIpAddress", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses IP_HASH_SALT when set", () => {
+    process.env.IP_HASH_SALT = "dedicated-salt";
+    process.env.AUTH_SECRET = "auth-secret";
+    const a = hashIpAddress("1.2.3.4");
+    const b = hashIpAddress("1.2.3.4");
+    expect(a).toBe(b);
+    expect(a).toHaveLength(64);
+  });
+
+  it("falls back to AUTH_SECRET instead of throwing in production", () => {
+    delete process.env.IP_HASH_SALT;
+    process.env.AUTH_SECRET = "auth-secret-fallback";
+    process.env.NODE_ENV = "production";
+    expect(() => hashIpAddress("8.8.8.8")).not.toThrow();
+    expect(hashIpAddress("8.8.8.8")).toHaveLength(64);
+  });
+
+  it("produces different hashes for different IPs", () => {
+    process.env.IP_HASH_SALT = "dedicated-salt";
+    expect(hashIpAddress("1.1.1.1")).not.toBe(hashIpAddress("2.2.2.2"));
+  });
+});

--- a/apps/web/src/lib/services/guest-identification.ts
+++ b/apps/web/src/lib/services/guest-identification.ts
@@ -27,27 +27,41 @@ export interface GuestIdentificationInput {
 }
 
 /**
+ * Resolve a salt for IP hashing without taking down guest auth.
+ * Prefer IP_HASH_SALT; fall back to AUTH_SECRET (already required for JWTs).
+ */
+function resolveIpHashSalt(): string {
+  const dedicated = process.env.IP_HASH_SALT?.trim();
+  if (dedicated) return dedicated;
+
+  const authSecret = process.env.AUTH_SECRET?.trim();
+  if (authSecret) {
+    console.warn(
+      "[guest-identification] IP_HASH_SALT missing — falling back to AUTH_SECRET. Set IP_HASH_SALT for a dedicated hash salt."
+    );
+    return authSecret;
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "IP_HASH_SALT (or AUTH_SECRET) is required in production for secure IP hashing. " +
+        "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\""
+    );
+  }
+
+  console.warn(
+    "[guest-identification] IP_HASH_SALT not set. Using development fallback. Set this in production!"
+  );
+  return "dev-only-salt";
+}
+
+/**
  * Hash IP address for privacy-safe storage
  * Uses SHA-256 with a salt to prevent reverse lookup
  */
 export function hashIpAddress(ip: string): string {
-  const salt = process.env.IP_HASH_SALT;
-  if (!salt) {
-    // In production, require a proper salt for security
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(
-        "IP_HASH_SALT environment variable is required in production for secure IP hashing. " +
-          "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\""
-      );
-    }
-    // In development, use a warning and fallback
-    console.warn(
-      "Warning: IP_HASH_SALT not set. Using development fallback. Set this in production!"
-    );
-  }
-  return createHash("sha256")
-    .update(`${salt || "dev-only-salt"}:${ip}`)
-    .digest("hex");
+  const salt = resolveIpHashSalt();
+  return createHash("sha256").update(`${salt}:${ip}`).digest("hex");
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Production `/api/auth/guest/lazy` was returning **500**, which surfaced as “Couldn't start your session” on guess submit.

### Cause
`hashIpAddress()` threw in production when `IP_HASH_SALT` was unset (confirmed missing from Vercel envs).

### Fix
- Fall back to `AUTH_SECRET` instead of hard-failing guest creation
- Added `IP_HASH_SALT` to Vercel Production / Preview / Development
- Better error logging on the lazy guest route

## Test plan
- [x] Unit tests for IP hash salt fallback
- [ ] Production `/api/auth/guest/lazy` returns 200
- [ ] Guest can submit an answer without Session error toast

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

