### PR TITLE
Fail closed on AI blog spoiler leaks

### DIFF
--- a/apps/web/agent/skills/generate-puzzle-blog.md
+++ b/apps/web/agent/skills/generate-puzzle-blog.md
@@ -52,7 +52,8 @@ You are Eve writing the daily Rebuzzle archive post for **yesterday's** puzzle.
 - Tone: engaging, educational, celebrates the aha — never snarky or clickbait
 - Vary examples and metaphors lightly so posts don't feel identical
 - Never put the answer in the title
-- Mention the answer naturally in solution + SEO body (5–8 times total is fine)
+- Mention the answer only inside the dedicated solution section (2–4 times is enough)
+- Never include the answer in the excerpt, metadata, introduction, analysis, strategy, history, FAQ, or call to action
 - No emojis unless the puzzle display itself uses them
 - Target 1200–2000 words for `fullContent`
 

--- a/apps/web/src/ai/config/blog.ts
+++ b/apps/web/src/ai/config/blog.ts
@@ -50,7 +50,7 @@ WRITING STYLE:
 
 SEO REQUIREMENTS:
 - Use clear H2 and H3 headings for structure
-- Include the puzzle answer naturally 5-8 times (NOT in title)
+- Keep the puzzle answer completely spoiler-safe outside the dedicated solution section
 - Target 1200-2000 words for comprehensive coverage
 - Include FAQ section for featured snippets
 - Focus keyword in first 100 words
@@ -183,7 +183,7 @@ ${originInfoText}
 - Hook readers immediately with an engaging opening
 - Introduce the puzzle type and today's challenge
 - Include focus keyword in first 100 words
-- Mention the answer "${puzzle.answer}" naturally for SEO
+- Do not mention or hint at the answer "${puzzle.answer}"
 - Set expectations for what readers will learn
 
 ## 2. PUZZLE ANALYSIS (200-300 words)
@@ -215,6 +215,7 @@ ${
 - Walk through the logic step-by-step
 - Explain the "aha" moment
 - Connect back to the strategy section
+- This is the ONLY section where the answer may appear
 
 ## 6. FAQ SECTION (3-5 Q&As)
 Create relevant FAQs such as:
@@ -222,6 +223,7 @@ Create relevant FAQs such as:
 - "What makes this puzzle challenging?"
 - "How can I improve at ${puzzleTypeName.toLowerCase()} puzzles?"
 - "Where can I find more puzzles like this?"
+- Keep every FAQ spoiler-free; never include the answer
 
 ## 7. CALL TO ACTION (50-80 words)
 - Encourage readers to try today's puzzle
@@ -229,7 +231,8 @@ Create relevant FAQs such as:
 - Invite them to explore more content
 
 **SEO REQUIREMENTS:**
-- Include "${puzzle.answer}" naturally 5-8 times (NOT in title)
+- Do not include "${puzzle.answer}" in the title, meta description, excerpt, or any section except THE SOLUTION
+- Mention the answer only 2-4 times inside THE SOLUTION
 - Use "${puzzleTypeName.toLowerCase()} puzzle" 3-5 times
 - Include related keywords: solve, strategy, tips, challenge, brain teaser
 - Proper H2/H3 heading structure

--- a/apps/web/src/ai/services/__tests__/blog-generator.test.ts
+++ b/apps/web/src/ai/services/__tests__/blog-generator.test.ts
@@ -1,0 +1,110 @@
+jest.mock("@/ai/client", () => ({
+  generateAIObject: jest.fn(),
+}));
+
+import { type GeneratedBlogPost, getBlogEditorialIssues } from "@/ai/services/blog-generator";
+
+function validPost(overrides: Partial<GeneratedBlogPost> = {}): GeneratedBlogPost {
+  return {
+    title: "A Sound-Based Rebus Challenge",
+    slug: "a-sound-based-rebus-challenge",
+    excerpt: "Learn a practical, spoiler-free method for approaching today's visual word puzzle.",
+    content: [
+      "# A Sound-Based Rebus Challenge",
+      "",
+      "## Introduction",
+      "Listen closely to the symbols without jumping to a conclusion.",
+      "",
+      "## Puzzle Analysis",
+      "The two compact clues reward phonetic thinking.",
+      "",
+      "## The Solution",
+      "The answer is **before**: bee supplies the sound ‘be,’ while four supplies ‘fore.’",
+      "",
+      "## Frequently Asked Questions",
+      "Practice by listing the literal and spoken meaning of each clue.",
+    ].join("\n"),
+    sections: {
+      introduction: "Listen closely to the symbols without jumping to a conclusion.",
+      puzzleAnalysis: "The two compact clues reward phonetic thinking.",
+      solvingStrategy: "Name each symbol, say each name aloud, and combine likely homophones.",
+      puzzleHistory: "Rebuses have long combined pictures and sounds to encode language.",
+      solution: "The answer is before: bee gives ‘be,’ while four gives ‘fore.’",
+      callToAction: "Try another daily puzzle and reuse the same sound-first process.",
+      faq: [
+        {
+          question: "What should I inspect first?",
+          answer: "Start with the literal name and spoken sound of every symbol.",
+        },
+      ],
+    },
+    seoMetadata: {
+      focusKeyword: "rebus puzzle strategy",
+      secondaryKeywords: ["phonetic rebus"],
+      metaDescription:
+        "Learn a practical, spoiler-free method for approaching today's visual word puzzle.",
+      readingTime: 4,
+      wordCount: 800,
+    },
+    ...overrides,
+  };
+}
+
+describe("getBlogEditorialIssues", () => {
+  it("accepts an answer that appears only in the dedicated solution section", () => {
+    expect(getBlogEditorialIssues(validPost(), "before")).toEqual([]);
+  });
+
+  it("rejects answer leakage in metadata, structured sections, FAQs, and markdown", () => {
+    const post = validPost({
+      excerpt: "Discover how the symbols spell before.",
+      content: "## Introduction\nThe answer is before.\n\n## The Solution\nThe answer is before.",
+      sections: {
+        ...validPost().sections,
+        introduction: "This introduction reveals before.",
+        faq: [{ question: "Is it before?", answer: "Yes." }],
+      },
+    });
+
+    expect(getBlogEditorialIssues(post, "before")).toEqual(
+      expect.arrayContaining([
+        "excerpt reveals the answer",
+        "introduction reveals the answer",
+        "FAQ 1 reveals the answer",
+        "full content reveals the answer outside the Solution section",
+      ])
+    );
+  });
+
+  it("requires a solution heading and the answer inside that section", () => {
+    const missingHeading = validPost({ content: "# Puzzle\nA completely spoiler-free article." });
+    expect(getBlogEditorialIssues(missingHeading, "before")).toContain(
+      "full content is missing a dedicated Solution heading"
+    );
+
+    const missingAnswer = validPost({
+      content: "## Introduction\nSpoiler-free setup.\n\n## The Solution\nCombine the two sounds.",
+    });
+    expect(getBlogEditorialIssues(missingAnswer, "before")).toContain(
+      "Solution section does not contain the answer"
+    );
+  });
+
+  it("uses answer word boundaries and rejects obvious repeated copy", () => {
+    expect(
+      getBlogEditorialIssues(
+        validPost({
+          excerpt: "Think beforehand about how each visual clue could sound when spoken aloud.",
+        }),
+        "before"
+      )
+    ).toEqual([]);
+
+    expect(
+      getBlogEditorialIssues(
+        validPost({ content: `${validPost().content}\nA rebus puzzle puzzle should be revised.` }),
+        "before"
+      )
+    ).toContain('full content contains the repeated phrase "puzzle puzzle"');
+  });
+});

--- a/apps/web/src/ai/services/blog-generator.ts
+++ b/apps/web/src/ai/services/blog-generator.ts
@@ -7,9 +7,10 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { generateAIText } from "@/ai/client";
+import { z } from "zod";
+import { generateAIObject } from "@/ai/client";
 import { BLOG_CONFIG } from "@/ai/config/blog";
-import type { BlogFAQItem, BlogPostSEOMetadata, BlogPostSections } from "@/db/models";
+import type { BlogPostSEOMetadata, BlogPostSections } from "@/db/models";
 import type { PuzzleLike } from "@/lib/puzzleUtils";
 import { getPuzzleDisplay, getPuzzleType } from "@/lib/puzzleUtils";
 
@@ -22,22 +23,27 @@ export interface GeneratedBlogPost {
   seoMetadata?: BlogPostSEOMetadata;
 }
 
-interface AIBlogResponse {
-  title: string;
-  metaDescription: string;
-  focusKeyword: string;
-  secondaryKeywords: string[];
-  sections: {
-    introduction?: string;
-    puzzleAnalysis?: string;
-    solvingStrategy?: string;
-    puzzleHistory?: string;
-    solution?: string;
-    callToAction?: string;
-  };
-  faq: BlogFAQItem[];
-  fullContent: string;
-}
+const aiBlogResponseSchema = z.object({
+  title: z.string().min(1),
+  metaDescription: z.string().min(20),
+  focusKeyword: z.string().min(1),
+  secondaryKeywords: z.array(z.string().min(1)),
+  sections: z.object({
+    introduction: z.string().min(1),
+    puzzleAnalysis: z.string().min(1),
+    solvingStrategy: z.string().min(1),
+    puzzleHistory: z.string().min(1),
+    solution: z.string().min(1),
+    callToAction: z.string().min(1),
+  }),
+  faq: z
+    .array(z.object({ question: z.string().min(1), answer: z.string().min(1) }))
+    .min(3)
+    .max(5),
+  fullContent: z.string().min(200),
+});
+
+type AIBlogResponse = z.infer<typeof aiBlogResponseSchema>;
 
 function loadEveBlogSkill(): string {
   try {
@@ -73,6 +79,80 @@ function stripAnswerFromTitle(title: string, answer: string, fallback: string): 
     return title.length > 60 ? `${title.slice(0, 57)}...` : title;
   }
   return fallback;
+}
+
+function answerPattern(answer: string): RegExp {
+  const escaped = answer
+    .trim()
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\s+/g, "\\s+");
+  return new RegExp(`(^|[^a-z0-9])${escaped}(?=$|[^a-z0-9])`, "iu");
+}
+
+function containsAnswer(value: string | undefined, answer: string): boolean {
+  return Boolean(value && answerPattern(answer).test(value));
+}
+
+function contentOutsideSolution(content: string): {
+  outside: string;
+  solution: string;
+} | null {
+  const heading = /^##\s+(?:the\s+)?solution\s*$/im.exec(content);
+  if (!heading || heading.index == null) return null;
+
+  const solutionStart = heading.index + heading[0].length;
+  const afterHeading = content.slice(solutionStart);
+  const nextHeading = /^##\s+/m.exec(afterHeading);
+  const solutionEnd =
+    nextHeading?.index == null ? content.length : solutionStart + nextHeading.index;
+
+  return {
+    outside: `${content.slice(0, heading.index)}\n${content.slice(solutionEnd)}`,
+    solution: content.slice(solutionStart, solutionEnd),
+  };
+}
+
+/** Deterministic publication gate for spoiler safety and obvious copy defects. */
+export function getBlogEditorialIssues(post: GeneratedBlogPost, answer: string): string[] {
+  const issues: string[] = [];
+  const spoilerFields: Array<[string, string | undefined]> = [
+    ["title", post.title],
+    ["excerpt", post.excerpt],
+    ["introduction", post.sections?.introduction],
+    ["puzzle analysis", post.sections?.puzzleAnalysis],
+    ["solving strategy", post.sections?.solvingStrategy],
+    ["puzzle history", post.sections?.puzzleHistory],
+    ["call to action", post.sections?.callToAction],
+    ["SEO meta description", post.seoMetadata?.metaDescription],
+  ];
+
+  for (const [label, value] of spoilerFields) {
+    if (containsAnswer(value, answer)) issues.push(`${label} reveals the answer`);
+  }
+
+  for (const [index, item] of (post.sections?.faq ?? []).entries()) {
+    if (containsAnswer(item.question, answer) || containsAnswer(item.answer, answer)) {
+      issues.push(`FAQ ${index + 1} reveals the answer`);
+    }
+  }
+
+  const contentParts = contentOutsideSolution(post.content);
+  if (!contentParts) {
+    issues.push("full content is missing a dedicated Solution heading");
+  } else {
+    if (containsAnswer(contentParts.outside, answer)) {
+      issues.push("full content reveals the answer outside the Solution section");
+    }
+    if (!containsAnswer(contentParts.solution, answer)) {
+      issues.push("Solution section does not contain the answer");
+    }
+  }
+
+  if (/\bpuzzle\s+puzzle\b/iu.test(post.content)) {
+    issues.push('full content contains the repeated phrase "puzzle puzzle"');
+  }
+
+  return [...new Set(issues)];
 }
 
 /**
@@ -121,51 +201,39 @@ export async function generateBlogPost(
       : "yesterday";
 
   try {
-    const response = await generateAIText({
-      system,
-      prompt: [
-        BLOG_CONFIG.prompts.generatePost(puzzleData),
-        "",
-        `Puzzle live date (UTC): ${publishedKey}`,
-        "Write the archive post for that day — consistent series voice, lightly unique.",
-      ].join("\n"),
-      temperature: 0.65,
-      modelType: "smart",
-    });
+    let retryFeedback = "";
+    let lastIssues: string[] = [];
 
-    const responseText = response.text;
-    const jsonMatch = responseText.match(/```json\s*([\s\S]*?)\s*```/);
-    const rawJson = jsonMatch?.[1] ?? responseText;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const parsedResponse: AIBlogResponse = await generateAIObject({
+        system,
+        prompt: [
+          BLOG_CONFIG.prompts.generatePost(puzzleData),
+          "",
+          `Puzzle live date (UTC): ${publishedKey}`,
+          "Write the archive post for that day — consistent series voice, lightly unique.",
+          retryFeedback,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        temperature: attempt === 1 ? 0.65 : 0.35,
+        modelType: "smart",
+        schema: aiBlogResponseSchema,
+      });
+      console.log(`[Blog Generator] Received structured Eve response (attempt ${attempt})`);
 
-    let parsedResponse: AIBlogResponse | null = null;
-    try {
-      parsedResponse = JSON.parse(rawJson.trim()) as AIBlogResponse;
-      console.log("[Blog Generator] Parsed Eve JSON response");
-    } catch {
-      console.log("[Blog Generator] JSON parse failed — using text fallback");
-    }
-
-    const difficultyPhrase = difficulty >= 7 ? "Tricky" : difficulty >= 5 ? "Challenging" : "Fun";
-    const fallbackTitle = `${difficultyPhrase} ${typeName} Puzzle`;
-
-    let title: string;
-    let content: string;
-    let excerpt: string;
-    let sections: BlogPostSections | undefined;
-    let seoMetadata: BlogPostSEOMetadata | undefined;
-
-    if (parsedResponse) {
-      title = stripAnswerFromTitle(
+      const difficultyPhrase = difficulty >= 7 ? "Tricky" : difficulty >= 5 ? "Challenging" : "Fun";
+      const fallbackTitle = `${difficultyPhrase} ${typeName} Puzzle`;
+      const title = stripAnswerFromTitle(
         parsedResponse.title || fallbackTitle,
         puzzle.answer,
         fallbackTitle
       );
-      content = parsedResponse.fullContent || responseText;
-      excerpt =
+      const content = parsedResponse.fullContent;
+      const excerpt =
         parsedResponse.metaDescription ||
         `A look back at the ${typeName.toLowerCase()} puzzle from ${publishedKey}.`;
-
-      sections = {
+      const sections: BlogPostSections = {
         introduction: parsedResponse.sections?.introduction,
         puzzleAnalysis: parsedResponse.sections?.puzzleAnalysis,
         solvingStrategy: parsedResponse.sections?.solvingStrategy,
@@ -174,42 +242,35 @@ export async function generateBlogPost(
         callToAction: parsedResponse.sections?.callToAction,
         faq: parsedResponse.faq,
       };
-
       const wordCount = content.split(/\s+/).filter(Boolean).length;
-      seoMetadata = {
+      const seoMetadata: BlogPostSEOMetadata = {
         focusKeyword: parsedResponse.focusKeyword || `${typeName.toLowerCase()} puzzle`,
         secondaryKeywords: parsedResponse.secondaryKeywords || [],
         metaDescription: parsedResponse.metaDescription || excerpt,
         readingTime: Math.max(1, Math.ceil(wordCount / 200)),
         wordCount,
       };
-    } else {
-      content = responseText;
-      title = fallbackTitle;
-      const h1Match = content.match(/^#\s+(.+)$/m);
-      if (h1Match?.[1]) {
-        title = stripAnswerFromTitle(
-          h1Match[1].replace(/\*\*/g, "").trim(),
-          puzzle.answer,
-          fallbackTitle
-        );
-      }
-      excerpt = `A look back at the ${typeName.toLowerCase()} puzzle from ${publishedKey}.`;
+      const slug = title
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, "")
+        .replace(/\s+/g, "-");
+      const generated = { title, content, slug, excerpt, sections, seoMetadata };
+
+      lastIssues = getBlogEditorialIssues(generated, puzzle.answer);
+      if (lastIssues.length === 0) return generated;
+
+      console.warn(`[Blog Generator] Editorial validation failed (attempt ${attempt})`, {
+        issues: lastIssues,
+      });
+      retryFeedback = [
+        "",
+        `Your previous draft failed validation: ${lastIssues.join("; ")}.`,
+        `Rewrite the entire JSON. The exact answer "${puzzle.answer}" may appear ONLY under the ## The Solution heading and in sections.solution.`,
+        "Do not put the answer in metadata, excerpt, FAQ, CTA, or any other section. Remove repetitive wording.",
+      ].join("\n");
     }
 
-    const slug = title
-      .toLowerCase()
-      .replace(/[^\w\s-]/g, "")
-      .replace(/\s+/g, "-");
-
-    return {
-      title,
-      content,
-      slug,
-      excerpt,
-      sections,
-      seoMetadata,
-    };
+    throw new Error(`Generated blog post failed editorial validation: ${lastIssues.join("; ")}`);
   } catch (error) {
     console.error("[Blog Generator] Failed to generate blog post:", error);
     throw error;


### PR DESCRIPTION
## Summary

- remove contradictory prompt rules that required the answer outside the solution
- use AI Gateway structured output for repository-ready article JSON
- reject answer leakage across metadata, sections, FAQs, and markdown
- retry low-quality drafts up to three times and fail closed
- reject obvious repeated copy such as puzzle puzzle`n
## Why

The first real Eve article PR proved the GitHub workflow, but its initial draft leaked the answer throughout the article and repeated awkward phrases. Schema validation alone could not enforce editorial quality.

## Validation

- 62 Jest suites / 348 tests passed
- TypeScript passed
- Biome passed on changed TypeScript
- Next.js production build passed (129 static pages)
- live generation rejected two flawed drafts, accepted the third with zero editorial issues, and updated PR #33