### PR TITLE
feat(generator): Add blind human recognition gate for icon candidates

### DIFF
--- a/apps/web/docs/HUMAN_ICON_RECOGNITION.md
+++ b/apps/web/docs/HUMAN_ICON_RECOGNITION.md
@@ -1,0 +1,61 @@
+# Blind human icon recognition
+
+Rebuzzle keeps rendering quality and human comprehension as separate gates.
+[ISO 9186-2](https://www.iso.org/standard/43484.html) tests whether a symbol's
+elements are perceptually identifiable. [ISO
+9186-1](https://www.iso.org/standard/59226.html) tests whether the symbol
+communicates its intended message without explanatory text. A clean SVG or a
+model confidence score is therefore not enough to qualify a puzzle asset.
+
+The admin panel at `/admin/icon-recognition` presents one unlabeled pictogram at
+the exact 36px or 72px player size. It never returns the intended concept,
+aliases, correctness, or aggregate results until that reviewer finishes the
+selected cohort. Answers use the catalog's exact synonym ontology; fuzzy or
+generic matches receive no credit.
+
+## Cohorts
+
+### Publication catalog
+
+- 98 publication-eligible assets at two player sizes (196 specimens)
+- at least three independent reviewers per specimen
+- at least 90% top-1 naming at both sizes for release evidence
+- at least 97% top-1 naming at both sizes for the market-leading evidence gate
+- no individual specimen below the two-of-three hard floor
+
+### Replacement candidates
+
+- 17 quarantined Material Symbol candidates at two sizes
+- seven known publication controls at two sizes, mixed into the blind order
+- 48 total specimens per reviewer
+- a reviewer is counted only after completing the cohort and naming at least
+  85% of hidden controls correctly
+- at least five qualified reviewers per specimen
+- the control cohort must reach at least 95% at both sizes
+- a candidate needs at least 90% aggregate naming and at least 80% at each size
+  before it appears as promotion-eligible
+- the cohort reaches the market-leading evidence gate only at 97% or better at
+  both sizes with no candidate below the size-specific floor
+
+Candidate eligibility is evidence, not automatic publication. Removing a
+catalog quarantine still requires the live independent-model benchmark, a
+review of confusion labels, and a versioned catalog change. Controls and
+candidate fixtures use a separate contract/catalog version so production
+reviews cannot be reused as candidate evidence.
+
+The use of familiar, unambiguous symbols and awareness of cultural differences
+also follows the [W3C cognitive accessibility icon
+guidance](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o1p07-icons-used/).
+
+## Verification
+
+```powershell
+pnpm.cmd exec jest `
+  src/ai/puzzle-agent/review/__tests__/icon-recognition-service.test.ts `
+  src/app/api/admin/ai/icon-recognition/__tests__/route.test.ts `
+  --runInBand
+```
+
+Human evidence is stored as immutable decisions in `iconRecognitionReviews`.
+The unique `(contractVersion, catalogVersion, fixtureId, reviewerId)` index
+prevents a reviewer from answering a specimen twice.

--- a/apps/web/docs/THIRD_PARTY_PICTOGRAMS.md
+++ b/apps/web/docs/THIRD_PARTY_PICTOGRAMS.md
@@ -17,4 +17,5 @@ only wraps it in a sanitized 64px SVG using the product ink color.
 Only path data required for the quarantined replacement candidates is included.
 These symbols are not publication eligible merely because they are vendored.
 Each candidate must pass Rebuzzle's blind multi-model tests at 36px and 72px,
-then the blind human naming panel, before its quarantine entry can be removed.
+then the [blind human naming panel](HUMAN_ICON_RECOGNITION.md), before its
+quarantine entry can be removed.

--- a/apps/web/src/ai/puzzle-agent/review/__tests__/icon-recognition-service.test.ts
+++ b/apps/web/src/ai/puzzle-agent/review/__tests__/icon-recognition-service.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
 import type { IconRecognitionReview } from "@/db/models";
-import { CURATED_PICTOGRAM_CATALOG_VERSION } from "../../visual/curated-pictograms";
+import {
+  CURATED_PICTOGRAM_CATALOG_VERSION,
+  listCuratedPictogramIds,
+} from "../../visual/curated-pictograms";
+import { MATERIAL_SYMBOL_CANDIDATE_SOURCE } from "../../visual/material-symbol-candidates";
 import {
   buildIconRecognitionFixtures,
   createIconRecognitionService,
@@ -52,10 +56,14 @@ function review(input: {
   matchedConceptId?: string;
 }): IconRecognitionReview {
   const correct = input.correct !== false;
+  const catalogVersion =
+    input.fixture.panelId === "candidates"
+      ? `${CURATED_PICTOGRAM_CATALOG_VERSION}+material-symbols-${MATERIAL_SYMBOL_CANDIDATE_SOURCE.commit.slice(0, 12)}`
+      : CURATED_PICTOGRAM_CATALOG_VERSION;
   return {
     id: `${input.reviewerId}:${input.fixture.fixtureId}`,
     contractVersion: HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
-    catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+    catalogVersion,
     fixtureId: input.fixture.fixtureId,
     assetId: input.fixture.assetId,
     conceptId: input.fixture.conceptId,
@@ -83,12 +91,37 @@ describe("blind human icon-recognition calibration", () => {
     }
   });
 
+  it("builds an isolated candidate cohort with hidden publication controls", () => {
+    const fixtures = buildIconRecognitionFixtures("candidates");
+
+    expect(fixtures).toHaveLength(48);
+    expect(fixtures.filter((fixture) => fixture.role === "candidate")).toHaveLength(34);
+    expect(fixtures.filter((fixture) => fixture.role === "control")).toHaveLength(14);
+    expect(new Set(fixtures.map((fixture) => fixture.fixtureId)).size).toBe(48);
+    expect(fixtures.find((fixture) => fixture.conceptId === "computer-mouse")?.assetId).toMatch(
+      /^material-symbols:mouse:/
+    );
+    const publicationFixtureIds = new Set(
+      buildIconRecognitionFixtures().map((fixture) => fixture.fixtureId)
+    );
+    expect(fixtures.some((fixture) => publicationFixtureIds.has(fixture.fixtureId))).toBe(false);
+  });
+
   it("accepts explicit catalog aliases without fuzzy over-credit", () => {
     expect(normalizeIconNamingGuess("An icon of a CAR!")).toBe("car");
     expect(resolveIconNamingGuess("an automobile icon")).toBe("car");
     expect(resolveIconNamingGuess("a picture of a bicycle")).toBe("bicycle");
+    expect(resolveIconNamingGuess("a battery icon")).toBe("battery");
     expect(resolveIconNamingGuess("car or bus")).toBeUndefined();
     expect(resolveIconNamingGuess("vehicle")).toBeUndefined();
+  });
+
+  it("keeps every canonical publication and candidate label unambiguous", () => {
+    const ambiguous = listCuratedPictogramIds({ includeQuarantined: true }).filter(
+      (conceptId) => resolveIconNamingGuess(conceptId) !== conceptId
+    );
+
+    expect(ambiguous).toEqual([]);
   });
 
   it("returns a blind payload and records an immutable response without correctness feedback", async () => {
@@ -117,6 +150,36 @@ describe("blind human icon-recognition calibration", () => {
         guess: fixture.conceptId,
       })
     ).rejects.toBeInstanceOf(IconRecognitionConflictError);
+  });
+
+  it("runs a complete candidate review without revealing labels between decisions", async () => {
+    const store = memoryRepository();
+    const service = createIconRecognitionService(store.repository);
+    const fixtures = buildIconRecognitionFixtures("candidates");
+    const fixtureById = new Map(fixtures.map((fixture) => [fixture.fixtureId, fixture]));
+
+    for (let completed = 0; completed < fixtures.length; completed += 1) {
+      const next = await service.getNext("candidate-reviewer", "candidates");
+      expect(next.progress.completed).toBe(completed);
+      expect(Object.keys(next.specimen ?? {}).sort()).toEqual(["fixtureId", "sizePx", "svg"]);
+      const fixture = fixtureById.get(next.specimen!.fixtureId)!;
+      await service.submit({
+        reviewerId: "candidate-reviewer",
+        panelId: "candidates",
+        fixtureId: fixture.fixtureId,
+        guess: fixture.conceptId,
+      });
+    }
+
+    const finished = await service.getNext("candidate-reviewer", "candidates");
+    expect(finished).toEqual({
+      specimen: null,
+      progress: { completed: 48, total: 48, remaining: 0, complete: true },
+    });
+    const { report } = await service.getReport("candidate-reviewer", "candidates");
+    expect(report.qualifiedReviewerCount).toBe(1);
+    expect(report.releaseReady).toBe(false);
+    expect(report.promotionEligibleConceptIds).toEqual([]);
   });
 
   it("withholds aggregate labels and confusions until the reviewer finishes", async () => {
@@ -156,6 +219,106 @@ describe("blind human icon-recognition calibration", () => {
     expect(report.marketLeadingReady).toBe(true);
     expect(report.status).toBe("market-leading");
     expect(report.generatedAt).toBe("2026-08-01T12:00:00.000Z");
+  });
+
+  it("qualifies replacement candidates only after five complete, control-valid panels", () => {
+    const fixtures = buildIconRecognitionFixtures("candidates");
+    const reviews = ["reviewer-1", "reviewer-2", "reviewer-3", "reviewer-4", "reviewer-5"].flatMap(
+      (reviewerId) => fixtures.map((fixture) => review({ fixture, reviewerId }))
+    );
+    const report = scoreIconRecognitionCalibration({
+      fixtures,
+      reviews,
+      panelId: "candidates",
+    });
+
+    expect(report.fixtureCount).toBe(48);
+    expect(report.targetFixtureCount).toBe(34);
+    expect(report.controlFixtureCount).toBe(14);
+    expect(report.qualifiedReviewerCount).toBe(5);
+    expect(report.excludedReviewerCount).toBe(0);
+    expect(report.controlGatePassed).toBe(true);
+    expect(report.sizeScores.map((score) => score.accuracy)).toEqual([1, 1]);
+    expect(report.marketLeadingReady).toBe(true);
+    expect(report.promotionEligibleConceptIds).toHaveLength(17);
+    expect(report.blockedCandidateConceptIds).toEqual([]);
+  });
+
+  it("does not score partial candidate panels or expose premature promotion evidence", () => {
+    const fixtures = buildIconRecognitionFixtures("candidates");
+    const reviews = fixtures
+      .slice(0, -1)
+      .map((fixture) => review({ fixture, reviewerId: "reviewer-partial" }));
+    const report = scoreIconRecognitionCalibration({
+      fixtures,
+      reviews,
+      panelId: "candidates",
+    });
+
+    expect(report.submittedDecisionCount).toBe(47);
+    expect(report.decisionCount).toBe(0);
+    expect(report.submittedReviewerCount).toBe(1);
+    expect(report.qualifiedReviewerCount).toBe(0);
+    expect(report.excludedReviewerCount).toBe(1);
+    expect(report.coverageRate).toBe(0);
+    expect(report.promotionEligibleConceptIds).toEqual([]);
+    expect(report.blockedCandidateConceptIds).toHaveLength(17);
+  });
+
+  it("fails candidate promotion when qualified reviewers miss the hidden controls", () => {
+    const fixtures = buildIconRecognitionFixtures("candidates");
+    const missedControl = fixtures.find(
+      (fixture) => fixture.role === "control" && fixture.sizePx === 36
+    )!;
+    const reviews = ["reviewer-1", "reviewer-2", "reviewer-3", "reviewer-4", "reviewer-5"].flatMap(
+      (reviewerId) =>
+        fixtures.map((fixture) =>
+          fixture.fixtureId === missedControl.fixtureId
+            ? review({ fixture, reviewerId, correct: false })
+            : review({ fixture, reviewerId })
+        )
+    );
+    const report = scoreIconRecognitionCalibration({
+      fixtures,
+      reviews,
+      panelId: "candidates",
+    });
+
+    expect(report.qualifiedReviewerCount).toBe(5);
+    expect(report.controlGatePassed).toBe(false);
+    expect(report.weakControls).toEqual([
+      expect.objectContaining({ fixtureId: missedControl.fixtureId, accuracy: 0 }),
+    ]);
+    expect(report.releaseReady).toBe(false);
+    expect(report.promotionEligibleConceptIds).toEqual([]);
+  });
+
+  it("blocks one weak candidate even when the cohort average exceeds 97%", () => {
+    const fixtures = buildIconRecognitionFixtures("candidates");
+    const weakCandidate = fixtures.find(
+      (fixture) => fixture.conceptId === "soda" && fixture.sizePx === 36
+    )!;
+    const reviews = ["reviewer-1", "reviewer-2", "reviewer-3", "reviewer-4", "reviewer-5"].flatMap(
+      (reviewerId, reviewerIndex) =>
+        fixtures.map((fixture) =>
+          fixture.fixtureId === weakCandidate.fixtureId && reviewerIndex < 2
+            ? review({ fixture, reviewerId, correct: false, matchedConceptId: "water" })
+            : review({ fixture, reviewerId })
+        )
+    );
+    const report = scoreIconRecognitionCalibration({
+      fixtures,
+      reviews,
+      panelId: "candidates",
+    });
+
+    expect(report.sizeScores.find((score) => score.sizePx === 36)?.accuracy).toBeGreaterThan(0.97);
+    expect(report.weakFixtures).toEqual([
+      expect.objectContaining({ conceptId: "soda", sizePx: 36, accuracy: 0.6 }),
+    ]);
+    expect(report.marketLeadingReady).toBe(false);
+    expect(report.promotionEligibleConceptIds).not.toContain("soda");
+    expect(report.blockedCandidateConceptIds).toEqual(["soda"]);
   });
 
   it("blocks promotion when a single unusable icon is hidden by a 97%+ catalog average", () => {

--- a/apps/web/src/ai/puzzle-agent/review/icon-recognition-service.ts
+++ b/apps/web/src/ai/puzzle-agent/review/icon-recognition-service.ts
@@ -6,13 +6,46 @@ import {
   listCuratedPictogramIds,
   resolveCuratedPictogram,
 } from "../visual/curated-pictograms";
+import {
+  listMaterialSymbolCandidateIds,
+  MATERIAL_SYMBOL_CANDIDATE_SOURCE,
+} from "../visual/material-symbol-candidates";
 
-export const HUMAN_ICON_RECOGNITION_CONTRACT_VERSION = "human-icon-recognition-v1";
+export const HUMAN_ICON_RECOGNITION_CONTRACT_VERSION = "human-icon-recognition-v2";
 export const ICON_RECOGNITION_SIZES = [36, 72] as const;
 export const ICON_RECOGNITION_MIN_REVIEWERS = 3;
+export const ICON_RECOGNITION_CANDIDATE_MIN_REVIEWERS = 5;
 export const ICON_RECOGNITION_RELEASE_ACCURACY = 0.9;
 export const ICON_RECOGNITION_MARKET_ACCURACY = 0.97;
 export const ICON_RECOGNITION_SPECIMEN_FLOOR = 2 / 3;
+export const ICON_RECOGNITION_CANDIDATE_SPECIMEN_FLOOR = 0.8;
+export const ICON_RECOGNITION_CONTROL_SCREEN_ACCURACY = 0.85;
+export const ICON_RECOGNITION_CONTROL_GATE_ACCURACY = 0.95;
+
+export const ICON_RECOGNITION_PANEL_IDS = ["publication", "candidates"] as const;
+export type IconRecognitionPanelId = (typeof ICON_RECOGNITION_PANEL_IDS)[number];
+
+const CANDIDATE_CONTROL_CONCEPT_IDS = [
+  "bicycle",
+  "car",
+  "clock",
+  "crown",
+  "envelope",
+  "fish",
+  "key",
+] as const;
+
+type IconRecognitionFixtureRole = "publication" | "candidate" | "control";
+
+type IconRecognitionPanelConfig = {
+  id: IconRecognitionPanelId;
+  catalogVersion: string;
+  conceptIds: string[];
+  candidateConceptIds: Set<string>;
+  controlConceptIds: Set<string>;
+  minReviewers: number;
+  specimenFloor: number;
+};
 
 export type IconRecognitionSize = (typeof ICON_RECOGNITION_SIZES)[number];
 
@@ -22,6 +55,8 @@ type IconRecognitionFixture = {
   conceptId: string;
   sizePx: IconRecognitionSize;
   svg: string;
+  panelId: IconRecognitionPanelId;
+  role: IconRecognitionFixtureRole;
 };
 
 export type BlindIconRecognitionSpecimen = Pick<
@@ -53,6 +88,7 @@ export type IconRecognitionFixtureScore = {
   fixtureId: string;
   conceptId: string;
   sizePx: IconRecognitionSize;
+  role: IconRecognitionFixtureRole;
   reviewers: number;
   decisions: number;
   correct: number;
@@ -61,6 +97,7 @@ export type IconRecognitionFixtureScore = {
 
 export type IconRecognitionConceptScore = {
   conceptId: string;
+  role: IconRecognitionFixtureRole;
   decisions: number;
   correct: number;
   accuracy: number | null;
@@ -69,17 +106,30 @@ export type IconRecognitionConceptScore = {
 
 export type IconRecognitionCalibrationReport = {
   contractVersion: typeof HUMAN_ICON_RECOGNITION_CONTRACT_VERSION;
-  catalogVersion: typeof CURATED_PICTOGRAM_CATALOG_VERSION;
+  catalogVersion: string;
+  panelId: IconRecognitionPanelId;
   fixtureCount: number;
+  targetFixtureCount: number;
+  controlFixtureCount: number;
+  submittedDecisionCount: number;
   decisionCount: number;
+  submittedReviewerCount: number;
   reviewerCount: number;
+  qualifiedReviewerCount: number;
+  excludedReviewerCount: number;
   requiredReviewersPerFixture: number;
   coveredFixtures: number;
   coverageRate: number;
   sizeScores: IconRecognitionSizeScore[];
+  controlSizeScores: IconRecognitionSizeScore[];
+  controlGateAccuracy: number;
+  controlGatePassed: boolean;
   conceptScores: IconRecognitionConceptScore[];
   specimenAccuracyFloor: number;
   weakFixtures: IconRecognitionFixtureScore[];
+  weakControls: IconRecognitionFixtureScore[];
+  promotionEligibleConceptIds: string[];
+  blockedCandidateConceptIds: string[];
   releaseReady: boolean;
   marketLeadingReady: boolean;
   status: "collecting" | "release-ready" | "market-leading";
@@ -124,6 +174,35 @@ function stableHash(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function panelConfig(panelId: IconRecognitionPanelId): IconRecognitionPanelConfig {
+  if (panelId === "candidates") {
+    const candidateConceptIds = new Set(listMaterialSymbolCandidateIds());
+    const controlConceptIds = new Set<string>(CANDIDATE_CONTROL_CONCEPT_IDS);
+    return {
+      id: panelId,
+      catalogVersion: `${CURATED_PICTOGRAM_CATALOG_VERSION}+material-symbols-${MATERIAL_SYMBOL_CANDIDATE_SOURCE.commit.slice(0, 12)}`,
+      conceptIds: [...candidateConceptIds, ...controlConceptIds],
+      candidateConceptIds,
+      controlConceptIds,
+      minReviewers: ICON_RECOGNITION_CANDIDATE_MIN_REVIEWERS,
+      specimenFloor: ICON_RECOGNITION_CANDIDATE_SPECIMEN_FLOOR,
+    };
+  }
+  return {
+    id: panelId,
+    catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+    conceptIds: listCuratedPictogramIds(),
+    candidateConceptIds: new Set(),
+    controlConceptIds: new Set(),
+    minReviewers: ICON_RECOGNITION_MIN_REVIEWERS,
+    specimenFloor: ICON_RECOGNITION_SPECIMEN_FLOOR,
+  };
+}
+
+export function normalizeIconRecognitionPanelId(value: unknown): IconRecognitionPanelId {
+  return value === "candidates" ? "candidates" : "publication";
+}
+
 export function normalizeIconNamingGuess(value: string): string {
   const words = value
     .toLowerCase()
@@ -140,7 +219,7 @@ export function normalizeIconNamingGuess(value: string): string {
 
 function aliasLookup(): Map<string, string | null> {
   const lookup = new Map<string, string | null>();
-  for (const conceptId of listCuratedPictogramIds()) {
+  for (const conceptId of listCuratedPictogramIds({ includeQuarantined: true })) {
     const aliases = new Set([conceptId, ...getCuratedPictogramAliases(conceptId)]);
     for (const alias of aliases) {
       const normalized = normalizeIconNamingGuess(alias);
@@ -162,18 +241,28 @@ export function resolveIconNamingGuess(value: string): string | undefined {
   return matched ?? undefined;
 }
 
-export function buildIconRecognitionFixtures(): IconRecognitionFixture[] {
-  return listCuratedPictogramIds().flatMap((conceptId) => {
-    const asset = resolveCuratedPictogram(conceptId);
+export function buildIconRecognitionFixtures(
+  panelIdInput: IconRecognitionPanelId = "publication"
+): IconRecognitionFixture[] {
+  const config = panelConfig(panelIdInput);
+  return config.conceptIds.flatMap((conceptId) => {
+    const isCandidate = config.candidateConceptIds.has(conceptId);
+    const asset = resolveCuratedPictogram(conceptId, { includeQuarantined: isCandidate });
     if (!asset) throw new Error(`Catalog asset did not resolve: ${conceptId}`);
     return ICON_RECOGNITION_SIZES.map((sizePx) => ({
       fixtureId: stableHash(
-        `${HUMAN_ICON_RECOGNITION_CONTRACT_VERSION}:${CURATED_PICTOGRAM_CATALOG_VERSION}:${asset.assetId}:${sizePx}`
+        `${HUMAN_ICON_RECOGNITION_CONTRACT_VERSION}:${config.id}:${config.catalogVersion}:${asset.assetId}:${sizePx}`
       ).slice(0, 32),
       assetId: asset.assetId,
       conceptId,
       sizePx,
       svg: asset.svg,
+      panelId: config.id,
+      role: isCandidate
+        ? "candidate"
+        : config.controlConceptIds.has(conceptId)
+          ? "control"
+          : "publication",
     }));
   });
 }
@@ -199,26 +288,51 @@ function orderedFixtures(reviewerId: string, fixtures: IconRecognitionFixture[])
 export function scoreIconRecognitionCalibration(input: {
   fixtures?: IconRecognitionFixture[];
   reviews: IconRecognitionReview[];
+  panelId?: IconRecognitionPanelId;
   minReviewersPerFixture?: number;
   now?: Date;
 }): IconRecognitionCalibrationReport {
-  const fixtures = input.fixtures ?? buildIconRecognitionFixtures();
+  const panelId = normalizeIconRecognitionPanelId(input.panelId ?? input.fixtures?.[0]?.panelId);
+  const config = panelConfig(panelId);
+  const fixtures = input.fixtures ?? buildIconRecognitionFixtures(panelId);
   const fixtureIds = new Set(fixtures.map((fixture) => fixture.fixtureId));
   const seenDecisions = new Set<string>();
-  const reviews = input.reviews.filter((review) => {
+  const submittedReviews = input.reviews.filter((review) => {
     const decisionKey = `${review.fixtureId}\u0000${review.reviewerId}`;
     const eligible =
       review.contractVersion === HUMAN_ICON_RECOGNITION_CONTRACT_VERSION &&
-      review.catalogVersion === CURATED_PICTOGRAM_CATALOG_VERSION &&
+      review.catalogVersion === config.catalogVersion &&
       fixtureIds.has(review.fixtureId) &&
       !seenDecisions.has(decisionKey);
     if (eligible) seenDecisions.add(decisionKey);
     return eligible;
   });
-  const minReviewers = Math.max(
-    1,
-    Math.floor(input.minReviewersPerFixture ?? ICON_RECOGNITION_MIN_REVIEWERS)
-  );
+  const minReviewers = Math.max(1, Math.floor(input.minReviewersPerFixture ?? config.minReviewers));
+  const controlFixtures = fixtures.filter((fixture) => fixture.role === "control");
+  const controlFixtureIds = new Set(controlFixtures.map((fixture) => fixture.fixtureId));
+  const submittedReviewerIds = new Set(submittedReviews.map((review) => review.reviewerId));
+  const qualifiedReviewerIds = new Set<string>();
+  for (const reviewerId of submittedReviewerIds) {
+    if (panelId === "publication") {
+      qualifiedReviewerIds.add(reviewerId);
+      continue;
+    }
+    const reviewerReviews = submittedReviews.filter((review) => review.reviewerId === reviewerId);
+    const completedFixtureIds = new Set(reviewerReviews.map((review) => review.fixtureId));
+    const controlReviews = reviewerReviews.filter((review) =>
+      controlFixtureIds.has(review.fixtureId)
+    );
+    const controlCorrect = controlReviews.filter((review) => review.correct).length;
+    const controlAccuracy = controlReviews.length ? controlCorrect / controlReviews.length : 0;
+    if (
+      completedFixtureIds.size === fixtures.length &&
+      controlReviews.length === controlFixtures.length &&
+      controlAccuracy >= ICON_RECOGNITION_CONTROL_SCREEN_ACCURACY
+    ) {
+      qualifiedReviewerIds.add(reviewerId);
+    }
+  }
+  const reviews = submittedReviews.filter((review) => qualifiedReviewerIds.has(review.reviewerId));
   const fixtureCounts = new Map<string, Set<string>>();
   for (const review of reviews) {
     const reviewers = fixtureCounts.get(review.fixtureId) ?? new Set<string>();
@@ -229,8 +343,22 @@ export function scoreIconRecognitionCalibration(input: {
     (fixture) => (fixtureCounts.get(fixture.fixtureId)?.size ?? 0) >= minReviewers
   ).length;
   const fullCoverage = coveredFixtures === fixtures.length;
+  const targetFixtures = fixtures.filter((fixture) => fixture.role !== "control");
+  const targetFixtureIds = new Set(targetFixtures.map((fixture) => fixture.fixtureId));
+  const targetReviews = reviews.filter((review) => targetFixtureIds.has(review.fixtureId));
+  const controlReviews = reviews.filter((review) => controlFixtureIds.has(review.fixtureId));
   const sizeScores = ICON_RECOGNITION_SIZES.map((sizePx): IconRecognitionSizeScore => {
-    const decisions = reviews.filter((review) => review.sizePx === sizePx);
+    const decisions = targetReviews.filter((review) => review.sizePx === sizePx);
+    const correct = decisions.filter((review) => review.correct).length;
+    return {
+      sizePx,
+      decisions: decisions.length,
+      correct,
+      accuracy: decisions.length ? correct / decisions.length : null,
+    };
+  });
+  const controlSizeScores = ICON_RECOGNITION_SIZES.map((sizePx): IconRecognitionSizeScore => {
+    const decisions = controlReviews.filter((review) => review.sizePx === sizePx);
     const correct = decisions.filter((review) => review.correct).length;
     return {
       sizePx,
@@ -248,6 +376,7 @@ export function scoreIconRecognitionCalibration(input: {
       fixtureId: fixture.fixtureId,
       conceptId: fixture.conceptId,
       sizePx: fixture.sizePx,
+      role: fixture.role,
       reviewers: fixtureCounts.get(fixture.fixtureId)?.size ?? 0,
       decisions: decisions.length,
       correct,
@@ -257,9 +386,10 @@ export function scoreIconRecognitionCalibration(input: {
   const weakFixtures = fixtureScores
     .filter(
       (score) =>
+        score.role !== "control" &&
         score.reviewers >= minReviewers &&
         score.accuracy !== null &&
-        score.accuracy < ICON_RECOGNITION_SPECIMEN_FLOOR
+        score.accuracy < config.specimenFloor
     )
     .sort(
       (left, right) =>
@@ -267,17 +397,48 @@ export function scoreIconRecognitionCalibration(input: {
         left.conceptId.localeCompare(right.conceptId) ||
         left.sizePx - right.sizePx
     );
+  const weakControls = fixtureScores
+    .filter(
+      (score) =>
+        score.role === "control" &&
+        score.reviewers >= minReviewers &&
+        score.accuracy !== null &&
+        score.accuracy < ICON_RECOGNITION_CONTROL_SCREEN_ACCURACY
+    )
+    .sort(
+      (left, right) =>
+        (left.accuracy ?? 1) - (right.accuracy ?? 1) ||
+        left.conceptId.localeCompare(right.conceptId) ||
+        left.sizePx - right.sizePx
+    );
+  const controlGatePassed =
+    panelId === "publication" ||
+    (controlFixtures.every(
+      (fixture) => (fixtureCounts.get(fixture.fixtureId)?.size ?? 0) >= minReviewers
+    ) &&
+      controlSizeScores.every(
+        (score) =>
+          score.accuracy !== null && score.accuracy >= ICON_RECOGNITION_CONTROL_GATE_ACCURACY
+      ));
   const noWeakFixtures = weakFixtures.length === 0;
   const releaseReady =
-    fullCoverage && noWeakFixtures && meetsAccuracy(ICON_RECOGNITION_RELEASE_ACCURACY);
+    fullCoverage &&
+    controlGatePassed &&
+    noWeakFixtures &&
+    meetsAccuracy(ICON_RECOGNITION_RELEASE_ACCURACY);
   const marketLeadingReady =
-    fullCoverage && noWeakFixtures && meetsAccuracy(ICON_RECOGNITION_MARKET_ACCURACY);
-  const conceptScores = listCuratedPictogramIds()
+    fullCoverage &&
+    controlGatePassed &&
+    noWeakFixtures &&
+    meetsAccuracy(ICON_RECOGNITION_MARKET_ACCURACY);
+  const targetConceptIds = [...new Set(targetFixtures.map((fixture) => fixture.conceptId))];
+  const conceptScores = targetConceptIds
     .map((conceptId): IconRecognitionConceptScore => {
-      const conceptReviews = reviews.filter((review) => review.conceptId === conceptId);
+      const conceptReviews = targetReviews.filter((review) => review.conceptId === conceptId);
       const correct = conceptReviews.filter((review) => review.correct).length;
       return {
         conceptId,
+        role: config.candidateConceptIds.has(conceptId) ? "candidate" : "publication",
         decisions: conceptReviews.length,
         correct,
         accuracy: conceptReviews.length ? correct / conceptReviews.length : null,
@@ -298,8 +459,29 @@ export function scoreIconRecognitionCalibration(input: {
         (left.accuracy ?? -1) - (right.accuracy ?? -1) ||
         left.conceptId.localeCompare(right.conceptId)
     );
+  const promotionEligibleConceptIds =
+    panelId === "candidates" && controlGatePassed
+      ? conceptScores
+          .filter(
+            (score) =>
+              score.role === "candidate" &&
+              score.accuracy !== null &&
+              score.accuracy >= ICON_RECOGNITION_RELEASE_ACCURACY &&
+              score.sizes.every(
+                (size) =>
+                  size.decisions >= minReviewers &&
+                  size.accuracy !== null &&
+                  size.accuracy >= config.specimenFloor
+              )
+          )
+          .map((score) => score.conceptId)
+          .sort()
+      : [];
+  const blockedCandidateConceptIds = [...config.candidateConceptIds]
+    .filter((conceptId) => !promotionEligibleConceptIds.includes(conceptId))
+    .sort();
   const confusionCounts = new Map<string, IconRecognitionConfusion>();
-  for (const review of reviews) {
+  for (const review of targetReviews) {
     if (review.correct || !review.matchedConceptId) continue;
     const key = `${review.conceptId}\u0000${review.matchedConceptId}`;
     const current = confusionCounts.get(key);
@@ -312,17 +494,30 @@ export function scoreIconRecognitionCalibration(input: {
 
   return {
     contractVersion: HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
-    catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+    catalogVersion: config.catalogVersion,
+    panelId,
     fixtureCount: fixtures.length,
+    targetFixtureCount: targetFixtures.length,
+    controlFixtureCount: controlFixtures.length,
+    submittedDecisionCount: submittedReviews.length,
     decisionCount: reviews.length,
-    reviewerCount: new Set(reviews.map((review) => review.reviewerId)).size,
+    submittedReviewerCount: submittedReviewerIds.size,
+    reviewerCount: qualifiedReviewerIds.size,
+    qualifiedReviewerCount: qualifiedReviewerIds.size,
+    excludedReviewerCount: submittedReviewerIds.size - qualifiedReviewerIds.size,
     requiredReviewersPerFixture: minReviewers,
     coveredFixtures,
     coverageRate: fixtures.length ? coveredFixtures / fixtures.length : 0,
     sizeScores,
+    controlSizeScores,
+    controlGateAccuracy: ICON_RECOGNITION_CONTROL_GATE_ACCURACY,
+    controlGatePassed,
     conceptScores,
-    specimenAccuracyFloor: ICON_RECOGNITION_SPECIMEN_FLOOR,
+    specimenAccuracyFloor: config.specimenFloor,
     weakFixtures,
+    weakControls,
+    promotionEligibleConceptIds,
+    blockedCandidateConceptIds,
     releaseReady,
     marketLeadingReady,
     status: marketLeadingReady ? "market-leading" : releaseReady ? "release-ready" : "collecting",
@@ -339,39 +534,72 @@ export function scoreIconRecognitionCalibration(input: {
 }
 
 export function createIconRecognitionService(repository: IconRecognitionRepository) {
-  const fixtures = buildIconRecognitionFixtures();
-  const fixtureById = new Map(fixtures.map((fixture) => [fixture.fixtureId, fixture]));
+  const panels = new Map(
+    ICON_RECOGNITION_PANEL_IDS.map((panelId) => {
+      const fixtures = buildIconRecognitionFixtures(panelId);
+      return [
+        panelId,
+        {
+          config: panelConfig(panelId),
+          fixtures,
+          fixtureById: new Map(fixtures.map((fixture) => [fixture.fixtureId, fixture])),
+          fixtureIds: new Set(fixtures.map((fixture) => fixture.fixtureId)),
+        },
+      ] as const;
+    })
+  );
 
-  async function reviewerDecisions(reviewerId: string) {
+  function panel(panelIdInput: unknown) {
+    const panelId = normalizeIconRecognitionPanelId(panelIdInput);
+    return panels.get(panelId)!;
+  }
+
+  async function reviewerDecisions(reviewerId: string, panelId: IconRecognitionPanelId) {
+    const current = panel(panelId);
     return repository.listReviewerDecisions({
       reviewerId,
       contractVersion: HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
-      catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+      catalogVersion: current.config.catalogVersion,
     });
   }
 
+  function completedFixtureIds(
+    decisions: IconRecognitionReview[],
+    fixtureIds: Set<string>
+  ): Set<string> {
+    return new Set(
+      decisions.filter((decision) => fixtureIds.has(decision.fixtureId)).map((row) => row.fixtureId)
+    );
+  }
+
   return {
-    async getNext(reviewerIdInput: string): Promise<{
+    async getNext(
+      reviewerIdInput: string,
+      panelIdInput: IconRecognitionPanelId = "publication"
+    ): Promise<{
       specimen: BlindIconRecognitionSpecimen | null;
       progress: IconRecognitionProgress;
     }> {
       const reviewerId = reviewerIdInput.trim().slice(0, 100);
       if (!reviewerId) throw new Error("Reviewer is required");
-      const decisions = await reviewerDecisions(reviewerId);
-      const completedIds = new Set(decisions.map((decision) => decision.fixtureId));
-      const fixture = orderedFixtures(reviewerId, fixtures).find(
+      const panelId = normalizeIconRecognitionPanelId(panelIdInput);
+      const current = panel(panelId);
+      const decisions = await reviewerDecisions(reviewerId, panelId);
+      const completedIds = completedFixtureIds(decisions, current.fixtureIds);
+      const fixture = orderedFixtures(reviewerId, current.fixtures).find(
         (candidate) => !completedIds.has(candidate.fixtureId)
       );
       return {
         specimen: fixture
           ? { fixtureId: fixture.fixtureId, sizePx: fixture.sizePx, svg: fixture.svg }
           : null,
-        progress: progressFor(fixtures.length, completedIds.size),
+        progress: progressFor(current.fixtures.length, completedIds.size),
       };
     },
 
     async submit(input: {
       reviewerId: string;
+      panelId?: IconRecognitionPanelId;
       fixtureId: string;
       guess?: string;
       uncertain?: boolean;
@@ -380,7 +608,9 @@ export function createIconRecognitionService(repository: IconRecognitionReposito
       const reviewerId = input.reviewerId.trim().slice(0, 100);
       const fixtureId = input.fixtureId.trim();
       if (!reviewerId || !fixtureId) throw new Error("Reviewer and specimen are required");
-      const fixture = fixtureById.get(fixtureId);
+      const panelId = normalizeIconRecognitionPanelId(input.panelId);
+      const current = panel(panelId);
+      const fixture = current.fixtureById.get(fixtureId);
       if (!fixture) throw new Error("Unknown or stale recognition specimen");
       const rawGuess = (input.guess ?? "").trim().slice(0, 100);
       const uncertain = input.uncertain === true || !rawGuess;
@@ -389,7 +619,7 @@ export function createIconRecognitionService(repository: IconRecognitionReposito
       const inserted = await repository.insertDecision({
         id: randomUUID(),
         contractVersion: HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
-        catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+        catalogVersion: current.config.catalogVersion,
         fixtureId,
         assetId: fixture.assetId,
         conceptId: fixture.conceptId,
@@ -403,32 +633,44 @@ export function createIconRecognitionService(repository: IconRecognitionReposito
         createdAt: input.now ?? new Date(),
       });
       if (!inserted) throw new IconRecognitionConflictError();
-      const decisions = await reviewerDecisions(reviewerId);
-      return progressFor(fixtures.length, new Set(decisions.map((row) => row.fixtureId)).size);
+      const decisions = await reviewerDecisions(reviewerId, panelId);
+      return progressFor(
+        current.fixtures.length,
+        completedFixtureIds(decisions, current.fixtureIds).size
+      );
     },
 
-    async getReport(reviewerIdInput: string): Promise<{
+    async getReport(
+      reviewerIdInput: string,
+      panelIdInput: IconRecognitionPanelId = "publication"
+    ): Promise<{
       report: IconRecognitionCalibrationReport;
       reviewerProgress: IconRecognitionProgress;
     }> {
       const reviewerId = reviewerIdInput.trim().slice(0, 100);
       if (!reviewerId) throw new Error("Reviewer is required");
+      const panelId = normalizeIconRecognitionPanelId(panelIdInput);
+      const current = panel(panelId);
       const [allReviews, reviewerReviews] = await Promise.all([
         repository.listCalibrationDecisions({
           contractVersion: HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
-          catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+          catalogVersion: current.config.catalogVersion,
         }),
-        reviewerDecisions(reviewerId),
+        reviewerDecisions(reviewerId, panelId),
       ]);
       const reviewerProgress = progressFor(
-        fixtures.length,
-        new Set(reviewerReviews.map((row) => row.fixtureId)).size
+        current.fixtures.length,
+        completedFixtureIds(reviewerReviews, current.fixtureIds).size
       );
       if (!reviewerProgress.complete) {
         throw new Error("Complete the blind naming panel before viewing calibration results");
       }
       return {
-        report: scoreIconRecognitionCalibration({ fixtures, reviews: allReviews }),
+        report: scoreIconRecognitionCalibration({
+          fixtures: current.fixtures,
+          reviews: allReviews,
+          panelId,
+        }),
         reviewerProgress,
       };
     },

--- a/apps/web/src/app/(admin)/admin/icon-recognition/page.tsx
+++ b/apps/web/src/app/(admin)/admin/icon-recognition/page.tsx
@@ -7,6 +7,7 @@ import { type FormEvent, useCallback, useEffect, useState } from "react";
 import type {
   BlindIconRecognitionSpecimen,
   IconRecognitionCalibrationReport,
+  IconRecognitionPanelId,
   IconRecognitionProgress,
 } from "@/ai/puzzle-agent/review/icon-recognition-service";
 import { useAuth } from "@/components/AuthProvider";
@@ -41,6 +42,7 @@ export default function IconRecognitionPage() {
   const router = useRouter();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { toast } = useToast();
+  const [panelId, setPanelId] = useState<IconRecognitionPanelId>("publication");
   const [specimen, setSpecimen] = useState<BlindIconRecognitionSpecimen | null>(null);
   const [progress, setProgress] = useState<IconRecognitionProgress | null>(null);
   const [report, setReport] = useState<IconRecognitionCalibrationReport | null>(null);
@@ -50,7 +52,7 @@ export default function IconRecognitionPage() {
   const [error, setError] = useState<string | null>(null);
 
   const loadReport = useCallback(async () => {
-    const response = await fetch("/api/admin/ai/icon-recognition?mode=report", {
+    const response = await fetch(`/api/admin/ai/icon-recognition?mode=report&panel=${panelId}`, {
       cache: "no-store",
     });
     if (response.status === 401) {
@@ -63,13 +65,16 @@ export default function IconRecognitionPage() {
     }
     setReport(data.report);
     if (data.reviewerProgress) setProgress(data.reviewerProgress);
-  }, [router]);
+  }, [panelId, router]);
 
   const loadNext = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setReport(null);
     try {
-      const response = await fetch("/api/admin/ai/icon-recognition", { cache: "no-store" });
+      const response = await fetch(`/api/admin/ai/icon-recognition?panel=${panelId}`, {
+        cache: "no-store",
+      });
       if (response.status === 401) {
         router.push("/login");
         return;
@@ -86,7 +91,7 @@ export default function IconRecognitionPage() {
     } finally {
       setLoading(false);
     }
-  }, [loadReport, router]);
+  }, [loadReport, panelId, router]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -109,6 +114,7 @@ export default function IconRecognitionPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          panelId,
           fixtureId: specimen.fixtureId,
           guess: input.uncertain ? "" : guess,
           uncertain: input.uncertain,
@@ -134,6 +140,15 @@ export default function IconRecognitionPage() {
     void submit({ uncertain: false });
   };
 
+  const selectPanel = (nextPanelId: IconRecognitionPanelId) => {
+    if (nextPanelId === panelId) return;
+    setSpecimen(null);
+    setProgress(null);
+    setReport(null);
+    setGuess("");
+    setPanelId(nextPanelId);
+  };
+
   if (authLoading || loading) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
@@ -156,6 +171,39 @@ export default function IconRecognitionPage() {
           your full panel is complete so later answers cannot be coached.
         </p>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Review cohort</CardTitle>
+          <CardDescription>
+            Cohorts are scored independently so experimental assets cannot inherit evidence from the
+            production catalog.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2">
+          <Button
+            aria-pressed={panelId === "publication"}
+            onClick={() => selectPanel("publication")}
+            type="button"
+            variant={panelId === "publication" ? "default" : "outline"}
+          >
+            Publication catalog
+          </Button>
+          <Button
+            aria-pressed={panelId === "candidates"}
+            onClick={() => selectPanel("candidates")}
+            type="button"
+            variant={panelId === "candidates" ? "default" : "outline"}
+          >
+            Replacement candidates
+          </Button>
+          <p className="text-muted-foreground text-xs sm:col-span-2">
+            {panelId === "publication"
+              ? "Qualifies every icon currently allowed in generated puzzles."
+              : "Blindly mixes quarantined replacements with known controls. Candidate answers count only after a reviewer completes the panel and passes the hidden control screen."}
+          </p>
+        </CardContent>
+      </Card>
 
       {progress && (
         <Card>
@@ -237,7 +285,7 @@ export default function IconRecognitionPage() {
             <AlertTitle>Blind panel complete</AlertTitle>
             <AlertDescription>
               Aggregate status: {report.status}. This report includes all independent reviewer
-              decisions for catalog {report.catalogVersion}.
+              decisions for the {report.panelId} cohort ({report.catalogVersion}).
             </AlertDescription>
           </Alert>
 
@@ -269,8 +317,8 @@ export default function IconRecognitionPage() {
             <CardHeader>
               <CardTitle>Readiness gates</CardTitle>
               <CardDescription>
-                Both sizes require complete three-reviewer coverage. Release is 90%; market-leading
-                is 97%.
+                Both sizes require complete {report.requiredReviewersPerFixture}-reviewer coverage.
+                Release is 90%; market-leading is 97%.
               </CardDescription>
             </CardHeader>
             <CardContent className="flex flex-wrap gap-2">
@@ -282,8 +330,56 @@ export default function IconRecognitionPage() {
               </Badge>
               <Badge variant="outline">{report.reviewerCount} reviewers</Badge>
               <Badge variant="outline">{report.decisionCount} decisions</Badge>
+              {report.panelId === "candidates" && (
+                <>
+                  <Badge variant={report.controlGatePassed ? "default" : "destructive"}>
+                    Controls {report.controlGatePassed ? "passed" : "not proven"}
+                  </Badge>
+                  <Badge variant="outline">
+                    {report.qualifiedReviewerCount}/{report.submittedReviewerCount} qualified
+                  </Badge>
+                </>
+              )}
             </CardContent>
           </Card>
+
+          {report.panelId === "candidates" && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Candidate promotion evidence</CardTitle>
+                <CardDescription>
+                  Each eligible concept has complete evidence, at least 90% aggregate naming, at
+                  least {percent(report.specimenAccuracyFloor)} at each player size, and a passing
+                  hidden-control cohort.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="default">
+                    {report.promotionEligibleConceptIds.length} eligible
+                  </Badge>
+                  <Badge variant="secondary">
+                    {report.blockedCandidateConceptIds.length} blocked
+                  </Badge>
+                  {report.excludedReviewerCount > 0 && (
+                    <Badge variant="destructive">
+                      {report.excludedReviewerCount} reviewer(s) excluded by controls
+                    </Badge>
+                  )}
+                </div>
+                {report.promotionEligibleConceptIds.length > 0 && (
+                  <p className="text-sm">
+                    Eligible: {report.promotionEligibleConceptIds.join(", ")}
+                  </p>
+                )}
+                {report.blockedCandidateConceptIds.length > 0 && (
+                  <p className="text-muted-foreground text-sm">
+                    Still quarantined: {report.blockedCandidateConceptIds.join(", ")}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           {report.weakFixtures.length > 0 && (
             <Card>

--- a/apps/web/src/app/api/admin/ai/icon-recognition/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/ai/icon-recognition/__tests__/route.test.ts
@@ -44,7 +44,7 @@ describe("icon recognition admin route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
-    expect(getNext).toHaveBeenCalledWith("admin-1");
+    expect(getNext).toHaveBeenCalledWith("admin-1", "publication");
     expect(Object.keys(data.specimen).sort()).toEqual(["fixtureId", "sizePx", "svg"]);
     expect(JSON.stringify(data)).not.toContain("conceptId");
     expect(JSON.stringify(data)).not.toContain("aliases");
@@ -65,6 +65,7 @@ describe("icon recognition admin route", () => {
     expect(response.status).toBe(200);
     expect(submit).toHaveBeenCalledWith({
       reviewerId: "admin-1",
+      panelId: "publication",
       fixtureId: "opaque",
       guess: "car",
       uncertain: false,
@@ -84,8 +85,42 @@ describe("icon recognition admin route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(getReport).toHaveBeenCalledWith("admin-1");
+    expect(getReport).toHaveBeenCalledWith("admin-1", "publication");
     expect(getNext).not.toHaveBeenCalled();
+  });
+
+  it("routes candidate panels through an isolated evidence cohort", async () => {
+    verifyAdminAccess.mockResolvedValue({ id: "admin-1" });
+    submit.mockResolvedValue({ completed: 1, total: 48, remaining: 47, complete: false });
+    getNext.mockResolvedValue({
+      specimen: { fixtureId: "candidate-opaque", sizePx: 36, svg: "<svg/>" },
+      progress: { completed: 0, total: 48, remaining: 48, complete: false },
+    });
+    const response = await GET(
+      new Request("https://rebuzzle.test/api/admin/ai/icon-recognition?panel=candidates")
+    );
+    const write = await POST(
+      new Request("https://rebuzzle.test/api/admin/ai/icon-recognition", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          panelId: "candidates",
+          fixtureId: "candidate-opaque",
+          guess: "battery",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(write.status).toBe(200);
+    expect(getNext).toHaveBeenCalledWith("admin-1", "candidates");
+    expect(submit).toHaveBeenCalledWith({
+      reviewerId: "admin-1",
+      panelId: "candidates",
+      fixtureId: "candidate-opaque",
+      guess: "battery",
+      uncertain: false,
+    });
   });
 
   it("returns conflict instead of overwriting an existing decision", async () => {

--- a/apps/web/src/app/api/admin/ai/icon-recognition/route.ts
+++ b/apps/web/src/app/api/admin/ai/icon-recognition/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { iconRecognitionService } from "@/ai/puzzle-agent/review/icon-recognition-server";
-import { IconRecognitionConflictError } from "@/ai/puzzle-agent/review/icon-recognition-service";
+import {
+  IconRecognitionConflictError,
+  normalizeIconRecognitionPanelId,
+} from "@/ai/puzzle-agent/review/icon-recognition-service";
 import { verifyAdminAccess } from "@/lib/admin-auth";
 
 const PRIVATE_NO_STORE = { "Cache-Control": "private, no-store" };
@@ -13,12 +16,14 @@ export async function GET(request: Request) {
   try {
     const admin = await verifyAdminAccess(request);
     if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 401 });
-    const mode = new URL(request.url).searchParams.get("mode");
+    const searchParams = new URL(request.url).searchParams;
+    const mode = searchParams.get("mode");
+    const panelId = normalizeIconRecognitionPanelId(searchParams.get("panel"));
     if (mode === "report") {
-      const result = await iconRecognitionService.getReport(admin.id);
+      const result = await iconRecognitionService.getReport(admin.id, panelId);
       return NextResponse.json({ success: true, ...result }, { headers: PRIVATE_NO_STORE });
     }
-    const result = await iconRecognitionService.getNext(admin.id);
+    const result = await iconRecognitionService.getNext(admin.id, panelId);
     return NextResponse.json({ success: true, ...result }, { headers: PRIVATE_NO_STORE });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to load recognition panel";
@@ -39,6 +44,7 @@ export async function POST(request: Request) {
     }
     const progress = await iconRecognitionService.submit({
       reviewerId: admin.id,
+      panelId: normalizeIconRecognitionPanelId(body.panelId),
       fixtureId: typeof body.fixtureId === "string" ? body.fixtureId : "",
       guess: typeof body.guess === "string" ? body.guess : undefined,
       uncertain: body.uncertain === true,


### PR DESCRIPTION
## What changed
- adds a separate blind replacement-candidate recognition cohort to the admin review tool
- mixes 17 quarantined Material Symbol candidates with seven hidden publication controls at 36px and 72px
- excludes incomplete or control-invalid reviewers from evidence
- requires five qualified reviewers, a 95% control gate at each size, 90% aggregate candidate recognition, and 80% at each size before a candidate can be reported promotion-eligible
- keeps promotion evidence-only: no quarantined asset is automatically published
- documents the protocol and ISO/W3C basis

## Why
Machine vision is currently provider-limited and recognizable source art is not enough by itself. This creates a blind human evidence path that cannot silently lower the production catalog's bar.

## Verification
- 69 test suites / 396 tests passed
- TypeScript passed
- changed-file Biome checks passed
- git diff --check passed
- Next.js production build passed (129 routes)
- targeted multi-model preflight failed closed at 0/0 judges and produced no score

## Remaining evidence boundary
- MongoDB was unreachable from this local environment during build diagnostics
- no claim is made that the candidate panel has five real human reviewers yet
- candidates remain quarantined until that evidence exists