### PR TITLE
Improve guess feedback conversation

### DIFF
--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -45,9 +45,9 @@ const TIER_LABEL: Record<ReactionTier, string> = {
  * The conversation.
  *
  * Each guess is a turn: what you said, Eve's instant read on it, and — if the
- * model gets there in time — a second bubble where she can't help adding
+ * model gets there in time — an extra riff where she can't help adding
  * something. The instant line never waits on the model, so feedback is always
- * immediate; the riff types itself in underneath if it shows up.
+ * immediate; the riff types itself into the same reply if it shows up.
  */
 export function GuessThread({ turns, footer, className }: GuessThreadProps) {
   const endRef = useRef<HTMLLIElement>(null);
@@ -56,7 +56,8 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
 
   // Follow the conversation the way a chat does — including as a riff grows.
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    endRef.current?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "end" });
   }, [turns.length, lastQuip, hasFooter]);
 
   if (turns.length === 0) return null;
@@ -74,27 +75,26 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
         const showRiff = Boolean(turn.quipPending || turn.quip);
 
         return (
-          <li className="flex flex-col gap-2" key={turn.id}>
+          <li className="flex flex-col gap-3" key={turn.id}>
             <MessageRow from="user">
               <MessageBubble from="user">{turn.text}</MessageBubble>
             </MessageRow>
 
             <MessageRow from="agent">
               <MessageAvatar />
-              <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-                <MessageBubble from="agent" tone={tone}>
-                  {turn.line}
-                </MessageBubble>
-
-                {showRiff ? (
-                  <MessageBubble from="agent">
-                    {turn.quip ? turn.quip : <MessageTyping />}
-                  </MessageBubble>
-                ) : null}
-
+              <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
                 <MessageMeta tone={tone}>
-                  {TIER_LABEL[turn.tier]} · Guess {turn.attemptNumber}
+                  Eve · {TIER_LABEL[turn.tier]} · Guess {turn.attemptNumber}
                 </MessageMeta>
+
+                <MessageBubble className="min-w-0" from="agent" tone={tone}>
+                  <p>{turn.line}</p>
+                  {showRiff ? (
+                    <div className="mt-2 border-border/70 border-t pt-2 text-muted-foreground">
+                      {turn.quip ? turn.quip : <MessageTyping />}
+                    </div>
+                  ) : null}
+                </MessageBubble>
               </div>
             </MessageRow>
           </li>

--- a/apps/web/src/components/ui/message.tsx
+++ b/apps/web/src/components/ui/message.tsx
@@ -33,12 +33,12 @@ export function MessageRow({ className, from, ...props }: MessageRowProps) {
 }
 
 const bubbleVariants = cva(
-  "w-fit max-w-[min(85%,34rem)] text-pretty text-[15px] leading-6 [overflow-wrap:anywhere]",
+  "w-fit max-w-[min(88%,34rem)] text-pretty text-[15px] leading-6 shadow-[0_1px_2px_hsl(var(--foreground)/0.04)] [overflow-wrap:anywhere]",
   {
     variants: {
       from: {
-        user: "rounded-2xl rounded-br-md bg-foreground px-3.5 py-2 font-medium text-background",
-        agent: "rounded-2xl rounded-bl-md border border-border bg-card px-3.5 py-2 text-foreground",
+        user: "rounded-2xl rounded-br-md bg-foreground px-4 py-2 font-medium text-background shadow-[0_3px_10px_hsl(var(--foreground)/0.12)]",
+        agent: "rounded-2xl rounded-tl-md border border-border bg-card px-4 py-3 text-foreground",
       },
       tone: {
         neutral: "",
@@ -85,9 +85,9 @@ export function MessageAvatar({ className }: { className?: string }) {
     <div
       aria-hidden
       className={cn(
-        "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full",
+        "flex h-7 w-7 shrink-0 items-center justify-center rounded-full shadow-sm ring-1 ring-white/20",
         "bg-gradient-to-br from-[#007cf0] to-[#7928ca]",
-        "font-medium text-[10px] text-white",
+        "font-semibold text-[10px] text-white",
         className
       )}
     >
@@ -108,7 +108,7 @@ export function MessageMeta({
   return (
     <p
       className={cn(
-        "flex items-center gap-1.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]",
+        "flex min-h-5 items-center gap-1.5 font-medium text-[11px] text-muted-foreground tracking-[0.01em]",
         className
       )}
     >


### PR DESCRIPTION
### Motivation

- Make Eve’s instant reaction and any streamed follow-up feel like a single, cohesive reply instead of two competing bubbles.
- Improve visual hierarchy so the speaker, reaction tier, and guess number are clearer at a glance.
- Respect user preferences for reduced motion when auto-scrolling the conversation.

### Description

- Consolidated the instant line and streamed quip into a single agent response card with a subtle divider for the streamed content in `apps/web/src/components/GuessThread.tsx`.
- Added explicit speaker/metadata text (`Eve · <tier> · Guess <n>`) above replies and increased vertical spacing between turns in `GuessThread`.
- Tweaked message primitives in `apps/web/src/components/ui/message.tsx` to strengthen hierarchy by expanding bubble max-width, adding shadows, adjusting padding/corner treatments, and making the avatar and meta typography more prominent.
- Updated conversation follow behavior to honor `prefers-reduced-motion` when calling `scrollIntoView` so motion is disabled for users who request reduced motion.

### Testing

- Ran `git diff --check` with no reported issues.
- Ran `pnpm --filter @rebuzzle/web exec biome check src/components/GuessThread.tsx src/components/ui/message.tsx` which completed (format/check warnings surfaced about engine but no code errors).
- Ran `pnpm --filter @rebuzzle/web exec tsc --noEmit --pretty false` which succeeded with no type errors.
- Attempted `pnpm --filter @rebuzzle/web dev` and a local server started, but full runtime verification was blocked by missing environment variables required for database/auth/AI integration and Playwright browser binaries; a Playwright screenshot run failed because the browser binary was not installed. No automated visual regression was captured for that reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d79ad25108326a269fdb27446ece0)