### PR TITLE
Raise pictogram craft: clarity gates + stronger drawing prompts

### DIFF
--- a/apps/web/agent/skills/generate-daily-puzzle.md
+++ b/apps/web/agent/skills/generate-daily-puzzle.md
@@ -11,10 +11,11 @@ description: End-to-end workflow for assembling a daily Rebuzzle puzzle with gen
 4. Pick a technique from the brief; optionally `list_technique_library`.
 5. **Compose a generative visual** (required path):
    - Plan layers: pictogram concepts + text emphasis + operators (+ rare image).
+   - Pictogram concepts must be **concrete nouns** (bee, clock, key, umbrella) — never abstract words alone (love/time/success). Icons must be instantly recognizable.
    - Call `compose_puzzle_visual` with those layers until within budget and funScore ≥ 68.
-   - Optionally preview a tile with `generate_pictogram`.
+   - Optionally preview a tile with `generate_pictogram` and regenerate if clarity fails.
    - Set `rebusPuzzle` = returned `unicodeFallback`; keep the full `visual` for persist/UI.
-   - Unicode-only mode is rejected — ensure ≥1 pictogram SVG or styled text layers.
+   - Unicode-only / unreadable blob SVGs are rejected — ensure ≥1 clear pictogram SVG or styled text layers.
 6. Write an explanation that maps each visual part → answer token; `craft_hint_ladder` for 3–5 hints.
 7. Pipeline: `validate_puzzle` → `check_uniqueness` → `calibrate_difficulty` → `stress_test_solvability` → `score_quality`.
 8. `critique_candidate` + `simulate_player_solve` + `score_rubric` — revise if not ship-worthy.

--- a/apps/web/src/ai/puzzle-agent/__tests__/quality.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/quality.test.ts
@@ -8,6 +8,7 @@ import {
   isKnownTechniqueId,
   normalizeAnswerKey,
 } from "../quality";
+import { INK_PICTOGRAM_EXAMPLE_EYE } from "../visual/style";
 
 describe("displayLeaksAnswer", () => {
   it("detects full answer in display", () => {
@@ -67,14 +68,29 @@ describe("evaluateVisualForPublish", () => {
     ).toBe(false);
   });
 
-  it("accepts composed pictogram SVG boards", () => {
+  it("accepts composed pictogram SVG boards with readable geometry", () => {
     expect(
       evaluateVisualForPublish({
         mode: "composed",
-        layers: [{ kind: "pictogram", svg: "<svg></svg>" }],
-        unicodeFallback: "🐝",
+        layers: [{ kind: "pictogram", svg: INK_PICTOGRAM_EXAMPLE_EYE }],
+        unicodeFallback: "👁️",
       }).ok
     ).toBe(true);
+  });
+
+  it("rejects unreadable blob pictograms", () => {
+    expect(
+      evaluateVisualForPublish({
+        mode: "composed",
+        layers: [
+          {
+            kind: "pictogram",
+            svg: '<svg viewBox="0 0 64 64"><circle cx="32" cy="32" r="20"/></svg>',
+          },
+        ],
+        unicodeFallback: "◆",
+      }).ok
+    ).toBe(false);
   });
 
   it("accepts styled text when typography is the joke", () => {
@@ -144,7 +160,7 @@ describe("evaluatePublishGates", () => {
     publishable: true,
     visual: {
       mode: "composed" as const,
-      layers: [{ kind: "pictogram", svg: "<svg/>" }],
+      layers: [{ kind: "pictogram", svg: INK_PICTOGRAM_EXAMPLE_EYE }],
       unicodeFallback: "☀️ + 🌻",
     },
   };

--- a/apps/web/src/ai/puzzle-agent/apex/critique.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/critique.ts
@@ -22,8 +22,8 @@ export async function critiqueCandidate(input: {
       temperature: AI_CONFIG.generation.temperature.factual,
       schema: CritiqueSchema,
       system: `You are an adversarial rebus editor for Rebuzzle.
-Reject lazy emoji salad, answer leaks, unfair obscurity, and weak aha moments.
-Ship only puzzles with a clean mapping and a satisfying click.
+Reject lazy emoji salad, unreadable or vague icons, answer leaks, unfair obscurity, and weak aha moments.
+Ship only puzzles with a clean mapping, recognizable visuals, and a satisfying click.
 Family-friendly. Be specific and ruthless but fair.`,
       prompt: [
         `Critique this ${input.tierLabel} candidate (difficulty ${input.difficulty}/10).`,
@@ -33,6 +33,8 @@ Family-friendly. Be specific and ruthless but fair.`,
         `Explanation: ${input.explanation}`,
         `Hints: ${input.hints.map((h, i) => `${i + 1}. ${h}`).join(" | ")}`,
         "",
+        "Also judge whether each pictured object would be instantly recognizable as a simple icon.",
+        "If icons sound abstract/vague, verdict revise and demand concrete nouns + clearer silhouettes.",
         "Score falseLeadQuality (0-100) and ahaPredicted (0-100).",
         "Verdict ship only if you'd be proud to publish it nationally.",
         "If revise/reject, give concrete reviseInstructions.",

--- a/apps/web/src/ai/puzzle-agent/apex/rubric.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/rubric.ts
@@ -3,6 +3,7 @@
  */
 
 import { evaluateVisualForPublish, isKnownTechniqueId } from "../quality";
+import { scorePictogramClarity } from "../visual/pictogram-clarity";
 import type { ApexCandidate, RubricScores } from "./types";
 
 function clamp(n: number): number {
@@ -38,13 +39,25 @@ export function scoreRubric(candidate: ApexCandidate): RubricScores {
   else novelty = Math.min(novelty, 40);
   novelty = clamp(novelty);
 
-  let visualCraft = visual.ok ? 72 : 35;
-  visualCraft += Math.min(18, visual.pictogramSvgCount * 8);
+  let visualCraft = visual.ok ? 68 : 35;
+  visualCraft += Math.min(14, visual.pictogramSvgCount * 6);
   visualCraft += Math.min(10, visual.textLayerCount * 4);
   if (candidate.visual.mode === "composed" || candidate.visual.mode === "hybrid") {
     visualCraft += 6;
   }
   if (candidate.visual.mode === "unicode") visualCraft -= 30;
+
+  const pictogramClarities = (candidate.visual.layers ?? [])
+    .filter((l) => l.kind === "pictogram" && l.svg)
+    .map((l) => scorePictogramClarity(l.svg).score);
+  if (pictogramClarities.length) {
+    const avg =
+      pictogramClarities.reduce((a, b) => a + b, 0) / pictogramClarities.length;
+    if (avg >= 72) visualCraft += 14;
+    else if (avg >= 58) visualCraft += 6;
+    else visualCraft -= 28;
+  }
+
   visualCraft = clamp(visualCraft);
 
   // Shareability: short punchy answer + clean fallback

--- a/apps/web/src/ai/puzzle-agent/quality.ts
+++ b/apps/web/src/ai/puzzle-agent/quality.ts
@@ -9,6 +9,7 @@ import {
   type DifficultyTierLabel,
 } from "./difficulty-levels";
 import { TECHNIQUE_LIBRARY, type TechniqueId } from "./technique-library";
+import { scorePictogramClarity } from "./visual/pictogram-clarity";
 
 export const TECHNIQUE_IDS = Object.keys(TECHNIQUE_LIBRARY) as TechniqueId[];
 
@@ -68,6 +69,8 @@ export type FunScoreSignals = {
   hasSpatialOrOperator: boolean;
   hasStyledText: boolean;
   explanationMapsWell: boolean;
+  /** Average pictogram clarity 0–100 when SVGs were scored */
+  avgPictogramClarity?: number | null;
 };
 
 /**
@@ -92,6 +95,12 @@ export function computeFunScore(signals: FunScoreSignals): number {
   if (signals.hasSpatialOrOperator) score += 8;
   if (signals.hasStyledText) score += 6;
   if (signals.explanationMapsWell) score += 8;
+
+  if (typeof signals.avgPictogramClarity === "number") {
+    if (signals.avgPictogramClarity >= 72) score += 8;
+    else if (signals.avgPictogramClarity >= 58) score += 3;
+    else score -= 16;
+  }
 
   score -= signals.issueCount * 12;
 
@@ -126,7 +135,8 @@ export function evaluateVisualForPublish(visual?: {
   }
 
   const layers = visual.layers ?? [];
-  const pictogramSvgCount = layers.filter((l) => l.kind === "pictogram" && l.svg).length;
+  const pictogramLayers = layers.filter((l) => l.kind === "pictogram" && l.svg);
+  const pictogramSvgCount = pictogramLayers.length;
   const textLayerCount = layers.filter((l) => l.kind === "text").length;
   const styledText = layers.some(
     (l) =>
@@ -134,6 +144,19 @@ export function evaluateVisualForPublish(visual?: {
       l.emphasis &&
       ["large", "small", "strike", "stacked", "tiny"].includes(l.emphasis)
   );
+
+  for (const layer of pictogramLayers) {
+    const clarity = scorePictogramClarity(layer.svg);
+    if (!clarity.ok) {
+      return {
+        ok: false,
+        reason: `Unreadable pictogram SVG (${clarity.reasons.join(", ") || "low clarity"}) — redraw with a clearer silhouette`,
+        mode: visual.mode,
+        pictogramSvgCount,
+        textLayerCount,
+      };
+    }
+  }
 
   if (visual.mode === "unicode" && pictogramSvgCount === 0 && !styledText) {
     return {

--- a/apps/web/src/ai/puzzle-agent/tool-impl.ts
+++ b/apps/web/src/ai/puzzle-agent/tool-impl.ts
@@ -220,7 +220,7 @@ export function proposeConceptSeeds(input: {
     recommendedTechniques: techniques.map((t) => t.id),
     bannedAnswerKeys: [...avoidKeys].slice(0, 40),
     seeds: seedIdeas,
-    note: "Seeds are starting points — invent a fresh answer not in bannedAnswerKeys / recent answers. Then call compose_puzzle_visual.",
+    note: "Seeds are starting points — invent a fresh answer not in bannedAnswerKeys / recent answers. Pictogram concepts must be concrete nouns (bee, clock, key) — never abstract words alone. Then call compose_puzzle_visual.",
   };
 }
 

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/pictogram-clarity.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/pictogram-clarity.test.ts
@@ -1,0 +1,35 @@
+import {
+  buildConcreteDrawingBrief,
+  isAbstractPictogramConcept,
+  scorePictogramClarity,
+} from "../pictogram-clarity";
+import { INK_PICTOGRAM_EXAMPLE_BEE, INK_PICTOGRAM_EXAMPLE_EYE } from "../style";
+
+describe("pictogram clarity", () => {
+  it("accepts crafted few-shot icons", () => {
+    expect(scorePictogramClarity(INK_PICTOGRAM_EXAMPLE_BEE).ok).toBe(true);
+    expect(scorePictogramClarity(INK_PICTOGRAM_EXAMPLE_EYE).ok).toBe(true);
+    expect(scorePictogramClarity(INK_PICTOGRAM_EXAMPLE_BEE).score).toBeGreaterThanOrEqual(58);
+  });
+
+  it("rejects empty or blob SVGs", () => {
+    expect(scorePictogramClarity("<svg></svg>").ok).toBe(false);
+    expect(
+      scorePictogramClarity(
+        '<svg viewBox="0 0 64 64"><circle cx="32" cy="32" r="20" fill="#ccc"/></svg>'
+      ).ok
+    ).toBe(false);
+    expect(
+      scorePictogramClarity(
+        '<svg viewBox="0 0 64 64"><circle cx="32" cy="32" r="20" fill="none" stroke="#1a1f1c"/></svg>'
+      ).ok
+    ).toBe(false);
+  });
+
+  it("flags abstract concepts for concrete redraw briefs", () => {
+    expect(isAbstractPictogramConcept("love")).toBe(true);
+    expect(isAbstractPictogramConcept("bee")).toBe(false);
+    expect(buildConcreteDrawingBrief("time")).toMatch(/abstract/i);
+    expect(buildConcreteDrawingBrief("umbrella")).toMatch(/concrete/i);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/visual/compose-visual.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/compose-visual.ts
@@ -19,6 +19,7 @@ import {
 } from "./composition";
 import { generateImageTile } from "./generate-image-tile";
 import { generatePictogram } from "./generate-pictogram";
+import { scorePictogramClarity } from "./pictogram-clarity";
 import { INK_PICTOGRAM_STYLE_ID } from "./style";
 
 export type ComposePuzzleVisualInput = {
@@ -64,17 +65,36 @@ export async function composePuzzleVisual(
 
   const filledLayers: VisualLayer[] = [];
 
+  let claritySum = 0;
+  let clarityCount = 0;
+
   for (const layer of input.layers) {
     if (layer.kind === "pictogram") {
       if (layer.svg && layer.svg.includes("<svg")) {
-        filledLayers.push(layer);
-        generated.pictograms += 1;
+        const clarity = scorePictogramClarity(layer.svg);
+        if (clarity.ok) {
+          filledLayers.push(layer);
+          generated.pictograms += 1;
+          claritySum += clarity.score;
+          clarityCount += 1;
+        } else {
+          generated.failedPictograms += 1;
+          filledLayers.push({
+            ...layer,
+            svg: undefined,
+            emojiFallback: layer.emojiFallback,
+          });
+          issues.push(
+            `Unreadable pictogram for "${layer.concept}" (${clarity.reasons.join(", ") || "low clarity"}) — regenerate with a clearer silhouette`
+          );
+        }
         continue;
       }
       const pic = await generatePictogram({
         concept: layer.concept,
         role: layer.role,
         emojiFallback: layer.emojiFallback,
+        maxRetries: 1,
       });
       if (pic.ok && pic.svg) {
         filledLayers.push({
@@ -83,12 +103,20 @@ export async function composePuzzleVisual(
           emojiFallback: pic.emojiFallback,
         });
         generated.pictograms += 1;
+        if (typeof pic.clarityScore === "number") {
+          claritySum += pic.clarityScore;
+          clarityCount += 1;
+        }
       } else {
         generated.failedPictograms += 1;
         filledLayers.push({
           ...layer,
+          svg: undefined,
           emojiFallback: pic.emojiFallback || layer.emojiFallback,
         });
+        issues.push(
+          `Pictogram "${layer.concept}" failed clarity/generation — use a more concrete noun or redraw`
+        );
         tips.push(`Pictogram fallback used for "${layer.concept}" — unicode emoji only`);
       }
       continue;
@@ -121,6 +149,8 @@ export async function composePuzzleVisual(
 
     filledLayers.push(layer);
   }
+
+  const avgPictogramClarity = clarityCount > 0 ? claritySum / clarityCount : null;
 
   if (filledLayers.length === 0) {
     issues.push("No renderable layers after generation");
@@ -219,10 +249,16 @@ export async function composePuzzleVisual(
     hasSpatialOrOperator: hasOperator || visual.layout === "stack" || visual.layout === "overlay",
     hasStyledText: styledText,
     explanationMapsWell: false,
+    avgPictogramClarity,
   });
 
   if (generated.pictograms === 0 && textLayers === 0) {
     tips.push("Prefer at least one custom pictogram or styled text layer for a generative board");
+  }
+  if (generated.failedPictograms > 0) {
+    tips.push(
+      "Failed pictograms usually mean the concept was too abstract — pick a concrete noun (bee, clock, key)"
+    );
   }
   if (visual.mode === "unicode") {
     issues.push("Compose fell back to unicode mode — regenerate pictogram SVGs before publishing");

--- a/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
@@ -31,12 +31,14 @@ export async function generateImageTile(
   input: GenerateImageTileInput
 ): Promise<GenerateImageTileResult> {
   const alt = input.alt.trim().slice(0, 120) || "Puzzle illustration";
+  const subject = input.prompt.trim().slice(0, 400);
   const prompt = [
     IMAGE_TILE_STYLE_GUIDE,
     "",
-    input.prompt.trim().slice(0, 400),
+    subject,
     "",
-    "Square tile, single subject, no text in the image.",
+    "Square tile. ONE instantly recognizable subject. Bold silhouette. No text in the image.",
+    "Avoid abstract blobs, busy backgrounds, collages, and tiny unreadable details.",
   ].join("\n");
 
   ensureGatewayKey();

--- a/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
@@ -1,15 +1,26 @@
 /**
  * Generate a single Ink Pictogram v1 SVG ("our emoji") for a concept.
+ * Retries when the SVG fails the deterministic clarity gate.
  */
 
 import { generateAIText } from "@/ai/client";
+import {
+  buildConcreteDrawingBrief,
+  scorePictogramClarity,
+} from "./pictogram-clarity";
 import { sanitizePictogramSvg } from "./sanitize-svg";
-import { INK_PICTOGRAM_PALETTE, INK_PICTOGRAM_STYLE_GUIDE, INK_PICTOGRAM_STYLE_ID } from "./style";
+import {
+  INK_PICTOGRAM_PALETTE,
+  INK_PICTOGRAM_STYLE_GUIDE,
+  INK_PICTOGRAM_STYLE_ID,
+} from "./style";
 
 export type GeneratePictogramInput = {
   concept: string;
   role?: string;
   emojiFallback?: string;
+  /** Extra retries after the first attempt (default 1 → up to 2 draws) */
+  maxRetries?: number;
 };
 
 export type GeneratePictogramResult = {
@@ -19,6 +30,9 @@ export type GeneratePictogramResult = {
   svg: string | null;
   emojiFallback: string;
   ok: boolean;
+  clarityScore?: number;
+  clarityReasons?: string[];
+  attempts?: number;
   error?: string;
 };
 
@@ -28,17 +42,22 @@ function guessEmojiFallback(concept: string): string {
     bee: "🐝",
     eye: "👁️",
     clock: "🕐",
+    hourglass: "⌛",
     sun: "☀️",
     moon: "🌙",
     star: "⭐",
     heart: "❤️",
     fire: "🔥",
     water: "💧",
+    rain: "🌧️",
     tree: "🌳",
+    leaf: "🍃",
+    flower: "🌸",
     fish: "🐟",
     bird: "🐦",
     dog: "🐕",
     cat: "🐱",
+    horse: "🐴",
     book: "📖",
     key: "🔑",
     lock: "🔒",
@@ -46,8 +65,10 @@ function guessEmojiFallback(concept: string): string {
     car: "🚗",
     boat: "⛵",
     train: "🚂",
+    plane: "✈️",
     apple: "🍎",
     cake: "🎂",
+    bread: "🍞",
     music: "🎵",
     phone: "📱",
     brain: "🧠",
@@ -57,7 +78,32 @@ function guessEmojiFallback(concept: string): string {
     crown: "👑",
     money: "💰",
     light: "💡",
+    bulb: "💡",
     puzzle: "🧩",
+    hat: "🎩",
+    shoe: "👟",
+    hand: "✋",
+    foot: "🦶",
+    ear: "👂",
+    nose: "👃",
+    mouth: "👄",
+    egg: "🥚",
+    bell: "🔔",
+    bridge: "🌉",
+    mountain: "⛰️",
+    cloud: "☁️",
+    umbrella: "☂️",
+    sword: "⚔️",
+    shield: "🛡️",
+    trophy: "🏆",
+    gift: "🎁",
+    ring: "💍",
+    candle: "🕯️",
+    camera: "📷",
+    map: "🗺️",
+    compass: "🧭",
+    anchor: "⚓",
+    wheel: "⚙️",
   };
   for (const [k, v] of Object.entries(map)) {
     if (c.includes(k)) return v;
@@ -65,11 +111,77 @@ function guessEmojiFallback(concept: string): string {
   return "◆";
 }
 
+function buildPrompt(input: {
+  concept: string;
+  role?: string;
+  attempt: number;
+  previousReasons?: string[];
+}): string {
+  const lines = [
+    `Subject to draw: "${input.concept}"`,
+    input.role ? `Role in the rebus: ${input.role}` : "",
+    buildConcreteDrawingBrief(input.concept),
+    "",
+    "REQUIREMENTS:",
+    "- Exactly one recognizable object (or classic symbol)",
+    "- 3–12 simple shapes/paths with a bold silhouette",
+    "- Distinctive identifying features (not a vague oval)",
+    "- Centered in 64×64 with ~6–8px padding",
+    `- Stroke ${INK_PICTOGRAM_PALETTE.ink} width 2.25; optional fill ${INK_PICTOGRAM_PALETTE.canvas}`,
+    "- Return ONLY a single <svg>...</svg> — no markdown, no commentary",
+    "",
+    "FORBIDDEN: abstract blobs, random squiggles, decorative swirls, unreadable geometry,",
+    "multiple scenes, tiny hairline details, gradients, filters, purple, text labels",
+  ];
+
+  if (input.attempt > 0) {
+    lines.push(
+      "",
+      "PREVIOUS ATTEMPT FAILED the clarity gate — redraw cleaner and more iconic.",
+      input.previousReasons?.length
+        ? `Failure reasons: ${input.previousReasons.join(", ")}`
+        : "Make the silhouette unmistakable."
+    );
+  }
+
+  return lines.filter(Boolean).join("\n");
+}
+
+async function drawOnce(input: {
+  concept: string;
+  role?: string;
+  attempt: number;
+  previousReasons?: string[];
+}): Promise<{ svg: string | null; rawError?: string }> {
+  try {
+    const response = await generateAIText({
+      modelType: "creative",
+      // Slightly higher on retry to escape a stuck bad composition
+      temperature: input.attempt === 0 ? 0.35 : 0.55,
+      system: [
+        INK_PICTOGRAM_STYLE_GUIDE,
+        "",
+        "Return ONLY a single <svg>...</svg> element. No markdown fences, no commentary.",
+        `Palette: ink=${INK_PICTOGRAM_PALETTE.ink}, canvas=${INK_PICTOGRAM_PALETTE.canvas}, accent=${INK_PICTOGRAM_PALETTE.accent}, mist=${INK_PICTOGRAM_PALETTE.mist}.`,
+      ].join("\n"),
+      prompt: buildPrompt(input),
+    });
+
+    return { svg: sanitizePictogramSvg(response.text) };
+  } catch (error) {
+    return {
+      svg: null,
+      rawError: error instanceof Error ? error.message : "generate_failed",
+    };
+  }
+}
+
 export async function generatePictogram(
   input: GeneratePictogramInput
 ): Promise<GeneratePictogramResult> {
   const concept = input.concept.trim().slice(0, 48);
   const emojiFallback = input.emojiFallback?.trim() || guessEmojiFallback(concept);
+  const maxAttempts = Math.max(1, Math.min(3, (input.maxRetries ?? 1) + 1));
 
   if (!concept) {
     return {
@@ -83,55 +195,55 @@ export async function generatePictogram(
     };
   }
 
-  try {
-    const response = await generateAIText({
-      modelType: "creative",
-      temperature: 0.4,
-      system: [
-        INK_PICTOGRAM_STYLE_GUIDE,
-        "",
-        "Return ONLY a single <svg>...</svg> element. No markdown, no commentary.",
-        `Palette: ink=${INK_PICTOGRAM_PALETTE.ink}, canvas=${INK_PICTOGRAM_PALETTE.canvas}, accent=${INK_PICTOGRAM_PALETTE.accent}, mist=${INK_PICTOGRAM_PALETTE.mist}.`,
-      ].join("\n"),
-      prompt: [
-        `Draw an Ink Pictogram for: "${concept}"`,
-        input.role ? `Role in rebus: ${input.role}` : "",
-        "Keep it iconic and instantly readable.",
-      ]
-        .filter(Boolean)
-        .join("\n"),
+  let lastReasons: string[] = [];
+  let lastScore = 0;
+  let lastError = "invalid_svg";
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const drawn = await drawOnce({
+      concept,
+      role: input.role,
+      attempt,
+      previousReasons: lastReasons,
     });
 
-    const svg = sanitizePictogramSvg(response.text);
-    if (!svg) {
+    if (!drawn.svg) {
+      lastError = drawn.rawError || "invalid_svg";
+      lastReasons = [lastError];
+      continue;
+    }
+
+    const clarity = scorePictogramClarity(drawn.svg);
+    lastScore = clarity.score;
+    lastReasons = clarity.reasons;
+
+    if (clarity.ok) {
       return {
         styleId: INK_PICTOGRAM_STYLE_ID,
         concept,
         role: input.role,
-        svg: null,
+        svg: drawn.svg,
         emojiFallback,
-        ok: false,
-        error: "invalid_svg",
+        ok: true,
+        clarityScore: clarity.score,
+        clarityReasons: clarity.reasons,
+        attempts: attempt + 1,
       };
     }
 
-    return {
-      styleId: INK_PICTOGRAM_STYLE_ID,
-      concept,
-      role: input.role,
-      svg,
-      emojiFallback,
-      ok: true,
-    };
-  } catch (error) {
-    return {
-      styleId: INK_PICTOGRAM_STYLE_ID,
-      concept,
-      role: input.role,
-      svg: null,
-      emojiFallback,
-      ok: false,
-      error: error instanceof Error ? error.message : "generate_failed",
-    };
+    lastError = `low_clarity:${clarity.score}:${clarity.reasons.join(",") || "unreadable"}`;
   }
+
+  return {
+    styleId: INK_PICTOGRAM_STYLE_ID,
+    concept,
+    role: input.role,
+    svg: null,
+    emojiFallback,
+    ok: false,
+    clarityScore: lastScore,
+    clarityReasons: lastReasons,
+    attempts: maxAttempts,
+    error: lastError,
+  };
 }

--- a/apps/web/src/ai/puzzle-agent/visual/index.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/index.ts
@@ -37,6 +37,13 @@ export {
 export { inventLabBrief, type LabBrief } from "./invent-lab-brief";
 export { type RunVisualLabInput, type RunVisualLabResult, runVisualLab } from "./run-visual-lab";
 export {
+  buildConcreteDrawingBrief,
+  isAbstractPictogramConcept,
+  passesPictogramClarity,
+  scorePictogramClarity,
+  type PictogramClarityResult,
+} from "./pictogram-clarity";
+export {
   IMAGE_TILE_STYLE_GUIDE,
   INK_PICTOGRAM_PALETTE,
   INK_PICTOGRAM_STYLE_GUIDE,

--- a/apps/web/src/ai/puzzle-agent/visual/invent-lab-brief.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/invent-lab-brief.ts
@@ -82,11 +82,16 @@ export async function inventLabBrief(input?: {
       temperature: 0.9,
       schema: LabBriefSchema,
       system: `You invent fresh rebus Visual Lab seeds.
-Return one concrete imageable concept (noun), one playful answer phrase, and a difficulty 4–9.
-Avoid overused seeds like "bee" / "before". Prefer idioms and compounds.`,
+Return:
+1) concept — a CONCRETE imageable noun an icon designer can draw in 1 second (bee, clock, key, umbrella, lighthouse). Never abstract words like love/time/success/energy alone.
+2) answer — a playful idiom/compound/phrase the rebus could encode
+3) difficulty 4–9
+Avoid overused seeds like "bee"/"before" when you can. Prefer idioms and compounds with clear visual nouns.`,
       prompt: [
         `Invent a Visual Lab seed around difficulty ${difficulty} (${adaptive.tierLabel}).`,
-        hasConcept ? `Concept hint: ${input!.concept}` : "Choose the concept yourself.",
+        hasConcept
+          ? `Concept hint: ${input!.concept}`
+          : "Choose a concrete noun yourself (object/animal/tool — not an abstract idea).",
         hasAnswer ? `Answer hint: ${input!.answer}` : "Choose the answer yourself.",
       ].join("\n"),
     });

--- a/apps/web/src/ai/puzzle-agent/visual/pictogram-clarity.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/pictogram-clarity.ts
@@ -1,0 +1,194 @@
+/**
+ * Deterministic clarity gate for LLM-generated Ink Pictograms.
+ * Catches blobs, empty geometry, and over-decorated SVGs that players can't read.
+ */
+
+export type PictogramClarityResult = {
+  /** 0–100 craft/readability estimate */
+  score: number;
+  ok: boolean;
+  reasons: string[];
+};
+
+const MIN_PASS_SCORE = 58;
+
+function clampScore(n: number): number {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+/**
+ * Heuristic readability score for a sanitized pictogram SVG.
+ * Not perfect — but blocks the worst unreadable blobs before publish.
+ */
+export function scorePictogramClarity(svg: string | null | undefined): PictogramClarityResult {
+  const reasons: string[] = [];
+  if (!svg || !svg.includes("<svg")) {
+    return { score: 0, ok: false, reasons: ["missing_svg"] };
+  }
+
+  let score = 52;
+
+  if (/<linearGradient|<radialGradient|<filter\b|feGaussianBlur|feDropShadow/i.test(svg)) {
+    score -= 28;
+    reasons.push("effects_or_gradients");
+  }
+
+  const shapeTags =
+    svg.match(/<(path|circle|ellipse|rect|polygon|polyline|line)\b/gi)?.length ?? 0;
+
+  if (shapeTags === 0) {
+    score -= 45;
+    reasons.push("no_shapes");
+  } else if (shapeTags === 1) {
+    score -= 30;
+    reasons.push("too_few_shapes");
+  } else if (shapeTags === 2) {
+    score -= 8;
+    reasons.push("sparse_shapes");
+  } else if (shapeTags >= 3 && shapeTags <= 14) {
+    score += 22;
+  } else if (shapeTags <= 20) {
+    score += 8;
+  } else {
+    score -= 18;
+    reasons.push("overly_complex");
+  }
+
+  const onlyCircle =
+    shapeTags === 1 && /<circle\b/i.test(svg) && !/<(path|ellipse|rect|polygon)\b/i.test(svg);
+  if (onlyCircle) {
+    score -= 35;
+    reasons.push("blob_circle");
+  }
+
+  const pathData = [...svg.matchAll(/\bd=["']([^"']{0,4000})["']/gi)].map((m) => m[1] ?? "");
+  const totalPathChars = pathData.reduce((sum, d) => sum + d.replace(/\s+/g, "").length, 0);
+  if (shapeTags > 0 && totalPathChars + shapeTags * 8 < 24) {
+    score -= 18;
+    reasons.push("thin_geometry");
+  }
+  if (totalPathChars > 80) score += 6;
+
+  const hasStroke = /\bstroke\s*=/i.test(svg) || /stroke\s*:/i.test(svg);
+  if (hasStroke) score += 12;
+  else {
+    score -= 12;
+    reasons.push("missing_stroke");
+  }
+
+  const hasFill = /\bfill\s*=/i.test(svg) || /fill\s*:/i.test(svg);
+  if (hasFill) score += 4;
+
+  if (/#(?:6[0-9a-f]{5}|7[0-9a-f]{5}|8[0-9a-f]{5}|9[0-9a-f]{5}|a[0-9a-f]{5}|b[0-9a-f]{5})\b|purple|violet|indigo|#7c3aed|#8b5cf6/i.test(
+    svg
+  )) {
+    score -= 14;
+    reasons.push("off_palette");
+  }
+
+  if (/<text\b/i.test(svg)) {
+    score -= 6;
+    reasons.push("contains_text");
+  }
+
+  // Tiny viewBox occupancy heuristics: tiny radii / boxes suggest unreadable dots
+  const tinyCircles = [...svg.matchAll(/<circle\b[^>]*\br=["'](\d+(?:\.\d+)?)["']/gi)].filter(
+    (m) => Number(m[1]) > 0 && Number(m[1]) < 1.2
+  ).length;
+  if (tinyCircles >= 4) {
+    score -= 10;
+    reasons.push("dust_details");
+  }
+
+  const finalScore = clampScore(score);
+  const ok = finalScore >= MIN_PASS_SCORE && !reasons.includes("no_shapes");
+
+  if (!ok && reasons.length === 0) reasons.push("below_clarity_threshold");
+
+  return { score: finalScore, ok, reasons };
+}
+
+export function passesPictogramClarity(svg: string | null | undefined): boolean {
+  return scorePictogramClarity(svg).ok;
+}
+
+/** Words that rarely draw well as a single icon — force a concrete metaphor. */
+const ABSTRACT_CONCEPTS = new Set([
+  "love",
+  "time",
+  "success",
+  "happiness",
+  "freedom",
+  "power",
+  "energy",
+  "idea",
+  "thought",
+  "hope",
+  "fear",
+  "luck",
+  "peace",
+  "chaos",
+  "truth",
+  "beauty",
+  "mind",
+  "soul",
+  "spirit",
+  "future",
+  "past",
+  "memory",
+  "dream",
+  "anger",
+  "joy",
+  "faith",
+  "trust",
+  "wisdom",
+  "knowledge",
+  "justice",
+  "nature",
+  "music",
+  "sound",
+  "silence",
+  "speed",
+  "strength",
+  "weakness",
+  "danger",
+  "safety",
+  "friendship",
+  "family",
+  "work",
+  "life",
+  "death",
+  "change",
+  "balance",
+  "chaos",
+  "order",
+]);
+
+export function isAbstractPictogramConcept(concept: string): boolean {
+  const key = concept.trim().toLowerCase().replace(/[^a-z\s-]/g, "");
+  if (!key) return true;
+  if (ABSTRACT_CONCEPTS.has(key)) return true;
+  // Multi-word abstract phrases
+  const parts = key.split(/[\s-]+/).filter(Boolean);
+  return parts.length > 0 && parts.every((p) => ABSTRACT_CONCEPTS.has(p));
+}
+
+/**
+ * Extra drawing brief so the model picks a concrete, recognizable subject.
+ */
+export function buildConcreteDrawingBrief(concept: string): string {
+  const trimmed = concept.trim();
+  if (isAbstractPictogramConcept(trimmed)) {
+    return [
+      `"${trimmed}" is abstract — do NOT draw a vague blob or decorative swirl.`,
+      `Pick ONE concrete iconic object players instantly associate with it`,
+      `(e.g. heart→love, hourglass/clock→time, lightbulb→idea, trophy→success).`,
+      `Draw that object with unmistakable identifying features.`,
+    ].join(" ");
+  }
+  return [
+    `Draw ONE concrete real-world object: a clear "${trimmed}".`,
+    `Someone glancing at 64×64 must recognize it in under one second.`,
+    `Include the 2–4 iconic features that identify this object (not a vague silhouette blob).`,
+  ].join(" ");
+}

--- a/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
@@ -44,6 +44,9 @@ export type RunVisualLabResult = {
     concept: string;
     svg: string | null;
     emojiFallback: string;
+    clarityScore?: number;
+    clarityReasons?: string[];
+    attempts?: number;
     error?: string;
   };
   /** Single image tile probe */
@@ -216,6 +219,9 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
         concept: pictogram.concept,
         svg: pictogram.svg,
         emojiFallback: pictogram.emojiFallback,
+        clarityScore: pictogram.clarityScore,
+        clarityReasons: pictogram.clarityReasons,
+        attempts: pictogram.attempts,
         error: pictogram.error,
       },
       visual: {

--- a/apps/web/src/ai/puzzle-agent/visual/style.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/style.ts
@@ -20,27 +20,51 @@ export const INK_PICTOGRAM_PALETTE = {
   strike: "#b23a2d",
 } as const;
 
-/** System prompt fragment injected into pictogram + image generators. */
+/** Tiny few-shot: a readable bee — striped body, wings, antennae. */
+export const INK_PICTOGRAM_EXAMPLE_BEE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><ellipse cx="32" cy="36" rx="15" ry="11" fill="${INK_PICTOGRAM_PALETTE.canvas}" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2.25"/><path d="M20 32h24M20 36h24M20 40h24" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2.25" stroke-linecap="round"/><path d="M18 28c-6-6-2-14 4-12" fill="none" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2" stroke-linecap="round"/><path d="M46 28c6-6 2-14-4-12" fill="none" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2" stroke-linecap="round"/><circle cx="26" cy="33" r="1.6" fill="${INK_PICTOGRAM_PALETTE.ink}"/><line x1="27" y1="24" x2="24" y2="16" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2" stroke-linecap="round"/><line x1="37" y1="24" x2="40" y2="16" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2" stroke-linecap="round"/></svg>`;
+
+/** Tiny few-shot: a readable eye. */
+export const INK_PICTOGRAM_EXAMPLE_EYE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><path d="M8 32c8-14 20-20 24-20s16 6 24 20c-8 14-20 20-24 20S16 46 8 32z" fill="${INK_PICTOGRAM_PALETTE.canvas}" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2.25" stroke-linejoin="round"/><circle cx="32" cy="32" r="9" fill="none" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2.25"/><circle cx="32" cy="32" r="4" fill="${INK_PICTOGRAM_PALETTE.ink}"/></svg>`;
+
+/** System prompt fragment injected into pictogram generators. */
 export const INK_PICTOGRAM_STYLE_GUIDE = `
-You are designing Rebuzzle Ink Pictogram v1 tiles.
+You are a senior icon designer drawing Rebuzzle Ink Pictogram v1 tiles for rebus puzzles.
+
+GOAL: Instant recognition at 48–96px. If a player cannot name the object in one second, you failed.
 
 LOCKED STYLE (non-negotiable):
-- Flat, crisp, editorial pictograms — like a modern rebus board, not clipart
+- Flat, crisp, editorial pictograms — modern rebus board icons, not clipart or doodles
 - ViewBox 0 0 64 64, single SVG root, no external fonts or images
 - Stroke-first: 2.25px rounded strokes in ${INK_PICTOGRAM_PALETTE.ink}
-- Optional soft fill ${INK_PICTOGRAM_PALETTE.canvas}; accent ${INK_PICTOGRAM_PALETTE.accent} only for one focal detail
-- No gradients, no drop shadows, no 3D, no photorealism, no purple, no glow
-- Centered subject, generous padding (~6px), readable at 48–96px
-- Family-friendly; no text letters inside the SVG unless the concept IS a letter
-- Prefer simple silhouettes that read instantly in a rebus
+- Optional soft fill ${INK_PICTOGRAM_PALETTE.canvas}; accent ${INK_PICTOGRAM_PALETTE.accent} only for ONE focal detail
+- No gradients, filters, drop shadows, 3D, photorealism, purple, glow, or noise textures
+- Centered subject, ~6–8px padding from edges
+- Family-friendly; no letters inside the SVG unless the concept IS a letter
+- Use 3–12 simple shapes/paths with a bold silhouette
+- Prefer closed outlines + a few distinctive interior marks (stripes, pupil, handle, etc.)
+
+CRAFT RULES:
+- Draw ONE concrete object (or one classic symbol like a heart / lightbulb)
+- Include the iconic features that make it unmistakable
+- Keep geometry chunky — avoid hairline details that vanish at small size
+- Do not draw abstract blobs, random squiggles, decorative swirls, or multi-scene collages
+- Do not invent unreadable "vibes" — invent a readable object
+
+GOOD EXAMPLE (bee — stripes + wings + antennae):
+${INK_PICTOGRAM_EXAMPLE_BEE}
+
+GOOD EXAMPLE (eye — lid almond + iris + pupil):
+${INK_PICTOGRAM_EXAMPLE_EYE}
 `.trim();
 
 export const IMAGE_TILE_STYLE_GUIDE = `
 Rebuzzle hybrid image tile style:
-- Soft ink illustration on paper-like canvas, muted teal accent only
-- Single clear subject, no collage, no watermark, no text overlays
-- Square composition, centered, high contrast silhouettes
-- Matches flat pictogram language — not photoreal stock photography
+- Soft ink illustration on paper-like canvas (${INK_PICTOGRAM_PALETTE.canvas}), muted teal accent only (${INK_PICTOGRAM_PALETTE.accent})
+- ONE clear, instantly recognizable real-world subject — bold silhouette, high contrast
+- Not abstract, not collage, no watermark, no text overlays, no purple glow
+- Square composition, centered, generous padding
+- Looks like a premium rebus icon, not photoreal stock photography
+- If the subject would be unclear, simplify to the most iconic view (side profile of a bee, front of a clock, etc.)
 `.trim();
 
 export type PictogramConcept = {

--- a/apps/web/src/components/DevVisualLab.tsx
+++ b/apps/web/src/components/DevVisualLab.tsx
@@ -43,6 +43,9 @@ type LabResult = {
     concept: string;
     svg: string | null;
     emojiFallback: string;
+    clarityScore?: number;
+    clarityReasons?: string[];
+    attempts?: number;
     error?: string;
   };
   image?: {
@@ -446,7 +449,14 @@ export function DevVisualLab() {
                 title="Pictogram"
                 lines={[
                   `${result.pictogram.ok ? "ok" : "failed"} · ${result.pictogram.concept}`,
-                  `fallback ${result.pictogram.emojiFallback}`,
+                  typeof result.pictogram.clarityScore === "number"
+                    ? `clarity ${result.pictogram.clarityScore}${
+                        result.pictogram.attempts ? ` · tries ${result.pictogram.attempts}` : ""
+                      }`
+                    : "clarity n/a",
+                  result.pictogram.clarityReasons?.length
+                    ? `reasons: ${result.pictogram.clarityReasons.join(", ")}`
+                    : `fallback ${result.pictogram.emojiFallback}`,
                   result.pictogram.error || (result.pictogram.svg ? "svg ready" : "no svg"),
                 ]}
               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pictograms were often unreadable blobs because any valid SVG passed publish. This raises craft quality so icons are instantly recognizable.

### Changes
- **Stronger Ink Pictogram style guide** with few-shot bee/eye examples and anti-blob rules
- **Clarity gate** (`scorePictogramClarity`) rejects thin geometry, single-circle blobs, gradients, etc.
- **Generate with retry**: failed clarity redraws once with failure reasons before falling back to emoji
- **Compose / publish**: unreadable SVGs are stripped and block publish; funScore rewards clear icons
- **Apex rubric + critique**: weigh readability, not just SVG count
- **Lab seeds / image tiles / Eve seeds**: push concrete nouns over abstract concepts

### Test plan
- [x] Unit tests for clarity heuristics + publish reject of blob SVGs
- [ ] Dev Lab → Custom pictogram: generate a few concepts; icons should read clearly or fall back instead of shipping blobs
- [ ] Full Eve / Apex preview: boards with failed clarity should revise rather than publish garbage icons
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

