### PR TITLE
Fix pictogram clarity TypeScript build error

### DIFF
--- a/apps/web/src/ai/puzzle-agent/apex/rubric.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/rubric.ts
@@ -47,9 +47,10 @@ export function scoreRubric(candidate: ApexCandidate): RubricScores {
   }
   if (candidate.visual.mode === "unicode") visualCraft -= 30;
 
-  const pictogramClarities = (candidate.visual.layers ?? [])
-    .filter((l) => l.kind === "pictogram" && l.svg)
-    .map((l) => scorePictogramClarity(l.svg).score);
+  const pictogramClarities = (candidate.visual.layers ?? []).flatMap((layer) => {
+    if (layer.kind !== "pictogram" || !layer.svg) return [];
+    return [scorePictogramClarity(layer.svg).score];
+  });
   if (pictogramClarities.length) {
     const avg =
       pictogramClarities.reduce((a, b) => a + b, 0) / pictogramClarities.length;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes a TypeScript narrowing error in `apex/rubric.ts` introduced by #26 that failed the Vercel build.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Existing pictogram/quality unit tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

