### PR TITLE
Habit-friendly daily difficulty + never-blank puzzle day

### DIFF
--- a/apps/web/src/ai/config.ts
+++ b/apps/web/src/ai/config.ts
@@ -58,6 +58,14 @@ export const AI_CONFIG = {
     // Prefer creative-tier models for wordplay; override with EVE_PUZZLE_MODEL
     model: process.env.EVE_PUZZLE_MODEL || "openai/gpt-5.6-luna",
     maxSteps: 24,
+    /**
+     * Default daily target on the 1–10 scale ≈ Difficult band.
+     * Weekly spine + learning override this for cron; override with EVE_DEFAULT_DIFFICULTY.
+     */
+    defaultTargetDifficulty: Math.max(
+      1,
+      Math.min(10, Number(process.env.EVE_DEFAULT_DIFFICULTY || 6) || 6)
+    ),
     qualityThreshold: 74,
     minFunScore: 68,
     maxAttempts: 4,

--- a/apps/web/src/ai/config/puzzle-types/rebus.ts
+++ b/apps/web/src/ai/config/puzzle-types/rebus.ts
@@ -153,7 +153,7 @@ import { formatVisualLibraryForPrompt } from "./utils/rebus-visual-library";
 // Constants
 const HINTS_MIN = 3;
 const HINTS_MAX = 5;
-const DEFAULT_TARGET_DIFFICULTY = 7; // Default to "difficult" level for rebus - more complex puzzles
+const DEFAULT_TARGET_DIFFICULTY = 6; // Difficult-band default; spine peaks to Evil/Impossible
 const ANSWER_MAX_LENGTH = 50;
 const EXPLANATION_MIN_LENGTH = 20;
 const EXPLANATION_MAX_LENGTH = 200;

--- a/apps/web/src/ai/learning/__tests__/adaptive-difficulty.test.ts
+++ b/apps/web/src/ai/learning/__tests__/adaptive-difficulty.test.ts
@@ -29,13 +29,27 @@ function perf(overrides: Partial<WindowPerformance> = {}): WindowPerformance {
 
 describe("adaptive difficulty", () => {
   it("uses the weekly spine as baseline", () => {
-    // UTC Wednesday = 3 → spine 8
+    // UTC Wednesday = 3 → spine 6 (Difficult)
     const wed = new Date("2026-07-29T12:00:00.000Z");
     expect(baselineDifficultyForDate(wed)).toBe(WEEKLY_DIFFICULTY_SPINE[3]);
+    expect(baselineDifficultyForDate(wed)).toBe(6);
+  });
+
+  it("averages in the Difficult band (~6/10) across the week", () => {
+    const avg =
+      WEEKLY_DIFFICULTY_SPINE.reduce((sum, n) => sum + n, 0) / WEEKLY_DIFFICULTY_SPINE.length;
+    expect(avg).toBeGreaterThanOrEqual(5.5);
+    expect(avg).toBeLessThanOrEqual(7);
+  });
+
+  it("keeps soft weekend days and a Friday Impossible peak", () => {
+    expect(WEEKLY_DIFFICULTY_SPINE[0]).toBe(5); // Sun Hard
+    expect(WEEKLY_DIFFICULTY_SPINE[5]).toBe(8); // Fri Impossible
+    expect(WEEKLY_DIFFICULTY_SPINE[6]).toBe(5); // Sat Hard
   });
 
   it("raises difficulty when players finish too quickly", () => {
-    const wed = new Date("2026-07-29T12:00:00.000Z"); // baseline 8
+    const wed = new Date("2026-07-29T12:00:00.000Z"); // baseline 6
     const result = computeAdaptiveDifficulty({
       date: wed,
       performance: perf({
@@ -46,15 +60,15 @@ describe("adaptive difficulty", () => {
         notes: ["too fast"],
       }),
     });
-    expect(result.baseline).toBe(8);
-    expect(result.target).toBe(9);
+    expect(result.baseline).toBe(6);
+    expect(result.target).toBe(7);
     expect(result.delta).toBe(1);
   });
 
   it("eases difficulty when solve rate collapses", () => {
-    const sun = new Date("2026-07-26T12:00:00.000Z"); // baseline 5
+    const mon = new Date("2026-07-27T12:00:00.000Z"); // baseline 6
     const result = computeAdaptiveDifficulty({
-      date: sun,
+      date: mon,
       performance: perf({
         tooHard: true,
         difficultyDelta: -1,
@@ -63,7 +77,8 @@ describe("adaptive difficulty", () => {
         notes: ["too hard"],
       }),
     });
-    expect(result.target).toBe(4);
+    expect(result.baseline).toBe(6);
+    expect(result.target).toBe(5);
   });
 
   it("clamps into the Hard–Impossible generation band", () => {

--- a/apps/web/src/ai/learning/adaptive-difficulty.ts
+++ b/apps/web/src/ai/learning/adaptive-difficulty.ts
@@ -5,8 +5,12 @@
 import { getDifficultyLevelForScore } from "../puzzle-agent/difficulty-levels";
 import type { WindowPerformance } from "./performance-monitor";
 
-/** Canonical weekly spine (UTC day index). Hard→Impossible vocabulary. */
-export const WEEKLY_DIFFICULTY_SPINE = [5, 4, 6, 8, 7, 5, 4] as const;
+/**
+ * Canonical weekly spine (UTC day index: Sun…Sat). Hard→Impossible vocabulary.
+ * Habit-friendly cadence: soft weekends, midweek Evil, Friday Impossible peak.
+ * Averages ~6.3/10 (Difficult band) so most days stay solvable without hints.
+ */
+export const WEEKLY_DIFFICULTY_SPINE = [5, 6, 7, 6, 7, 8, 5] as const;
 
 export function baselineDifficultyForDate(date: Date = new Date()): number {
   const dayOfWeek = date.getUTCDay();

--- a/apps/web/src/ai/puzzle-agent/tool-impl.ts
+++ b/apps/web/src/ai/puzzle-agent/tool-impl.ts
@@ -297,7 +297,8 @@ Each seed must be clever but fair, with concrete drawable pictogram nouns.
 Never suggest overused tropes: ${OVERUSED_REBUS_TROPES.join(", ")}.
 Prefer idioms/compounds/positional plays with a clean aha.
 techniqueId MUST be one of: ${techIds.join(", ")}.
-pictogramNouns must be concrete objects a stranger can sketch (key, umbrella, lighthouse) — never abstract words.`,
+pictogramNouns must be concrete objects a stranger can sketch (key, umbrella, lighthouse) — never abstract words.
+Default difficulty follows the weekly spine (Difficult band, Evil/Impossible peaks) — prefer fair mechanisms.`,
       prompt: [
         `Invent 5 distinct puzzle seeds for tier ${level.label} (difficulty ${input.targetDifficulty}/10).`,
         `Band ${level.min}–${level.max}. Budget ${level.componentBudget.min}–${level.componentBudget.max} parts.`,

--- a/apps/web/src/app/actions/gameActions.ts
+++ b/apps/web/src/app/actions/gameActions.ts
@@ -163,8 +163,21 @@ export async function fetchGameOverSolution(): Promise<{
 export async function fetchGameData(_isPreview = false): Promise<PublicGameData> {
   try {
     // Never run Eve/AI on the interactive board path — cron owns generation.
-    const result = await getTodaysPuzzle(undefined, undefined, { allowAiGenerate: false });
-    const puzzle = (result.success ? result.puzzle : null) as TodaysPuzzle | null;
+    // Still guarantee a seed so the day is never blank if cron is late/fails.
+    let result = await getTodaysPuzzle(undefined, undefined, { allowAiGenerate: false });
+    let puzzle = (result.success ? result.puzzle : null) as TodaysPuzzle | null;
+
+    if (!puzzle || !(puzzle.puzzle || puzzle.rebusPuzzle)) {
+      try {
+        const { ensureDailyPuzzleSeeded } = await import("@/lib/game/ensure-daily-puzzle");
+        const { getUtcPuzzleDate } = await import("@/lib/game/daily-lock");
+        await ensureDailyPuzzleSeeded(getUtcPuzzleDate());
+        result = await getTodaysPuzzle(undefined, undefined, { allowAiGenerate: false });
+        puzzle = (result.success ? result.puzzle : null) as TodaysPuzzle | null;
+      } catch {
+        // fall through to empty
+      }
+    }
 
     if (!puzzle) {
       return emptyGameData();

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -10,6 +10,9 @@ import {
 } from "@/ai/learning";
 import { db } from "@/db";
 import { getCachedDailyPuzzleFromDb } from "@/lib/cache/daily-puzzle";
+import { archivePuzzleForDate } from "@/lib/game/archive-daily-puzzle";
+import { canUpgradeTodaysSeed, ensureDailyPuzzleSeeded } from "@/lib/game/ensure-daily-puzzle";
+import { pickFallbackPuzzle } from "@/lib/game/fallback-puzzles";
 import { persistDailyPuzzle } from "@/lib/game/persist-daily-puzzle";
 import { logger } from "@/lib/logger";
 
@@ -55,43 +58,13 @@ async function calculateDailyDifficulty(date?: Date): Promise<{
 }
 
 /**
- * Hardcoded fallback puzzles (only used if AI fails AND database fails)
- */
-const FALLBACK_PUZZLES = [
-  {
-    rebusPuzzle: "☀️ 🌻",
-    answer: "sunflower",
-    difficulty: 3,
-    explanation: "Sun (☀️) + Flower (🌻) = Sunflower",
-    category: "compound_words",
-    hints: ["Think about nature", "Combine two elements", "A yellow flower"],
-  },
-  {
-    rebusPuzzle: "🐝 4️⃣",
-    answer: "before",
-    difficulty: 4,
-    explanation: "Bee (🐝) sounds like 'be' + Four (4️⃣) = Before",
-    category: "phonetic",
-    hints: ["Think about sounds", "Phonetic wordplay", "Relates to time"],
-  },
-  {
-    rebusPuzzle: "🌙 💡",
-    answer: "moonlight",
-    difficulty: 5,
-    explanation: "Moon (🌙) + Light (💡) = Moonlight",
-    category: "compound_words",
-    hints: ["Think about nighttime", "Two elements combine", "Natural illumination"],
-  },
-];
-
-/**
  * Get or generate today's puzzle
  *
  * SMART TOKEN USAGE:
  * 1. Check Data Cache / database first (puzzle already generated for today)
- * 2. If not found, generate with AI (ONE TIME per day)
- * 3. Store in database + revalidateTag("daily-puzzle")
- * 4. All subsequent requests hit "use cache" (NO TOKENS!)
+ * 2. If seed-only and cron allows AI, upgrade before anyone finishes the day
+ * 3. If not found, generate with AI (ONE TIME per day) or seed a guarantee fallback
+ * 4. Store in database + revalidateTag("daily-puzzle")
  *
  * @param dateString - Date string in YYYY-MM-DD format
  * @param puzzleType - Optional puzzle type (e.g., "rebus", "word-puzzle")
@@ -105,11 +78,26 @@ async function getOrGenerateDailyPuzzle(
   const failOnAiError = options?.failOnAiError === true;
   logger.info("Getting puzzle for date", { dateString, allowAiGenerate, failOnAiError });
 
+  let upgradingSeed = false;
+
   // STEP 1: Cross-request cached DB read via Cache Components ("use cache")
   try {
     const cached = await getCachedDailyPuzzleFromDb(dateString);
     if (cached) {
-      return cached;
+      if (allowAiGenerate) {
+        const upgrade = await canUpgradeTodaysSeed(dateString);
+        if (upgrade.canUpgrade && upgrade.reason === "upgradeable_seed") {
+          upgradingSeed = true;
+          logger.info("Upgrading deterministic seed with Eve", {
+            dateString,
+            seedPuzzleId: cached.id,
+          });
+        } else {
+          return cached;
+        }
+      } else {
+        return cached;
+      }
     }
   } catch (dbError) {
     logger.error(
@@ -122,30 +110,28 @@ async function getOrGenerateDailyPuzzle(
   }
 
   // Double-check once more before generating (race with concurrent requests)
-  try {
-    const raceCheck = await db.puzzleOps.findByDate(dateString);
-    if (raceCheck) {
-      revalidateTag("daily-puzzle", "max");
-      const cached = await getCachedDailyPuzzleFromDb(dateString);
-      if (cached) {
-        return cached;
+  if (!upgradingSeed) {
+    try {
+      const raceCheck = await db.puzzleOps.findByDate(dateString);
+      if (raceCheck) {
+        revalidateTag("daily-puzzle", "max");
+        const cached = await getCachedDailyPuzzleFromDb(dateString);
+        if (cached) {
+          return cached;
+        }
       }
+    } catch (finalCheckError) {
+      logger.error(
+        "Final pre-generation check failed",
+        finalCheckError instanceof Error ? finalCheckError : new Error(String(finalCheckError))
+      );
     }
-  } catch (finalCheckError) {
-    logger.error(
-      "Final pre-generation check failed",
-      finalCheckError instanceof Error ? finalCheckError : new Error(String(finalCheckError))
-    );
   }
 
   // Interactive play path: never block TTFB on Eve — persist a fast fallback.
-  // Cron / regenerate / admin regenerate should call with allowAiGenerate: true.
+  // Cron / workflow / admin regenerate should call with allowAiGenerate: true.
   if (!allowAiGenerate) {
-    const [y, m, d] = dateString.split("-").map(Number);
-    const dayOfYear = Math.floor(
-      (Date.UTC(y!, (m ?? 1) - 1, d ?? 1) - Date.UTC(y!, 0, 0)) / 86_400_000
-    );
-    const fallback = FALLBACK_PUZZLES[dayOfYear % FALLBACK_PUZZLES.length]!;
+    const fallback = pickFallbackPuzzle(dateString);
     const persisted = await persistDailyPuzzle({
       dateString,
       puzzleDisplay: fallback.rebusPuzzle,
@@ -158,7 +144,10 @@ async function getOrGenerateDailyPuzzle(
       aiGenerated: false,
       rebusPuzzle: fallback.rebusPuzzle,
       allowDuplicateAnswer: true,
-      metadataExtra: { fallbackReason: "Play-path fast seed (AI deferred to cron)" },
+      metadataExtra: {
+        fallbackReason: "Play-path fast seed (AI deferred to cron)",
+        seedKind: "play_path",
+      },
     });
     return {
       id: persisted.id,
@@ -267,6 +256,14 @@ async function getOrGenerateDailyPuzzle(
       puzzleDisplay = visual.unicodeFallback;
     }
 
+    // If cron is replacing a play-path/guarantee seed, archive it only after Eve succeeds.
+    if (upgradingSeed) {
+      const archived = await archivePuzzleForDate(dateString, "seed_upgrade");
+      if (!archived.success) {
+        throw new Error(`Failed to archive seed before upgrade: ${archived.message}`);
+      }
+    }
+
     // Persist first — clients must receive a real DB id for /api/puzzles/guess
     const persisted = await persistDailyPuzzle({
       dateString,
@@ -298,6 +295,7 @@ async function getOrGenerateDailyPuzzle(
         selfLearning: true,
         estimatedSolveRate: result.metadata.estimatedSolveRate,
         simCalibrationBias: result.metadata.simCalibrationBias,
+        upgradedFromSeed: upgradingSeed,
       },
     });
 
@@ -379,12 +377,38 @@ async function getOrGenerateDailyPuzzle(
       throw error instanceof Error ? error : new Error(String(error));
     }
 
-    // STEP 4: AI failed — persist a deterministic fallback so guessing still works
-    const [y, m, d] = dateString.split("-").map(Number);
-    const dayOfYear = Math.floor(
-      (Date.UTC(y!, (m ?? 1) - 1, d ?? 1) - Date.UTC(y!, 0, 0)) / 86_400_000
-    );
-    const fallback = FALLBACK_PUZZLES[dayOfYear % FALLBACK_PUZZLES.length]!;
+    // STEP 4: AI failed — keep an existing seed, otherwise persist a guarantee fallback
+    if (upgradingSeed) {
+      const existing = await db.puzzleOps.findByDate(dateString);
+      if (existing) {
+        logger.warn("Eve upgrade failed — keeping live seed puzzle", {
+          dateString,
+          puzzleId: existing.id,
+        });
+        return {
+          id: existing.id,
+          puzzle: existing.puzzle || existing.rebusPuzzle || "",
+          rebusPuzzle: existing.rebusPuzzle,
+          puzzleType: existing.puzzleType || "rebus",
+          difficulty:
+            typeof existing.metadata?.difficultyScore === "number"
+              ? existing.metadata.difficultyScore
+              : 5,
+          answer: existing.answer,
+          explanation: existing.explanation,
+          hints: existing.hints || [],
+          date: dateString,
+          topic: existing.category,
+          category: existing.category,
+          relevanceScore: 7,
+          aiGenerated: false,
+          fromDatabase: true,
+          fallbackReason: existing.metadata?.fallbackReason || "Kept seed after Eve failure",
+        };
+      }
+    }
+
+    const fallback = pickFallbackPuzzle(dateString);
 
     logger.warn("Persisting emergency fallback puzzle", {
       dateString,
@@ -405,6 +429,7 @@ async function getOrGenerateDailyPuzzle(
       allowDuplicateAnswer: true,
       metadataExtra: {
         fallbackReason: error instanceof Error ? error.message : "AI generation failed",
+        seedKind: "ai_failure",
       },
     });
 
@@ -480,10 +505,11 @@ export async function getTodaysPuzzle(
     }
 
     // Last resort — still persist so /api/puzzles/guess can resolve the id
-    const lastResortPuzzle = FALLBACK_PUZZLES[0]!;
     const todayString = dateString || getTodayDateString();
+    const lastResortPuzzle = pickFallbackPuzzle(todayString);
 
     try {
+      await ensureDailyPuzzleSeeded(todayString);
       const persisted = await persistDailyPuzzle({
         dateString: todayString,
         puzzleDisplay: lastResortPuzzle.rebusPuzzle,
@@ -496,7 +522,10 @@ export async function getTodaysPuzzle(
         aiGenerated: false,
         rebusPuzzle: lastResortPuzzle.rebusPuzzle,
         allowDuplicateAnswer: true,
-        metadataExtra: { fallbackReason: "Emergency fallback" },
+        metadataExtra: {
+          fallbackReason: "Emergency fallback",
+          seedKind: "emergency",
+        },
       });
 
       return {
@@ -580,7 +609,7 @@ export async function previewPuzzleGeneration() {
     logger.info("Testing AI puzzle generation");
 
     const result = await generateMasterPuzzle({
-      targetDifficulty: 5,
+      targetDifficulty: baselineDifficultyForDate(),
       requireNovelty: true,
       qualityThreshold: 70,
       maxAttempts: 2,

--- a/apps/web/src/app/actions/regeneratePuzzleActions.ts
+++ b/apps/web/src/app/actions/regeneratePuzzleActions.ts
@@ -1,15 +1,12 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
 import { formatGatewayAuthError, isGatewayAuthError, probeGatewayAuth } from "@/ai/client";
 import { resolveAdaptiveDifficultyForDate } from "@/ai/learning";
 import { normalizeAnswerKey } from "@/ai/learning/answer-registry";
 import { generateMasterPuzzle } from "@/ai/services/master-puzzle-orchestrator";
-import type { Puzzle } from "@/db/models";
-import { getCollection } from "@/db/mongodb";
+import { archiveTodaysPuzzle as archiveTodaysPuzzleLib } from "@/lib/game/archive-daily-puzzle";
 import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
 import { persistDailyPuzzle } from "@/lib/game/persist-daily-puzzle";
-import { logger } from "@/lib/logger";
 
 /**
  * Soft-retire today's puzzle into the archive instead of hard-deleting.
@@ -20,58 +17,7 @@ export async function archiveTodaysPuzzle(): Promise<{
   message: string;
   archivedIds: string[];
 }> {
-  try {
-    const collection = getCollection<Puzzle>("puzzles");
-    const dateKey = getUtcPuzzleDate();
-    const start = new Date(`${dateKey}T00:00:00.000Z`);
-    const end = new Date(`${dateKey}T23:59:59.999Z`);
-
-    const existing = await collection
-      .find({ publishedAt: { $gte: start, $lte: end }, active: true })
-      .project({ id: 1 })
-      .toArray();
-
-    const archivedIds = existing.map((p) => String(p.id));
-
-    if (archivedIds.length) {
-      await collection.updateMany(
-        { id: { $in: archivedIds } },
-        {
-          $set: {
-            active: false,
-            "metadata.archived": true,
-            "metadata.retiredAt": new Date().toISOString(),
-            "metadata.retiredReason": "regenerate",
-            "metadata.retiredDateKey": dateKey,
-          },
-        }
-      );
-    }
-
-    revalidateTag("daily-puzzle", "max");
-    revalidateTag(`daily-puzzle-${dateKey}`, "max");
-
-    logger.info("Archived today's puzzle(s) before regenerate", {
-      dateKey,
-      count: archivedIds.length,
-      archivedIds,
-    });
-
-    return {
-      success: true,
-      message: archivedIds.length
-        ? `Archived ${archivedIds.length} puzzle(s) for ${dateKey}`
-        : `No active puzzle for ${dateKey} to archive`,
-      archivedIds,
-    };
-  } catch (error) {
-    console.error("Error archiving today's puzzle:", error);
-    return {
-      success: false,
-      message: error instanceof Error ? error.message : "Unknown error",
-      archivedIds: [],
-    };
-  }
+  return archiveTodaysPuzzleLib("regenerate");
 }
 
 /** @deprecated Prefer archiveTodaysPuzzle — hard delete destroys uniqueness history */

--- a/apps/web/src/app/api/workflows/daily-content/route.ts
+++ b/apps/web/src/app/api/workflows/daily-content/route.ts
@@ -78,6 +78,26 @@ export async function POST(request: Request) {
       logger.error("Puzzle generation failed", new Error(errMsg));
     }
 
+    // Never leave the day blank — seed a fair fallback if Eve produced nothing.
+    let guarantee: { id?: string; seeded?: boolean } = {};
+    try {
+      const { ensureDailyPuzzleSeeded } = await import("@/lib/game/ensure-daily-puzzle");
+      const dateKey = new Date().toISOString().slice(0, 10);
+      const ensured = await ensureDailyPuzzleSeeded(dateKey);
+      guarantee = { id: ensured.id, seeded: ensured.seeded };
+      if (ensured.seeded) {
+        logger.warn("Daily guarantee seed persisted after empty/failed generation", {
+          dateKey,
+          puzzleId: ensured.id,
+        });
+      }
+    } catch (ensureError) {
+      logger.error(
+        "Daily guarantee seed failed",
+        ensureError instanceof Error ? ensureError : new Error(String(ensureError))
+      );
+    }
+
     logger.info("Revalidating puzzle cache");
     revalidateTag("daily-puzzle", "max");
 
@@ -94,7 +114,8 @@ export async function POST(request: Request) {
         puzzleId:
           puzzleResult.success && puzzleResult.puzzle
             ? (puzzleResult.puzzle as { id?: string }).id
-            : undefined,
+            : guarantee.id,
+        guaranteeSeeded: guarantee.seeded === true,
       },
       blog: blogResult,
       completedAt: new Date().toISOString(),

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -133,12 +133,13 @@ function NoPuzzleDisplay() {
   return (
     <Layout>
       <StatusPanel
-        eyebrow="No puzzle yet"
+        action={{ href: "/", label: "Refresh" }}
+        eyebrow="Almost ready"
         headingId="no-puzzle-title"
         secondaryAction={{ href: "/blog", label: "Read the blog while you wait" }}
-        title="Today's puzzle isn't live."
+        title="Today's puzzle is finishing up."
       >
-        A new puzzle lands every day at midnight. Check back shortly.
+        We keep a backup ready every day — refresh in a moment if you still don&apos;t see the board.
       </StatusPanel>
     </Layout>
   );

--- a/apps/web/src/db/models.ts
+++ b/apps/web/src/db/models.ts
@@ -131,6 +131,9 @@ export interface Puzzle {
       ogDescription: string;
     };
     aiGenerated?: boolean;
+    /** Present when the row is an emergency / play-path seed Eve may upgrade */
+    fallbackReason?: string;
+    seedKind?: "daily_guarantee" | "play_path" | "ai_failure" | "emergency";
     qualityScore?: number;
     uniquenessScore?: number;
     generatedAt?: string;

--- a/apps/web/src/lib/cache/daily-puzzle.ts
+++ b/apps/web/src/lib/cache/daily-puzzle.ts
@@ -22,6 +22,9 @@ export type CachedDailyPuzzle = {
   fromDatabase: true;
   /** Generative composed board when Eve built custom pictograms */
   visual?: PuzzleVisual;
+  /** Set when this row is a deterministic seed (upgradeable by cron) */
+  fallbackReason?: string;
+  seedKind?: string;
 };
 
 function formatPuzzleFromDb(puzzle: Puzzle, dateString: string): CachedDailyPuzzle {
@@ -67,9 +70,12 @@ function formatPuzzleFromDb(puzzle: Puzzle, dateString: string): CachedDailyPuzz
     category: puzzle.metadata?.category || puzzle.category || "general",
     relevanceScore: 8,
     seoMetadata: (puzzle.metadata?.seoMetadata as Record<string, unknown>) || {},
-    aiGenerated: true,
+    aiGenerated: puzzle.metadata?.aiGenerated !== false,
     fromDatabase: true,
     visual: puzzle.visual,
+    fallbackReason: puzzle.metadata?.fallbackReason,
+    seedKind:
+      typeof puzzle.metadata?.seedKind === "string" ? puzzle.metadata.seedKind : undefined,
   };
 }
 

--- a/apps/web/src/lib/game/__tests__/fallback-puzzles.test.ts
+++ b/apps/web/src/lib/game/__tests__/fallback-puzzles.test.ts
@@ -1,0 +1,46 @@
+import {
+  FALLBACK_PUZZLES,
+  isUpgradeableSeedPuzzle,
+  pickFallbackPuzzle,
+} from "../fallback-puzzles";
+
+describe("fallback puzzles", () => {
+  it("has a rotating pool of fair Hard/Difficult seeds", () => {
+    expect(FALLBACK_PUZZLES.length).toBeGreaterThanOrEqual(10);
+    for (const p of FALLBACK_PUZZLES) {
+      expect(p.difficulty).toBeGreaterThanOrEqual(4);
+      expect(p.difficulty).toBeLessThanOrEqual(6);
+      expect(p.hints.length).toBeGreaterThanOrEqual(2);
+      expect(p.answer.trim().length).toBeGreaterThan(2);
+    }
+  });
+
+  it("picks deterministically by UTC date", () => {
+    const a = pickFallbackPuzzle("2026-08-01");
+    const b = pickFallbackPuzzle("2026-08-01");
+    const c = pickFallbackPuzzle("2026-08-02");
+    expect(a).toEqual(b);
+    expect(a.answer).not.toEqual(c.answer);
+  });
+
+  it("detects upgradeable seeds", () => {
+    expect(
+      isUpgradeableSeedPuzzle({
+        aiGenerated: false,
+        metadata: { fallbackReason: "Play-path", seedKind: "play_path" },
+      })
+    ).toBe(true);
+    expect(
+      isUpgradeableSeedPuzzle({
+        aiGenerated: true,
+        metadata: { aiGenerated: true },
+      })
+    ).toBe(false);
+    expect(
+      isUpgradeableSeedPuzzle({
+        fallbackReason: "Daily guarantee seed",
+        aiGenerated: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/game/archive-daily-puzzle.ts
+++ b/apps/web/src/lib/game/archive-daily-puzzle.ts
@@ -1,0 +1,78 @@
+/**
+ * Soft-retire today's active puzzle into the archive (keeps answer uniqueness).
+ */
+
+import { revalidateTag } from "next/cache";
+import type { Puzzle } from "@/db/models";
+import { getCollection } from "@/db/mongodb";
+import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
+import { logger } from "@/lib/logger";
+
+export async function archivePuzzleForDate(
+  dateKey: string,
+  reason = "regenerate"
+): Promise<{
+  success: boolean;
+  message: string;
+  archivedIds: string[];
+}> {
+  try {
+    const collection = getCollection<Puzzle>("puzzles");
+    const start = new Date(`${dateKey}T00:00:00.000Z`);
+    const end = new Date(`${dateKey}T23:59:59.999Z`);
+
+    const existing = await collection
+      .find({ publishedAt: { $gte: start, $lte: end }, active: true })
+      .project({ id: 1 })
+      .toArray();
+
+    const archivedIds = existing.map((p) => String(p.id));
+
+    if (archivedIds.length) {
+      await collection.updateMany(
+        { id: { $in: archivedIds } },
+        {
+          $set: {
+            active: false,
+            "metadata.archived": true,
+            "metadata.retiredAt": new Date().toISOString(),
+            "metadata.retiredReason": reason,
+            "metadata.retiredDateKey": dateKey,
+          },
+        }
+      );
+    }
+
+    revalidateTag("daily-puzzle", "max");
+    revalidateTag(`daily-puzzle-${dateKey}`, "max");
+
+    logger.info("Archived daily puzzle(s)", {
+      dateKey,
+      count: archivedIds.length,
+      archivedIds,
+      reason,
+    });
+
+    return {
+      success: true,
+      message: archivedIds.length
+        ? `Archived ${archivedIds.length} puzzle(s) for ${dateKey}`
+        : `No active puzzle for ${dateKey} to archive`,
+      archivedIds,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error",
+      archivedIds: [],
+    };
+  }
+}
+
+export async function archiveTodaysPuzzle(reason = "regenerate"): Promise<{
+  success: boolean;
+  message: string;
+  archivedIds: string[];
+}> {
+  return archivePuzzleForDate(getUtcPuzzleDate(), reason);
+}

--- a/apps/web/src/lib/game/ensure-daily-puzzle.ts
+++ b/apps/web/src/lib/game/ensure-daily-puzzle.ts
@@ -1,0 +1,90 @@
+/**
+ * Guarantee a playable puzzle exists for a UTC date.
+ * Seeds a deterministic fallback when the day is empty; never leaves the board blank.
+ */
+
+import { getCollection } from "@/db/mongodb";
+import type { Puzzle } from "@/db/models";
+import { db } from "@/db";
+import { logger } from "@/lib/logger";
+import {
+  isUpgradeableSeedPuzzle,
+  pickFallbackPuzzle,
+} from "./fallback-puzzles";
+import { persistDailyPuzzle } from "./persist-daily-puzzle";
+
+export async function puzzleHasFinalAttempts(puzzleId: string): Promise<boolean> {
+  try {
+    const hit = await getCollection("puzzleAttempts").findOne(
+      { puzzleId, isFinal: true },
+      { projection: { _id: 1 } }
+    );
+    return Boolean(hit);
+  } catch {
+    return true; // fail closed — don't upgrade if we can't check
+  }
+}
+
+/**
+ * Persist a deterministic seed if no active puzzle exists for the date.
+ * Idempotent: returns the existing puzzle when already present.
+ */
+export async function ensureDailyPuzzleSeeded(dateString: string): Promise<{
+  id: string;
+  seeded: boolean;
+  alreadyExisted: boolean;
+}> {
+  const existing = await db.puzzleOps.findByDate(dateString);
+  if (existing) {
+    return { id: existing.id, seeded: false, alreadyExisted: true };
+  }
+
+  const fallback = pickFallbackPuzzle(dateString);
+  logger.warn("Seeding guaranteed daily puzzle (empty day)", { dateString });
+
+  const persisted = await persistDailyPuzzle({
+    dateString,
+    puzzleDisplay: fallback.rebusPuzzle,
+    puzzleType: "rebus",
+    answer: fallback.answer,
+    difficulty: fallback.difficulty,
+    category: fallback.category,
+    explanation: fallback.explanation,
+    hints: fallback.hints,
+    aiGenerated: false,
+    rebusPuzzle: fallback.rebusPuzzle,
+    allowDuplicateAnswer: true,
+    metadataExtra: {
+      fallbackReason: "Daily guarantee seed (empty day)",
+      seedKind: "daily_guarantee",
+    },
+  });
+
+  return {
+    id: persisted.id,
+    seeded: !persisted.alreadyExisted,
+    alreadyExisted: persisted.alreadyExisted,
+  };
+}
+
+/**
+ * Cron/AI path: seed may be replaced only if nobody has finished today's board.
+ */
+export async function canUpgradeTodaysSeed(dateString: string): Promise<{
+  canUpgrade: boolean;
+  puzzle: Puzzle | null;
+  reason: string;
+}> {
+  const puzzle = await db.puzzleOps.findByDate(dateString);
+  if (!puzzle) {
+    return { canUpgrade: true, puzzle: null, reason: "no_puzzle" };
+  }
+  if (!isUpgradeableSeedPuzzle(puzzle)) {
+    return { canUpgrade: false, puzzle, reason: "not_a_seed" };
+  }
+  const played = await puzzleHasFinalAttempts(puzzle.id);
+  if (played) {
+    return { canUpgrade: false, puzzle, reason: "already_played" };
+  }
+  return { canUpgrade: true, puzzle, reason: "upgradeable_seed" };
+}

--- a/apps/web/src/lib/game/fallback-puzzles.ts
+++ b/apps/web/src/lib/game/fallback-puzzles.ts
@@ -1,0 +1,149 @@
+/**
+ * Deterministic daily seeds — keep the board live when Eve/cron fails.
+ * Fair Hard/Difficult rebus only; cron may upgrade seeds before anyone plays.
+ */
+
+export type FallbackPuzzle = {
+  rebusPuzzle: string;
+  answer: string;
+  difficulty: number;
+  explanation: string;
+  category: string;
+  hints: string[];
+};
+
+/** Rotating pool — answers reused only for emergency seeds (allowDuplicateAnswer). */
+export const FALLBACK_PUZZLES: readonly FallbackPuzzle[] = [
+  {
+    rebusPuzzle: "☀️ 🌻",
+    answer: "sunflower",
+    difficulty: 4,
+    explanation: "Sun (☀️) + flower (🌻) = sunflower",
+    category: "compound_words",
+    hints: ["Think about nature", "Combine two elements", "A yellow flower that follows the sun"],
+  },
+  {
+    rebusPuzzle: "🐝 4️⃣",
+    answer: "before",
+    difficulty: 5,
+    explanation: "Bee (🐝) sounds like “be” + four (4️⃣) = before",
+    category: "phonetic",
+    hints: ["Think about sounds", "Phonetic wordplay", "Relates to time"],
+  },
+  {
+    rebusPuzzle: "🌙 💡",
+    answer: "moonlight",
+    difficulty: 5,
+    explanation: "Moon (🌙) + light (💡) = moonlight",
+    category: "compound_words",
+    hints: ["Think about nighttime", "Two elements combine", "Natural illumination"],
+  },
+  {
+    rebusPuzzle: "🔥 🏠",
+    answer: "fireplace",
+    difficulty: 4,
+    explanation: "Fire (🔥) + place/house (🏠) = fireplace",
+    category: "compound_words",
+    hints: ["Warmth indoors", "Combine the two icons", "Where logs burn at home"],
+  },
+  {
+    rebusPuzzle: "⭐ 🐟",
+    answer: "starfish",
+    difficulty: 4,
+    explanation: "Star (⭐) + fish (🐟) = starfish",
+    category: "compound_words",
+    hints: ["Ocean creature", "Combine the symbols", "Five-armed sea animal"],
+  },
+  {
+    rebusPuzzle: "📖 🐛",
+    answer: "bookworm",
+    difficulty: 5,
+    explanation: "Book (📖) + worm (🐛) = bookworm",
+    category: "compound_words",
+    hints: ["A kind of reader", "Combine the two icons", "Loves reading"],
+  },
+  {
+    rebusPuzzle: "🌧️ 🧥",
+    answer: "raincoat",
+    difficulty: 4,
+    explanation: "Rain (🌧️) + coat (🧥) = raincoat",
+    category: "compound_words",
+    hints: ["Wet weather gear", "Combine the icons", "Keeps you dry outside"],
+  },
+  {
+    rebusPuzzle: "🦷 🧚",
+    answer: "tooth fairy",
+    difficulty: 5,
+    explanation: "Tooth (🦷) + fairy (🧚) = tooth fairy",
+    category: "phrases",
+    hints: ["Childhood myth", "Two separate ideas", "Leaves coins under pillows"],
+  },
+  {
+    rebusPuzzle: "⏰ ⏹️",
+    answer: "timeout",
+    difficulty: 5,
+    explanation: "Time (⏰) + out/stop (⏹️) = timeout",
+    category: "compound_words",
+    hints: ["Sports / parenting pause", "Clock plus stop", "A short break"],
+  },
+  {
+    rebusPuzzle: "🧠 🌊",
+    answer: "brainstorm",
+    difficulty: 5,
+    explanation: "Brain (🧠) + storm (🌊/storm vibe) = brainstorm",
+    category: "compound_words",
+    hints: ["Creative session", "Mind + weather energy", "Throw ideas around"],
+  },
+  {
+    rebusPuzzle: "👀 🍬",
+    answer: "eye candy",
+    difficulty: 6,
+    explanation: "Eye (👀) + candy (🍬) = eye candy",
+    category: "phrases",
+    hints: ["Idiom for looks", "Sight + sweet", "Pleasing to look at"],
+  },
+  {
+    rebusPuzzle: "🧊 💔",
+    answer: "cold hearted",
+    difficulty: 6,
+    explanation: "Ice/cold (🧊) + broken/heart (💔) ≈ cold-hearted",
+    category: "phrases",
+    hints: ["Personality idiom", "Temperature + emotion", "Unfeeling"],
+  },
+] as const;
+
+export function dayOfYearUtc(dateString: string): number {
+  const [y, m, d] = dateString.split("-").map(Number);
+  return Math.floor(
+    (Date.UTC(y!, (m ?? 1) - 1, d ?? 1) - Date.UTC(y!, 0, 0)) / 86_400_000
+  );
+}
+
+export function pickFallbackPuzzle(dateString: string): FallbackPuzzle {
+  const idx = dayOfYearUtc(dateString) % FALLBACK_PUZZLES.length;
+  return FALLBACK_PUZZLES[idx]!;
+}
+
+export type SeedMeta = {
+  aiGenerated?: boolean;
+  fallbackReason?: string;
+  seedKind?: string;
+};
+
+/** True when today's row is an emergency / play-path seed Eve may still upgrade. */
+export function isUpgradeableSeedPuzzle(puzzle: {
+  aiGenerated?: boolean;
+  fallbackReason?: string;
+  seedKind?: string;
+  metadata?: SeedMeta | null;
+}): boolean {
+  const meta = puzzle.metadata ?? {};
+  if (puzzle.fallbackReason || meta.fallbackReason) return true;
+  const seedKind = puzzle.seedKind ?? meta.seedKind;
+  if (seedKind === "daily_guarantee" || seedKind === "play_path" || seedKind === "ai_failure") {
+    return true;
+  }
+  if (puzzle.aiGenerated === false) return true;
+  if (meta.aiGenerated === false) return true;
+  return false;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Makes the daily game more retainable: soften the difficulty cadence, and guarantee a playable puzzle every day even when Eve/cron fails.

### Difficulty cadence
- Weekly spine is now `[5, 6, 7, 6, 7, 8, 5]` (Sun→Sat): soft weekends, midweek Evil, Friday Impossible peak
- Average ~6.3/10 (Difficult band) instead of an Impossible-heavy week
- Default Eve/rebus target falls back to **6** (`EVE_DEFAULT_DIFFICULTY` still overrides)

### Never-blank day
- Expanded deterministic fallback pool (Hard/Difficult seeds)
- `ensureDailyPuzzleSeeded()` runs after daily-content cron and from the play path if the board is empty
- Cron can **upgrade** an unplayed seed once Eve succeeds (archives seed, persists AI puzzle)
- If Eve fails after a seed is live, the seed stays — players keep a board
- Empty-state copy updated to “finishing up” + refresh

### Tests
- `adaptive-difficulty` + `fallback-puzzles` → **9 passed**

### Notes
- Seeds reuse answers only with `allowDuplicateAnswer` (emergency path)
- Already-played seeds are never replaced mid-day
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

