### PR TITLE
Add puzzle like/dislike learning for Dev Lab and game-over

### DIFF
--- a/apps/web/src/ai/learning/__tests__/puzzle-quality-vote.test.ts
+++ b/apps/web/src/ai/learning/__tests__/puzzle-quality-vote.test.ts
@@ -1,0 +1,58 @@
+import {
+  isPuzzleQualityVote,
+  mapPuzzleQualityVote,
+  qualityVotesToGuidance,
+} from "../puzzle-quality-vote";
+
+describe("puzzle quality vote", () => {
+  it("maps like/dislike to rating fields", () => {
+    expect(mapPuzzleQualityVote("like").rating).toBe(5);
+    expect(mapPuzzleQualityVote("like").metrics.creative).toBe(true);
+    expect(mapPuzzleQualityVote("dislike").rating).toBe(1);
+    expect(mapPuzzleQualityVote("dislike").metrics.boring).toBe(true);
+  });
+
+  it("validates vote strings", () => {
+    expect(isPuzzleQualityVote("like")).toBe(true);
+    expect(isPuzzleQualityVote("dislike")).toBe(true);
+    expect(isPuzzleQualityVote("meh")).toBe(false);
+  });
+
+  it("turns aggregates into prefer/avoid guidance", () => {
+    const liked = qualityVotesToGuidance({
+      likes: 12,
+      dislikes: 2,
+      total: 14,
+      likeRate: 12 / 14,
+      likedTechniques: ["homophone"],
+      dislikedTechniques: [],
+      notes: [],
+    });
+    expect(liked.preferPatterns.length).toBeGreaterThan(0);
+    expect(liked.preferPatterns.some((p) => p.includes("homophone"))).toBe(true);
+
+    const disliked = qualityVotesToGuidance({
+      likes: 2,
+      dislikes: 10,
+      total: 12,
+      likeRate: 2 / 12,
+      likedTechniques: [],
+      dislikedTechniques: ["emoji_sum"],
+      notes: [],
+    });
+    expect(disliked.avoidPatterns.length).toBeGreaterThan(0);
+    expect(disliked.avoidPatterns.some((p) => p.includes("emoji_sum"))).toBe(true);
+
+    const thin = qualityVotesToGuidance({
+      likes: 1,
+      dislikes: 1,
+      total: 2,
+      likeRate: 0.5,
+      likedTechniques: [],
+      dislikedTechniques: [],
+      notes: [],
+    });
+    expect(thin.preferPatterns).toEqual([]);
+    expect(thin.avoidPatterns).toEqual([]);
+  });
+});

--- a/apps/web/src/ai/learning/index.ts
+++ b/apps/web/src/ai/learning/index.ts
@@ -45,3 +45,12 @@ export {
   loadSimCalibration,
   type SimCalibration,
 } from "./sim-calibration";
+export {
+  isPuzzleQualityVote,
+  loadQualityVoteAggregate,
+  mapPuzzleQualityVote,
+  qualityVotesToGuidance,
+  type PuzzleQualityVote,
+  type QualityVoteAggregate,
+  type QualityVoteMapping,
+} from "./puzzle-quality-vote";

--- a/apps/web/src/ai/learning/learning-loop.ts
+++ b/apps/web/src/ai/learning/learning-loop.ts
@@ -172,11 +172,11 @@ export async function runLearningCalibration(input?: {
     // non-blocking
   }
 
-  // Mark recent difficulty perception feedback as consumed by this calibration
+  // Mark recent difficulty + quality feedback as consumed by this calibration
   try {
     await getCollection("aiFeedback").updateMany(
       {
-        feedbackType: "difficulty_accuracy",
+        feedbackType: { $in: ["difficulty_accuracy", "puzzle_quality"] },
         processedForLearning: false,
       },
       {

--- a/apps/web/src/ai/learning/puzzle-quality-vote.ts
+++ b/apps/web/src/ai/learning/puzzle-quality-vote.ts
@@ -1,0 +1,201 @@
+/**
+ * Like / dislike votes on puzzles — feeds generation quality tuning.
+ */
+
+import { getCollection } from "@/db/mongodb";
+
+export type PuzzleQualityVote = "like" | "dislike";
+
+export type QualityVoteMapping = {
+  vote: PuzzleQualityVote;
+  rating: number;
+  satisfaction: number;
+  metrics: {
+    creative?: boolean;
+    boring?: boolean;
+  };
+};
+
+export function isPuzzleQualityVote(value: unknown): value is PuzzleQualityVote {
+  return value === "like" || value === "dislike";
+}
+
+export function mapPuzzleQualityVote(vote: PuzzleQualityVote): QualityVoteMapping {
+  if (vote === "like") {
+    return {
+      vote,
+      rating: 5,
+      satisfaction: 5,
+      metrics: { creative: true },
+    };
+  }
+  return {
+    vote,
+    rating: 1,
+    satisfaction: 1,
+    metrics: { boring: true },
+  };
+}
+
+export type QualityVoteAggregate = {
+  likes: number;
+  dislikes: number;
+  total: number;
+  likeRate: number;
+  /** Recent disliked technique ids (when available on linked puzzles) */
+  dislikedTechniques: string[];
+  likedTechniques: string[];
+  notes: string[];
+};
+
+/**
+ * Turn quality votes into generation prefer/avoid guidance.
+ */
+export function qualityVotesToGuidance(agg: QualityVoteAggregate): {
+  preferPatterns: string[];
+  avoidPatterns: string[];
+  notes: string[];
+} {
+  const preferPatterns: string[] = [];
+  const avoidPatterns: string[] = [];
+  const notes = [...agg.notes];
+
+  if (agg.total < 5) {
+    return {
+      preferPatterns,
+      avoidPatterns,
+      notes: [`Quality vote sample too small (${agg.total})`],
+    };
+  }
+
+  if (agg.likeRate >= 0.7) {
+    preferPatterns.push("Players liked recent boards — keep strong aha + clear visual mapping");
+    preferPatterns.push("Preserve creative technique mix that earned likes");
+    notes.push(`${Math.round(agg.likeRate * 100)}% liked recent puzzles`);
+  } else if (agg.likeRate <= 0.35) {
+    avoidPatterns.push("Recent puzzles earned dislikes — avoid vague or boring boards");
+    avoidPatterns.push("Skip weak aha / overused compounds that feel flat");
+    preferPatterns.push("Prioritize fair, delightful mechanisms with progressive hints");
+    notes.push(`Only ${Math.round(agg.likeRate * 100)}% liked recent puzzles — raise craft bar`);
+  }
+
+  if (agg.dislikedTechniques.length) {
+    avoidPatterns.push(
+      `Techniques with recent dislikes: ${agg.dislikedTechniques.slice(0, 4).join(", ")}`
+    );
+  }
+  if (agg.likedTechniques.length) {
+    preferPatterns.push(
+      `Techniques with recent likes: ${agg.likedTechniques.slice(0, 4).join(", ")}`
+    );
+  }
+
+  return { preferPatterns, avoidPatterns, notes };
+}
+
+function topTechniqueIds(ids: string[], limit = 4): string[] {
+  const counts = new Map<string, number>();
+  for (const id of ids) {
+    if (!id) continue;
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => id);
+}
+
+/**
+ * Load recent puzzle_quality feedback and map to technique guidance.
+ */
+export async function loadQualityVoteAggregate(input?: {
+  lookbackDays?: number;
+  limit?: number;
+}): Promise<QualityVoteAggregate> {
+  const lookbackDays = input?.lookbackDays ?? 14;
+  const limit = input?.limit ?? 500;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - lookbackDays);
+
+  const empty: QualityVoteAggregate = {
+    likes: 0,
+    dislikes: 0,
+    total: 0,
+    likeRate: 0,
+    dislikedTechniques: [],
+    likedTechniques: [],
+    notes: ["No quality votes yet"],
+  };
+
+  try {
+    const docs = (await getCollection("aiFeedback")
+      .find({
+        feedbackType: "puzzle_quality",
+        timestamp: { $gte: cutoff },
+      })
+      .project({ rating: 1, puzzleId: 1, metrics: 1 })
+      .sort({ timestamp: -1 })
+      .limit(limit)
+      .toArray()) as Array<{
+      rating?: number;
+      puzzleId?: string;
+      metrics?: { creative?: boolean; boring?: boolean };
+    }>;
+
+    if (!docs.length) return empty;
+
+    let likes = 0;
+    let dislikes = 0;
+    const likedPuzzleIds: string[] = [];
+    const dislikedPuzzleIds: string[] = [];
+
+    for (const doc of docs) {
+      const isLike =
+        (typeof doc.rating === "number" && doc.rating >= 4) ||
+        Boolean(doc.metrics?.creative);
+      if (isLike) {
+        likes += 1;
+        if (doc.puzzleId) likedPuzzleIds.push(doc.puzzleId);
+      } else {
+        dislikes += 1;
+        if (doc.puzzleId) dislikedPuzzleIds.push(doc.puzzleId);
+      }
+    }
+
+    const total = likes + dislikes;
+    const puzzleIds = [...new Set([...likedPuzzleIds, ...dislikedPuzzleIds])];
+    const techniqueByPuzzle = new Map<string, string>();
+
+    if (puzzleIds.length) {
+      const puzzles = (await getCollection("puzzles")
+        .find({ id: { $in: puzzleIds } })
+        .project({ id: 1, "metadata.techniqueId": 1 })
+        .limit(puzzleIds.length)
+        .toArray()) as Array<{ id: string; metadata?: { techniqueId?: string } }>;
+
+      for (const puzzle of puzzles) {
+        const techniqueId = puzzle.metadata?.techniqueId;
+        if (techniqueId) techniqueByPuzzle.set(puzzle.id, techniqueId);
+      }
+    }
+
+    const likedTechniques = topTechniqueIds(
+      likedPuzzleIds.map((id) => techniqueByPuzzle.get(id) || "").filter(Boolean)
+    );
+    const dislikedTechniques = topTechniqueIds(
+      dislikedPuzzleIds.map((id) => techniqueByPuzzle.get(id) || "").filter(Boolean)
+    );
+
+    return {
+      likes,
+      dislikes,
+      total,
+      likeRate: total > 0 ? likes / total : 0,
+      likedTechniques,
+      dislikedTechniques,
+      notes: [`${likes} likes / ${dislikes} dislikes over ${lookbackDays}d`],
+    };
+  } catch {
+    return empty;
+  }
+}

--- a/apps/web/src/ai/puzzle-agent/apex/learning-context.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/learning-context.ts
@@ -4,10 +4,14 @@
 
 import { isFeatureEnabled } from "../../config/feature-flags";
 import { measureWindowPerformance } from "../../learning/performance-monitor";
+import {
+  loadQualityVoteAggregate,
+  qualityVotesToGuidance,
+} from "../../learning/puzzle-quality-vote";
 import type { LearningDigest } from "./types";
 
 /**
- * Aggregate recent finals into avoid/prefer guidance and a numeric difficulty delta.
+ * Aggregate recent finals + like/dislike quality votes into generation guidance.
  */
 export async function loadLearningDigest(input?: {
   lookbackDays?: number;
@@ -31,10 +35,13 @@ export async function loadLearningDigest(input?: {
   const lookbackDays = input?.lookbackDays ?? 7;
 
   try {
-    const window = await measureWindowPerformance({
-      lookbackDays,
-      minFinals: 8,
-    });
+    const [window, qualityVotes] = await Promise.all([
+      measureWindowPerformance({
+        lookbackDays,
+        minFinals: 8,
+      }),
+      loadQualityVoteAggregate({ lookbackDays: Math.max(lookbackDays, 14) }),
+    ]);
 
     const avoidPatterns: string[] = [];
     const preferPatterns: string[] = [];
@@ -74,12 +81,17 @@ export async function loadLearningDigest(input?: {
       preferPatterns.push("Make hint 2 structural, not just thematic");
     }
 
+    const qualityGuidance = qualityVotesToGuidance(qualityVotes);
+    preferPatterns.push(...qualityGuidance.preferPatterns);
+    avoidPatterns.push(...qualityGuidance.avoidPatterns);
+    difficultyDriftNotes.push(...qualityGuidance.notes);
+
     return {
       enabled: true,
       avoidPatterns,
       preferPatterns,
       difficultyDriftNotes,
-      sampleSize: window.finalPlays,
+      sampleSize: window.finalPlays + qualityVotes.total,
       targetDifficultyDelta: window.difficultyDelta,
       tooEasy: window.tooEasy,
       tooHard: window.tooHard,

--- a/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
@@ -54,7 +54,13 @@ export type RunVisualLabResult = {
     model?: string;
     error?: string;
   };
-  /** Full Eve / Apex puzzle preview (not persisted) */
+  /** Invented or AI-chosen seed (shown in Dev Lab) */
+  seed?: {
+    concept: string;
+    answer: string;
+    difficulty: number;
+  };
+  /** Full Eve / Apex puzzle preview — API may persist as inactive lab row */
   puzzle?: {
     rebusPuzzle: string;
     answer: string;
@@ -69,6 +75,8 @@ export type RunVisualLabResult = {
     funScore?: number;
     engine?: "apex" | "eve";
     thinkingSummary?: string;
+    fingerprint?: string;
+    uniquenessScore?: number;
   };
   compose?: {
     funScore: number;
@@ -140,6 +148,11 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
         durationMs: Date.now() - start,
         engine: result.metadata.engine,
       },
+      seed: {
+        concept: result.puzzle.category || "rebus",
+        answer: result.puzzle.answer,
+        difficulty: result.puzzle.difficulty,
+      },
       visual: result.puzzle.visual,
       puzzle: {
         rebusPuzzle: result.puzzle.rebusPuzzle,
@@ -155,6 +168,8 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
         funScore: result.metadata.qualityMetrics.scores.fun,
         engine: result.metadata.engine,
         thinkingSummary: result.metadata.aiThinking.summary,
+        fingerprint: result.metadata.fingerprint,
+        uniquenessScore: result.metadata.uniquenessScore,
       },
     };
   }
@@ -175,6 +190,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
     usesAi: modeMeta.usesAi,
     estimatedCost: modeMeta.estimatedCost,
   };
+  const seed = { concept, answer, difficulty };
 
   if (mode === "pictogram") {
     const pictogram = await generatePictogram({
@@ -194,6 +210,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
     return {
       mode,
       meta: { ...baseMeta, durationMs: Date.now() - start },
+      seed,
       pictogram: {
         ok: pictogram.ok,
         concept: pictogram.concept,
@@ -237,6 +254,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
     return {
       mode,
       meta: { ...baseMeta, durationMs: Date.now() - start },
+      seed,
       image: {
         ok: image.ok,
         alt: image.alt,
@@ -261,6 +279,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
     return {
       mode,
       meta: { ...baseMeta, durationMs: Date.now() - start },
+      seed,
       visual,
       compose: {
         funScore: 55,
@@ -292,6 +311,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
     return {
       mode,
       meta: { ...baseMeta, durationMs: Date.now() - start },
+      seed,
       visual: composed.visual,
       compose: {
         funScore: composed.funScore,
@@ -318,6 +338,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
     return {
       mode,
       meta: { ...baseMeta, durationMs: Date.now() - start },
+      seed,
       visual: composed.visual,
       compose: {
         funScore: composed.funScore,

--- a/apps/web/src/app/api/dev/visual-lab/route.ts
+++ b/apps/web/src/app/api/dev/visual-lab/route.ts
@@ -1,5 +1,5 @@
 /**
- * Dev Mode Visual Lab API — generate visual variants without publishing.
+ * Dev Mode Visual Lab API — generate visual variants, persist for feedback.
  * Auth: any signed-in user (guest OK), same gate as /api/dev/session.
  */
 
@@ -17,6 +17,7 @@ import {
 } from "@/ai/puzzle-agent/visual/lab-recipes";
 import { runVisualLab } from "@/ai/puzzle-agent/visual/run-visual-lab";
 import { getAuthenticatedUser } from "@/lib/auth-middleware";
+import { persistLabPuzzle } from "@/lib/game/persist-lab-puzzle";
 
 export async function GET(request: Request) {
   const authUser = await getAuthenticatedUser(request);
@@ -48,6 +49,7 @@ export async function POST(request: Request) {
       answer?: unknown;
       difficulty?: unknown;
       renderImages?: unknown;
+      persist?: unknown;
     };
 
     if (!isVisualLabMode(body.mode)) {
@@ -85,10 +87,49 @@ export async function POST(request: Request) {
       renderImages: body.renderImages !== false,
     });
 
+    // Always store generations as inactive lab puzzles so we can like/dislike + learn
+    let puzzleId: string | undefined;
+    const answer = result.puzzle?.answer || result.seed?.answer;
+    if (body.persist !== false && answer) {
+      try {
+        const persisted = await persistLabPuzzle({
+          puzzleDisplay:
+            result.puzzle?.rebusPuzzle ||
+            result.visual?.unicodeFallback ||
+            "◆",
+          answer,
+          difficulty: result.puzzle?.difficulty ?? result.seed?.difficulty ?? 5,
+          difficultyLevel: result.puzzle?.difficultyLevel,
+          category: result.puzzle?.category || "dev_lab",
+          explanation:
+            result.puzzle?.explanation ||
+            (result.seed
+              ? `Dev Lab ${body.mode} probe — concept “${result.seed.concept}”.`
+              : undefined),
+          hints: result.puzzle?.hints,
+          techniqueId: result.puzzle?.techniqueId,
+          visual: result.puzzle?.visual || result.visual,
+          rebusPuzzle: result.puzzle?.rebusPuzzle,
+          labMode: body.mode,
+          engine: result.meta.engine || result.puzzle?.engine,
+          qualityScore: result.puzzle?.qualityScore,
+          funScore: result.puzzle?.funScore ?? result.compose?.funScore,
+          fingerprint: result.puzzle?.fingerprint,
+          uniquenessScore: result.puzzle?.uniquenessScore,
+          createdByUserId: authUser.userId,
+        });
+        puzzleId = persisted.id;
+      } catch (persistError) {
+        console.warn("[dev/visual-lab] persist soft-failed", persistError);
+      }
+    }
+
     return NextResponse.json({
       success: true,
-      /** Explicit: never writes to the daily puzzle catalog */
+      /** Inactive lab row may exist; never swaps today's daily */
       published: false,
+      persisted: Boolean(puzzleId),
+      puzzleId,
       result,
       gateway: authProbe.diagnostics,
     });

--- a/apps/web/src/app/api/puzzles/rating/route.ts
+++ b/apps/web/src/app/api/puzzles/rating/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from "next/server";
+import {
+  isPuzzleQualityVote,
+  mapPuzzleQualityVote,
+} from "@/ai/learning/puzzle-quality-vote";
+import { aiFeedbackOps } from "@/db/ai-operations";
+import { getCollection } from "@/db/mongodb";
+import { getAuthenticatedUser } from "@/lib/auth-middleware";
+import { getUserKey, rateLimit } from "@/lib/middleware/rate-limit";
+
+/**
+ * POST /api/puzzles/rating
+ *
+ * Like / dislike a puzzle (daily or Dev Lab). Feeds AIFeedback puzzle_quality
+ * into the self-learning generation loop.
+ */
+export async function POST(request: Request) {
+  try {
+    const user = await getAuthenticatedUser(request);
+    if (!user) {
+      return NextResponse.json({ success: false, error: "Not authenticated" }, { status: 401 });
+    }
+
+    const userLimit = await rateLimit({
+      windowMs: 60 * 1000,
+      maxRequests: 20,
+      keyGenerator: () => getUserKey(`puzzle-rating:${user.userId}`),
+    })(request);
+
+    if (userLimit && !userLimit.success) {
+      return NextResponse.json(
+        { success: false, error: "Too many ratings" },
+        { status: 429 }
+      );
+    }
+
+    const body = (await request.json()) as {
+      puzzleId?: string;
+      vote?: string;
+      solved?: boolean;
+      timeSpentSeconds?: number;
+      hintsUsed?: number;
+      attemptNumber?: number;
+      comment?: string;
+      source?: string;
+    };
+
+    const puzzleId = typeof body.puzzleId === "string" ? body.puzzleId.trim() : "";
+    if (!puzzleId || !isPuzzleQualityVote(body.vote)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid puzzleId or vote" },
+        { status: 400 }
+      );
+    }
+
+    const puzzle = await getCollection("puzzles").findOne(
+      { id: puzzleId },
+      { projection: { id: 1 } }
+    );
+    if (!puzzle) {
+      return NextResponse.json({ success: false, error: "Puzzle not found" }, { status: 404 });
+    }
+
+    const mapping = mapPuzzleQualityVote(body.vote);
+    const solved = Boolean(body.solved);
+    const timeSpentSeconds =
+      typeof body.timeSpentSeconds === "number" && body.timeSpentSeconds > 0
+        ? Math.min(body.timeSpentSeconds, 7200)
+        : 0;
+    const hintsUsed =
+      typeof body.hintsUsed === "number" && body.hintsUsed >= 0
+        ? Math.min(body.hintsUsed, 20)
+        : 0;
+    const attemptNumber =
+      typeof body.attemptNumber === "number" && body.attemptNumber > 0
+        ? Math.min(body.attemptNumber, 20)
+        : 1;
+    const source =
+      typeof body.source === "string" ? body.source.slice(0, 32) : "player";
+
+    const existing = (await getCollection("aiFeedback").findOne({
+      userId: user.userId,
+      puzzleId,
+      feedbackType: "puzzle_quality",
+    })) as { id?: string; rating?: number } | null;
+
+    const now = new Date();
+    const prevWasLike =
+      typeof existing?.rating === "number" ? existing.rating >= 4 : null;
+    const nextIsLike = mapping.vote === "like";
+
+    if (existing?.id) {
+      await getCollection("aiFeedback").updateOne(
+        { id: existing.id },
+        {
+          $set: {
+            rating: mapping.rating,
+            satisfaction: mapping.satisfaction,
+            metrics: mapping.metrics,
+            comment:
+              typeof body.comment === "string"
+                ? body.comment.slice(0, 500)
+                : undefined,
+            context: {
+              timeSpentSeconds,
+              hintsUsed,
+              attemptNumber,
+              solved,
+            },
+            processedForLearning: false,
+            timestamp: now,
+          },
+        }
+      );
+    } else {
+      await aiFeedbackOps.create({
+        id: crypto.randomUUID(),
+        puzzleId,
+        userId: user.userId,
+        feedbackType: "puzzle_quality",
+        rating: mapping.rating,
+        satisfaction: mapping.satisfaction,
+        metrics: mapping.metrics,
+        comment: typeof body.comment === "string" ? body.comment.slice(0, 500) : undefined,
+        context: {
+          timeSpentSeconds,
+          hintsUsed,
+          attemptNumber,
+          solved,
+        },
+        processedForLearning: false,
+        timestamp: now,
+        createdAt: now,
+      });
+    }
+
+    await getCollection("puzzleAttempts").updateOne(
+      { userId: user.userId, puzzleId, isFinal: true },
+      { $set: { userSatisfaction: mapping.satisfaction } }
+    );
+
+    const counterInc: Record<string, number> = {};
+    if (prevWasLike === null) {
+      if (nextIsLike) counterInc["metadata.likes"] = 1;
+      else counterInc["metadata.dislikes"] = 1;
+    } else if (prevWasLike && !nextIsLike) {
+      counterInc["metadata.likes"] = -1;
+      counterInc["metadata.dislikes"] = 1;
+    } else if (!prevWasLike && nextIsLike) {
+      counterInc["metadata.likes"] = 1;
+      counterInc["metadata.dislikes"] = -1;
+    }
+
+    await getCollection("puzzles").updateOne(
+      { id: puzzleId },
+      {
+        ...(Object.keys(counterInc).length ? { $inc: counterInc } : {}),
+        $set: {
+          "metadata.lastQualityVoteAt": now.toISOString(),
+          "metadata.lastQualityVote": mapping.vote,
+          "metadata.qualityVoteSource": source,
+        },
+      }
+    );
+
+    return NextResponse.json({
+      success: true,
+      vote: mapping.vote,
+      updated: Boolean(existing),
+    });
+  } catch (error) {
+    console.error("puzzle rating error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to record rating" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/game-over/game-over-client.tsx
+++ b/apps/web/src/app/game-over/game-over-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Flame, TrendingUp, UserPlus, X } from "lucide-react";
+import { Check, Flame, ThumbsDown, ThumbsUp, TrendingUp, UserPlus, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
@@ -27,6 +27,7 @@ interface GameData {
 }
 
 type PerceptionChoice = "too_easy" | "just_right" | "too_hard";
+type QualityVote = "like" | "dislike";
 
 interface WordResult {
   word: string;
@@ -68,6 +69,8 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
   const [todaySolves, setTodaySolves] = useState<number | null>(null);
   const [perception, setPerception] = useState<PerceptionChoice | null>(null);
   const [perceptionSaving, setPerceptionSaving] = useState(false);
+  const [qualityVote, setQualityVote] = useState<QualityVote | null>(null);
+  const [qualityVoteSaving, setQualityVoteSaving] = useState(false);
 
   const [solution, setSolution] = useState({
     answer: gameData.answer || "",
@@ -181,6 +184,18 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
     typeof params.time === "string" ? Number.parseInt(params.time, 10) : completionData?.timeTaken;
   const difficulty = gameData?.difficulty ?? 5;
 
+  function resolvePuzzleId(): string {
+    if (gameData.puzzleId) return gameData.puzzleId;
+    try {
+      const stored = localStorage.getItem("lastGameSolution");
+      if (!stored) return "";
+      const parsed = JSON.parse(stored) as { puzzleId?: string };
+      return parsed.puzzleId || "";
+    } catch {
+      return "";
+    }
+  }
+
   useEffect(() => {
     const puzzleId = gameData.puzzleId;
     if (!puzzleId || typeof window === "undefined") return;
@@ -194,24 +209,18 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
       ) {
         setPerception(stored);
       }
+      const qualityKey = `puzzleQualityVote:${puzzleId}`;
+      const qualityStored = localStorage.getItem(qualityKey);
+      if (qualityStored === "like" || qualityStored === "dislike") {
+        setQualityVote(qualityStored);
+      }
     } catch {
       // ignore
     }
   }, [gameData.puzzleId]);
 
   async function submitPerception(choice: PerceptionChoice) {
-    const puzzleId =
-      gameData.puzzleId ||
-      (() => {
-        try {
-          const stored = localStorage.getItem("lastGameSolution");
-          if (!stored) return "";
-          const parsed = JSON.parse(stored) as { puzzleId?: string };
-          return parsed.puzzleId || "";
-        } catch {
-          return "";
-        }
-      })();
+    const puzzleId = resolvePuzzleId();
 
     if (!puzzleId || perceptionSaving || perception) return;
     setPerceptionSaving(true);
@@ -234,6 +243,34 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
       // Non-blocking — local selection still stands
     } finally {
       setPerceptionSaving(false);
+    }
+  }
+
+  async function submitQualityVote(vote: QualityVote) {
+    const puzzleId = resolvePuzzleId();
+    if (!puzzleId || qualityVoteSaving) return;
+    setQualityVoteSaving(true);
+    setQualityVote(vote);
+    try {
+      localStorage.setItem(`puzzleQualityVote:${puzzleId}`, vote);
+      await fetch("/api/puzzles/rating", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          puzzleId,
+          vote,
+          source: "game_over",
+          solved: success,
+          timeSpentSeconds: typeof timeTaken === "number" ? timeTaken : 0,
+          hintsUsed: completionData?.usedHints ?? 0,
+          attemptNumber: attempts,
+        }),
+      });
+    } catch {
+      // Non-blocking — local selection still stands
+    } finally {
+      setQualityVoteSaving(false);
     }
   }
 
@@ -393,6 +430,44 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
               </div>
               {perception && (
                 <p className="text-muted-foreground text-xs">Thanks — this tunes tomorrow&apos;s puzzle</p>
+              )}
+            </div>
+
+            <div className="space-y-3 text-center">
+              <p className="eyebrow">Did you enjoy this puzzle?</p>
+              <div className="flex items-center justify-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={qualityVoteSaving}
+                  onClick={() => void submitQualityVote("like")}
+                  className={cn(
+                    "gap-2",
+                    qualityVote === "like" && "border-success/50 bg-success/10 text-success"
+                  )}
+                >
+                  <ThumbsUp className="h-4 w-4" />
+                  Like
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={qualityVoteSaving}
+                  onClick={() => void submitQualityVote("dislike")}
+                  className={cn(
+                    "gap-2",
+                    qualityVote === "dislike" &&
+                      "border-destructive/50 bg-destructive/10 text-destructive"
+                  )}
+                >
+                  <ThumbsDown className="h-4 w-4" />
+                  Dislike
+                </Button>
+              </div>
+              {qualityVote && (
+                <p className="text-muted-foreground text-xs">
+                  Saved — likes help Eve craft better boards
+                </p>
               )}
             </div>
 
@@ -561,6 +636,44 @@ export default function GameOverClient({ gameData, searchParams: params }: GameO
               </div>
               {perception && (
                 <p className="text-muted-foreground text-xs">Thanks — this tunes tomorrow&apos;s puzzle</p>
+              )}
+            </div>
+
+            <div className="space-y-3 text-center">
+              <p className="eyebrow">Did you enjoy this puzzle?</p>
+              <div className="flex items-center justify-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={qualityVoteSaving}
+                  onClick={() => void submitQualityVote("like")}
+                  className={cn(
+                    "gap-2",
+                    qualityVote === "like" && "border-success/50 bg-success/10 text-success"
+                  )}
+                >
+                  <ThumbsUp className="h-4 w-4" />
+                  Like
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={qualityVoteSaving}
+                  onClick={() => void submitQualityVote("dislike")}
+                  className={cn(
+                    "gap-2",
+                    qualityVote === "dislike" &&
+                      "border-destructive/50 bg-destructive/10 text-destructive"
+                  )}
+                >
+                  <ThumbsDown className="h-4 w-4" />
+                  Dislike
+                </Button>
+              </div>
+              {qualityVote && (
+                <p className="text-muted-foreground text-xs">
+                  Saved — likes help Eve craft better boards
+                </p>
               )}
             </div>
 

--- a/apps/web/src/components/DevVisualLab.tsx
+++ b/apps/web/src/components/DevVisualLab.tsx
@@ -5,7 +5,7 @@
  * Preview only; never publishes today's puzzle.
  */
 
-import { FlaskConical, Loader2, Sparkles } from "lucide-react";
+import { FlaskConical, Loader2, Sparkles, ThumbsDown, ThumbsUp } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { PuzzleContainer, PuzzleDisplay } from "@/components/PuzzleDisplay";
@@ -30,6 +30,12 @@ type LabResult = {
     durationMs: number;
     usesAi: boolean;
     estimatedCost: string;
+    engine?: string;
+  };
+  seed?: {
+    concept: string;
+    answer: string;
+    difficulty: number;
   };
   visual?: PuzzleVisual;
   pictogram?: {
@@ -58,6 +64,7 @@ type LabResult = {
     visual?: PuzzleVisual;
     qualityScore?: number;
     funScore?: number;
+    thinkingSummary?: string;
   };
   compose?: {
     funScore: number;
@@ -73,6 +80,8 @@ type LabResult = {
     };
   };
 };
+
+type QualityVote = "like" | "dislike";
 
 const FALLBACK_MODES: ModeMeta[] = [
   {
@@ -142,6 +151,9 @@ export function DevVisualLab() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [result, setResult] = useState<LabResult | null>(null);
+  const [puzzleId, setPuzzleId] = useState<string | null>(null);
+  const [vote, setVote] = useState<QualityVote | null>(null);
+  const [voteSaving, setVoteSaving] = useState(false);
 
   useEffect(() => {
     setDevOn(isDevModeEnabled());
@@ -176,6 +188,8 @@ export function DevVisualLab() {
     setBusy(true);
     setError("");
     setResult(null);
+    setPuzzleId(null);
+    setVote(null);
     try {
       const res = await fetch("/api/dev/visual-lab", {
         method: "POST",
@@ -185,21 +199,48 @@ export function DevVisualLab() {
           mode: selected,
           // Concept, answer, and difficulty are invented by the AI / adaptive loop
           renderImages: true,
+          persist: true,
         }),
       });
       const data = (await res.json()) as {
         success?: boolean;
         result?: LabResult;
+        puzzleId?: string;
+        persisted?: boolean;
         error?: string;
       };
       if (!res.ok || !data.success || !data.result) {
         throw new Error(data.error || "Generation failed");
       }
       setResult(data.result);
+      setPuzzleId(data.puzzleId || null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Generation failed");
     } finally {
       setBusy(false);
+    }
+  };
+
+  const submitVote = async (next: QualityVote) => {
+    if (!puzzleId || voteSaving) return;
+    setVoteSaving(true);
+    setVote(next);
+    try {
+      await fetch("/api/puzzles/rating", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          puzzleId,
+          vote: next,
+          source: "dev_lab",
+          solved: true,
+        }),
+      });
+    } catch {
+      // keep local selection
+    } finally {
+      setVoteSaving(false);
     }
   };
 
@@ -221,6 +262,10 @@ export function DevVisualLab() {
   const previewVisual = result?.visual || result?.puzzle?.visual;
   const previewFallback =
     result?.puzzle?.rebusPuzzle || result?.visual?.unicodeFallback || "◆";
+  const revealedAnswer = result?.puzzle?.answer || result?.seed?.answer || "";
+  const revealedDifficulty =
+    result?.puzzle?.difficulty ?? result?.seed?.difficulty ?? null;
+  const revealedConcept = result?.seed?.concept || result?.pictogram?.concept || "";
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 md:px-6 md:py-14">
@@ -306,6 +351,72 @@ export function DevVisualLab() {
             </PuzzleContainer>
           </section>
 
+          {revealedAnswer ? (
+            <section className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-5 text-center">
+              <p className="mb-2 font-medium text-[10px] uppercase tracking-wide text-amber-800 dark:text-amber-300">
+                Answer
+              </p>
+              <p className="font-semibold text-2xl tracking-tight text-foreground md:text-3xl">
+                {revealedAnswer}
+              </p>
+              <div className="mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-muted-foreground text-xs">
+                {revealedConcept ? <span>Concept: {revealedConcept}</span> : null}
+                {revealedDifficulty != null ? <span>Difficulty {revealedDifficulty}/10</span> : null}
+                {puzzleId ? (
+                  <span className="font-mono text-[10px] text-subtle">saved · {puzzleId.slice(0, 8)}</span>
+                ) : (
+                  <span className="text-subtle">not saved</span>
+                )}
+              </div>
+              {result.puzzle?.explanation ? (
+                <p className="mx-auto mt-3 max-w-md text-muted-foreground text-sm leading-6">
+                  {result.puzzle.explanation}
+                </p>
+              ) : null}
+              <div className="mt-5 flex items-center justify-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!puzzleId || voteSaving}
+                  onClick={() => void submitVote("like")}
+                  className={cn(
+                    "gap-2",
+                    vote === "like" && "border-success/50 bg-success/10 text-success"
+                  )}
+                >
+                  <ThumbsUp className="h-4 w-4" />
+                  Like
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!puzzleId || voteSaving}
+                  onClick={() => void submitVote("dislike")}
+                  className={cn(
+                    "gap-2",
+                    vote === "dislike" && "border-destructive/50 bg-destructive/10 text-destructive"
+                  )}
+                >
+                  <ThumbsDown className="h-4 w-4" />
+                  Dislike
+                </Button>
+              </div>
+              {!puzzleId ? (
+                <p className="mt-2 text-muted-foreground text-xs">
+                  Persist failed — regenerate to enable votes.
+                </p>
+              ) : vote ? (
+                <p className="mt-2 text-muted-foreground text-xs">
+                  Saved — votes tune future generation.
+                </p>
+              ) : (
+                <p className="mt-2 text-muted-foreground text-xs">
+                  Rate this board so Eve can learn what works.
+                </p>
+              )}
+            </section>
+          ) : null}
+
           <section className="grid gap-3 sm:grid-cols-2 text-xs">
             <MetaCard
               title="Run"
@@ -364,21 +475,16 @@ export function DevVisualLab() {
             )}
           </section>
 
-          {result.puzzle?.explanation && (
+          {result.puzzle?.hints?.length ? (
             <section className="rounded-lg border border-border bg-inset p-4 text-sm">
-              <p className="mb-1 font-medium text-xs uppercase tracking-wide text-subtle">
-                Explanation
-              </p>
-              <p>{result.puzzle.explanation}</p>
-              {result.puzzle.hints?.length ? (
-                <ul className="mt-3 list-disc space-y-1 pl-5 text-muted-foreground text-xs">
-                  {result.puzzle.hints.map((h) => (
-                    <li key={h}>{h}</li>
-                  ))}
-                </ul>
-              ) : null}
+              <p className="mb-1 font-medium text-xs uppercase tracking-wide text-subtle">Hints</p>
+              <ul className="list-disc space-y-1 pl-5 text-muted-foreground text-xs">
+                {result.puzzle.hints.map((h) => (
+                  <li key={h}>{h}</li>
+                ))}
+              </ul>
             </section>
-          )}
+          ) : null}
 
           <details className="rounded-lg border border-border bg-muted/30 p-3 text-xs">
             <summary className="cursor-pointer font-medium">Raw JSON</summary>

--- a/apps/web/src/db/models.ts
+++ b/apps/web/src/db/models.ts
@@ -167,6 +167,16 @@ export interface Puzzle {
     estimatedSolveRate?: number;
     /** Rolling sim bias applied when publishing */
     simCalibrationBias?: number;
+    /** Dev Visual Lab preview (inactive) */
+    lab?: boolean;
+    source?: string;
+    labMode?: string;
+    createdByUserId?: string;
+    likes?: number;
+    dislikes?: number;
+    lastQualityVote?: "like" | "dislike";
+    lastQualityVoteAt?: string;
+    qualityVoteSource?: string;
   };
   // Legacy field for backward compatibility (will be populated from puzzle field)
   rebusPuzzle?: string;

--- a/apps/web/src/lib/game/persist-lab-puzzle.ts
+++ b/apps/web/src/lib/game/persist-lab-puzzle.ts
@@ -1,0 +1,94 @@
+/**
+ * Persist a Dev Visual Lab generation as an inactive puzzle for feedback + learning.
+ * Never becomes today's daily (active: false).
+ */
+
+import { normalizeAnswerKey } from "@/ai/learning/answer-registry";
+import { db } from "@/db";
+import type { NewPuzzle, PuzzleVisual } from "@/db/models";
+import { logger } from "@/lib/logger";
+import { toLegacyDifficultyLabel } from "./published-puzzle";
+
+export type PersistLabPuzzleInput = {
+  puzzleDisplay: string;
+  answer: string;
+  difficulty: number;
+  difficultyLevel?: string;
+  category?: string;
+  explanation?: string;
+  hints?: string[];
+  techniqueId?: string;
+  visual?: PuzzleVisual;
+  rebusPuzzle?: string;
+  labMode: string;
+  engine?: string;
+  qualityScore?: number;
+  funScore?: number;
+  fingerprint?: string;
+  uniquenessScore?: number;
+  createdByUserId?: string;
+};
+
+/**
+ * Insert an inactive lab puzzle. Returns the new id.
+ */
+export async function persistLabPuzzle(input: PersistLabPuzzleInput): Promise<{ id: string }> {
+  const id = crypto.randomUUID();
+  const now = new Date();
+  const answerKey = normalizeAnswerKey(input.answer);
+  const puzzleDisplay =
+    input.puzzleDisplay.trim() ||
+    input.visual?.unicodeFallback?.trim() ||
+    input.rebusPuzzle?.trim() ||
+    "◆";
+
+  const doc: NewPuzzle = {
+    id,
+    puzzle: puzzleDisplay,
+    puzzleType: "rebus",
+    answer: input.answer,
+    difficulty: toLegacyDifficultyLabel(input.difficulty),
+    category: input.category || "dev_lab",
+    explanation: input.explanation || "",
+    hints: input.hints || [],
+    publishedAt: now,
+    createdAt: now,
+    active: false,
+    visual: input.visual,
+    rebusPuzzle: input.rebusPuzzle ?? puzzleDisplay,
+    metadata: {
+      topic: input.category || "dev_lab",
+      category: input.category || "dev_lab",
+      puzzleType: "rebus",
+      aiGenerated: true,
+      generatedAt: now.toISOString(),
+      lab: true,
+      source: "dev_lab",
+      labMode: input.labMode,
+      generationMethod: "dev-lab",
+      engine: input.engine,
+      techniqueId: input.techniqueId,
+      visualStyleId: input.visual?.styleId,
+      difficultyScore: input.difficulty,
+      difficultyLevel: input.difficultyLevel,
+      answerKey,
+      qualityScore: input.qualityScore,
+      funScore: input.funScore,
+      fingerprint: input.fingerprint,
+      uniquenessScore: input.uniquenessScore,
+      archived: true,
+      retiredReason: "dev_lab_preview",
+      createdByUserId: input.createdByUserId,
+    },
+  };
+
+  await db.puzzleOps.create(doc);
+
+  logger.info("Persisted Dev Lab puzzle", {
+    puzzleId: id,
+    labMode: input.labMode,
+    answerKey,
+  });
+
+  return { id };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Players and Dev Lab can like/dislike puzzles; those votes feed Eve’s generation learning loop.

### Dev Visual Lab
- After generate, the **answer** (plus concept/difficulty) is shown prominently
- Generations are **persisted** as inactive lab puzzles (`active: false`, never become daily)
- **Like / Dislike** buttons save feedback when persist succeeds

### Game over (win & lose)
- New **Did you enjoy this puzzle?** like/dislike under difficulty perception
- Votes go to `POST /api/puzzles/rating` with source `game_over`

### Learning
- Quality votes stored as `AIFeedback` with `feedbackType: "puzzle_quality"`
- Puzzle metadata counters (`likes` / `dislikes`) updated
- `loadLearningDigest` merges like/dislike guidance into prefer/avoid patterns (including liked/disliked techniques)
- Calibration marks `puzzle_quality` feedback as processed

## Test plan
- [x] Unit tests for `mapPuzzleQualityVote` / `qualityVotesToGuidance`
- [ ] Dev Lab: generate a mode → see answer → like/dislike persists
- [ ] Game-over win/lose: like/dislike today’s puzzle
- [ ] Confirm lab puzzles stay inactive / not swapped into daily
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

