### PR TITLE
Reject broken pictograms at player size

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -6,9 +6,9 @@ Generate daily rebus puzzles that are recognizable, fair, novel, and delightful 
 
 ## Audit finding
 
-The current Apex/Eve pipeline already has strong conceptual machinery: multiple candidates, named techniques, uniqueness checks, difficulty calibration, adversarial critique, simulated players, and a tournament rubric. Its critical blind spot is visual evidence.
+The Apex/Eve pipeline began with strong conceptual machinery—multiple candidates, named techniques, uniqueness checks, difficulty calibration, adversarial critique, simulated players, and a tournament rubric—but weak visual evidence.
 
-Generated SVGs are currently checked mainly through markup heuristics such as shape count, strokes, and palette. Blind recognition receives SVG source text rather than rendered pixels. Apex critique receives the declared pictogram concepts and Unicode fallback rather than the visual shown to the player. As a result, a structurally valid SVG can be scored as a recognizable “car” even when its rendered silhouette does not resemble one.
+That original blind spot is now guarded by deterministic player-pixel checks, blind multi-model icon naming, responsive board perception, screenshot-only solving, answer-aware rejection, and human calibration workflows. The remaining market-readiness gap is empirical: the implemented gates still need sufficient qualified-player evidence and credentialed frozen-benchmark results. A green automated pipeline remains screening evidence, not proof that every intended “car” looks like a car to players.
 
 ## Non-negotiable publish contract
 
@@ -71,12 +71,13 @@ For each object:
 
 1. Sanitize the SVG.
 2. Render it at the real 72px player size; test the compact 36px presentation as well.
-3. Enlarge those pixels without adding detail for evaluator compatibility.
-4. Ask at least two independent vision models to name the object without revealing its intended concept.
-5. Require semantic agreement, sufficient confidence, and no high-probability conflicting reading.
-6. On failure, select a vetted asset, redraw from specific feedback, substitute a more concrete cue, or reject the candidate.
+3. Reject the exact player rasters when meaningful 3:1-contrast ink occupies less than 6% or more than 55% of the tile, the visible bounding area is below 18%, content touches the canvas edge, or rasterization fails.
+4. Enlarge those pixels without adding detail for evaluator compatibility.
+5. Ask at least two independent vision models to name the object without revealing its intended concept.
+6. Require semantic agreement, sufficient confidence, and no high-probability conflicting reading.
+7. On failure, select a vetted asset, redraw from specific feedback, substitute a more concrete cue, or reject the candidate.
 
-Structural SVG heuristics remain useful for security and craft, but they are not semantic-recognition evidence.
+The pixel thresholds are deliberately wider than the measured publication catalog envelope: its 36px high-contrast occupancy is approximately 11–33%, with every current asset occupying at least half the width and 58% of the height. Structural and pixel checks catch broken rendering; neither is semantic-recognition evidence, so blind naming and human calibration remain mandatory.
 
 ## Whole-board gate
 
@@ -139,6 +140,7 @@ The first implementation slice now includes:
 - a 98-concept publication catalog selected from 118 local Lucide-backed candidates, with 20 benchmark-failing assets quarantined behind exact provenance checks until replacements pass;
 - catalog-first resolution before long-tail SVG generation;
 - 36px and 72px rasterization so evaluators see compact and large player-level detail;
+- a deterministic 36px/72px pixel-integrity gate for contrast, visible-ink occupancy, subject bounds, canvas-edge contact, and rasterization failures, enforced before model calls and on approved-cache reuse;
 - two independent blind vision judges at every icon size;
 - one shared presentation specification used by the React player and server renderer;
 - independent board perception at compact 320px, mobile 375px, and desktop 768px;
@@ -213,13 +215,13 @@ The workflow and gates are implemented, but no human decisions have been fabrica
 
 ### Human-governed generated asset registry
 
-The curated Lucide-backed catalog remains the first and preferred visual source. When a genuinely long-tail concept requires generated SVG artwork, the asset may support only the puzzle generation attempt that produced it after passing the live structural and two-model recognition gates. It is not silently promoted into a reusable cache.
+The curated Lucide-backed catalog remains the first and preferred visual source. When a genuinely long-tail concept requires generated SVG artwork, the asset may support only the puzzle generation attempt that produced it after passing the structural, exact player-pixel, and live two-model recognition gates. It is not silently promoted into a reusable cache.
 
 Every newly accepted long-tail SVG is submitted to `generated-pictogram-registry-v1` with its exact SHA-256, normalized concept, style version, clarity evidence, 36px and 72px recognition evidence, and append-only audit event. The registry accepts at most one pending candidate per concept so reviewers are not flooded with competing variants. Guesses receive only exact normalized concept or simple singular/plural credit; fuzzy category matches do not turn an ambiguous symbol into an approval.
 
 Administrators review the queue at `/admin/generated-assets`. Each browser payload contains only an opaque fixture ID, exact player-size sanitized SVG, and size. A response is immutable for that reviewer/specimen, “I don't know” is a failure, and no correctness is returned. The concept and aggregate status become visible to that reviewer only after they have judged both sizes of that candidate, preventing the 36px result from coaching the 72px decision or vice versa.
 
-Reusable approval is deliberately strict: three independent reviewers must name the intended object correctly at 36px and all three must do so again at 72px. One completed size with any miss rejects the candidate. An approved lookup still verifies the stored hash, exact sanitization, structural clarity, and current automated recognition at both sizes. A corrupted or regressed asset is atomically quarantined and fresh generation resumes through the full gate; it is never served merely because it passed an older model version.
+Reusable approval is deliberately strict: three independent reviewers must name the intended object correctly at 36px and all three must do so again at 72px. One completed size with any miss rejects the candidate. An approved lookup still verifies the stored hash, exact sanitization, structural clarity, player-pixel integrity, and current automated recognition at both sizes. A corrupted or regressed asset is atomically quarantined and fresh generation resumes through the full gate; it is never served merely because it passed an older model version.
 
 This registry converts generation into a governed asset-sourcing lane rather than an unlimited source of production icons. The code, storage locks, panel, and runtime quarantine are implemented, but no approvals have been fabricated. Market readiness for long-tail artwork remains unproven until real independent reviewers complete candidates and those assets survive live credentialed recognition plus player telemetry.
 
@@ -267,7 +269,7 @@ The evaluator commands write versioned JSON evidence under `artifacts/puzzle-gen
 
 Live vision preflight fails before scoring when any configured independent judge is unavailable. The failure now identifies the player size, model ID, and a sanitized provider error for every missing judge; benchmark artifacts retain the same diagnostics. This keeps publication fail-closed while distinguishing revoked credentials, unavailable model IDs, provider limits, and unsupported requests from an ordinary recognition miss.
 
-The solve report distinguishes answer presence from actual playability. A profile counts as detected only when both independent judges agree; one-of-two agreement is a failure, not half credit. Promotion currently requires at least 80% answer presence, 75% top-answer detection, 70% dominant-answer detection, 70% compact top-answer detection, mean reciprocal rank of at least 0.75, and no more than 10% ambiguous observations. These are provisional automated screening thresholds; human calibration remains authoritative. Benchmark contract `2026-08-02.7` invalidates both reports produced under the older any-one-judge scoring semantics and pre-quarantine catalog reports.
+The solve report distinguishes answer presence from actual playability. A profile counts as detected only when both independent judges agree; one-of-two agreement is a failure, not half credit. Promotion currently requires at least 80% answer presence, 75% top-answer detection, 70% dominant-answer detection, 70% compact top-answer detection, mean reciprocal rank of at least 0.75, and no more than 10% ambiguous observations. These are provisional automated screening thresholds; human calibration remains authoritative. Benchmark contract `2026-08-02.8` also binds live-generator evidence to the deterministic player-pixel gate; reports from earlier contracts cannot promote this generator.
 
 The editorial report prevents trivial evaluators from winning: known-good acceptance must remain at least 95%, known-failure detection at least 99%, two-judge failure consensus at least 90%, compact failure detection at least 99%, and all critical fixtures must pass. Market-readiness remains false until the corpus contains at least 150 vetted positives, 100 vetted failures, complete technique coverage, and at least 10 failures per failure class. The current 24-positive/12-failure seed is executable infrastructure, not market-leading evidence.
 
@@ -304,6 +306,7 @@ An external run can promote only with at least 100 human-approved originals, bot
 ### Stage 1 — stop unrecognizable publication
 
 - Rasterize SVGs at player size.
+- Reject invisible, off-canvas, low-contrast, tiny, edge-clipped, and overfilled player rasters deterministically.
 - Replace SVG-source recognition with blind pixel recognition.
 - Require independent model consensus and fail closed.
 - Make low icon-recognition scores a hard Apex rejection.
@@ -332,6 +335,7 @@ An external run can promote only with at least 100 human-approved originals, bot
 
 - [ISO 9186-1](https://www.iso.org/standard/59226.html) defines comprehension testing for graphical symbols without explanatory text.
 - [ISO 9186-2](https://www.iso.org/standard/43484.html) covers perceptual-quality testing so symbol elements are identifiable to the eventual user population.
+- [WCAG 2.2 non-text contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast) requires meaningful graphical objects to reach 3:1 contrast against adjacent colors and warns that thin antialiased shapes can be materially fainter in practice.
 - [REBUS benchmark](https://arxiv.org/abs/2401.05604) reports that strong multimodal models still perform poorly on difficult rebus solving, supporting human calibration rather than trusting model self-scores.
 - [Puzzled by Puzzles](https://aclanthology.org/2025.emnlp-main.1101/) finds persistent VLM difficulty with abstraction, visual metaphor, and lateral reasoning.
 - [RE-BUS](https://rebus-dataset.github.io/) provides a larger 1,333-puzzle benchmark and structured visual-reasoning evaluation ideas.

--- a/apps/web/src/ai/puzzle-agent/benchmark/types.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/types.ts
@@ -1,6 +1,6 @@
 import type { EditorialFailureKind } from "../visual/editorial-consensus";
 
-export const PUZZLE_GENERATOR_BENCHMARK_VERSION = "2026-08-02.7";
+export const PUZZLE_GENERATOR_BENCHMARK_VERSION = "2026-08-02.8";
 export const ICON_BENCHMARK_TILE_SIZES = [36, 72] as const;
 
 export type IconBenchmarkExpectation = "accept" | "reject";

--- a/apps/web/src/ai/puzzle-agent/review/__tests__/generated-pictogram-registry.test.ts
+++ b/apps/web/src/ai/puzzle-agent/review/__tests__/generated-pictogram-registry.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "@jest/globals";
 import type { GeneratedPictogramCandidate, GeneratedPictogramReview } from "@/db/models";
 import { resolveCuratedPictogram } from "../../visual/curated-pictograms";
@@ -118,6 +119,9 @@ function automatedInput(concept = "lighthouse") {
   };
 }
 
+const OFF_CANVAS_SVG =
+  '<svg viewBox="0 0 64 64"><path d="M 96 96 L 110 96 L 110 110 L 96 110 Z" fill="#1a1f1c" stroke="#1a1f1c"/><path d="M 112 96 L 126 96 L 126 110 L 112 110 Z" fill="#1a1f1c" stroke="#1a1f1c"/><path d="M 96 112 L 110 112 L 110 126 L 96 126 Z" fill="#1a1f1c" stroke="#1a1f1c"/></svg>';
+
 async function completeReviewer(
   registry: ReturnType<typeof createGeneratedPictogramRegistry>,
   reviewerId: string,
@@ -148,6 +152,19 @@ describe("human-governed generated pictogram registry", () => {
     await expect(
       registry.submitCandidate({ ...automatedInput(), recognitionProfiles: [] })
     ).rejects.toThrow("both player-size");
+    expect(store.candidates).toHaveLength(0);
+  });
+
+  it("rejects source-valid candidates that disappear at player size", async () => {
+    const store = memoryRepository();
+    const registry = createGeneratedPictogramRegistry(store.repository);
+
+    await expect(
+      registry.submitCandidate({
+        ...automatedInput(),
+        svg: OFF_CANVAS_SVG,
+      })
+    ).rejects.toThrow("player-pixel integrity");
     expect(store.candidates).toHaveLength(0);
   });
 
@@ -260,6 +277,21 @@ describe("human-governed generated pictogram registry", () => {
     await expect(registry.findApproved("lighthouse")).resolves.toBeNull();
     expect(store.candidates[0]?.status).toBe("quarantined");
     expect(store.candidates[0]?.auditHistory.at(-1)?.actor).toBe("runtime-gate");
+  });
+
+  it("quarantines a hash-valid approved asset whose player raster regresses", async () => {
+    const store = memoryRepository();
+    const registry = createGeneratedPictogramRegistry(store.repository);
+    await registry.submitCandidate(automatedInput());
+    await completeReviewer(registry, "reviewer-1", "lighthouse");
+    await completeReviewer(registry, "reviewer-2", "lighthouse");
+    await completeReviewer(registry, "reviewer-3", "lighthouse");
+    store.candidates[0]!.svg = OFF_CANVAS_SVG;
+    store.candidates[0]!.assetSha256 = createHash("sha256").update(OFF_CANVAS_SVG).digest("hex");
+
+    await expect(registry.findApproved("lighthouse")).resolves.toBeNull();
+    expect(store.candidates[0]?.status).toBe("quarantined");
+    expect(store.candidates[0]?.auditHistory.at(-1)?.reason).toContain("integrity validation");
   });
 
   it("ignores stale registry versions", async () => {

--- a/apps/web/src/ai/puzzle-agent/review/generated-pictogram-registry.ts
+++ b/apps/web/src/ai/puzzle-agent/review/generated-pictogram-registry.ts
@@ -6,6 +6,7 @@ import type {
   GeneratedPictogramStatus,
 } from "@/db/models";
 import { scorePictogramClarity } from "../visual/pictogram-clarity";
+import { evaluatePictogramPixelIntegrity } from "../visual/pictogram-pixel-integrity";
 import { sanitizePictogramSvg } from "../visual/sanitize-svg";
 import { INK_PICTOGRAM_STYLE_ID } from "../visual/style";
 import { normalizeIconNamingGuess, resolveIconNamingGuess } from "./icon-recognition-service";
@@ -255,6 +256,12 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
       if (!svg) throw new Error("Generated pictogram candidate SVG is invalid");
       const clarity = scorePictogramClarity(svg);
       if (!clarity.ok) throw new Error("Generated pictogram candidate failed structural clarity");
+      const pixelIntegrity = await evaluatePictogramPixelIntegrity(svg);
+      if (!pixelIntegrity.ok) {
+        throw new Error(
+          `Generated pictogram candidate failed player-pixel integrity: ${pixelIntegrity.reasons.join(", ")}`
+        );
+      }
       const profileSizes = new Set((input.recognitionProfiles ?? []).map((row) => row.tileSize));
       if (!profileSizes.has(36) || !profileSizes.has(72)) {
         throw new Error(
@@ -291,7 +298,8 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
           event({
             action: "submitted",
             actor: "generator",
-            reason: "Passed current structural and two-size automated recognition gates",
+            reason:
+              "Passed current structural, player-pixel, and two-size automated recognition gates",
             now,
           }),
         ],
@@ -311,11 +319,13 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
         conceptKey,
       });
       if (!candidate) return null;
+      const pixelIntegrity = await evaluatePictogramPixelIntegrity(candidate.svg);
       const valid =
         candidate.status === "approved" &&
         candidate.assetSha256 === sha256(candidate.svg) &&
         sanitizePictogramSvg(candidate.svg) === candidate.svg &&
-        scorePictogramClarity(candidate.svg).ok;
+        scorePictogramClarity(candidate.svg).ok &&
+        pixelIntegrity.ok;
       if (valid) return candidate;
       await this.quarantine(candidate.id, "Approved registry asset failed integrity validation");
       return null;

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/generate-pictogram-registry.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/generate-pictogram-registry.test.ts
@@ -86,6 +86,23 @@ describe("generated pictogram registry integration", () => {
     });
   });
 
+  it("rejects a source-valid drawing that disappears at player size before vision calls", async () => {
+    generateAIText.mockResolvedValueOnce({
+      text: '<svg viewBox="0 0 64 64"><path d="M 96 96 L 110 96 L 110 110 L 96 110 Z" fill="#1a1f1c" stroke="#1a1f1c"/><path d="M 112 96 L 126 96 L 126 110 L 112 110 Z" fill="#1a1f1c" stroke="#1a1f1c"/><path d="M 96 112 L 110 112 L 110 126 L 96 126 Z" fill="#1a1f1c" stroke="#1a1f1c"/></svg>',
+    });
+
+    const result = await generatePictogram({
+      concept: "lighthouse",
+      maxRetries: 0,
+      usage: "review",
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.error).toContain("pixel_integrity");
+    expect(recognizePictogramIcon).not.toHaveBeenCalled();
+    expect(submitCandidate).not.toHaveBeenCalled();
+  });
+
   it("reuses a human-approved exact asset but still reruns current recognition", async () => {
     findApproved.mockResolvedValue({ id: "generated-pictogram:approved", svg });
 

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/pictogram-pixel-integrity.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/pictogram-pixel-integrity.test.ts
@@ -1,0 +1,42 @@
+import { listCuratedPictogramIds, resolveCuratedPictogram } from "../curated-pictograms";
+import { evaluatePictogramPixelIntegrity } from "../pictogram-pixel-integrity";
+
+describe("player-sized pictogram pixel integrity", () => {
+  it("accepts every publication catalog asset at 36px and 72px", async () => {
+    const failures: Array<{ id: string; reasons: string[] }> = [];
+    for (const id of listCuratedPictogramIds()) {
+      const result = await evaluatePictogramPixelIntegrity(resolveCuratedPictogram(id)!.svg);
+      if (!result.ok) failures.push({ id, reasons: result.reasons });
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it.each([
+    [
+      "off-canvas",
+      '<svg viewBox="0 0 64 64"><circle cx="100" cy="100" r="12" fill="#1a1f1c"/></svg>',
+      "too_little_visible_ink",
+    ],
+    [
+      "low-contrast",
+      '<svg viewBox="0 0 64 64"><rect x="8" y="8" width="48" height="48" fill="none" stroke="#d8dad7" stroke-width="5"/></svg>',
+      "insufficient_contrast",
+    ],
+    [
+      "tiny",
+      '<svg viewBox="0 0 64 64"><rect x="30" y="30" width="4" height="4" fill="#1a1f1c"/></svg>',
+      "visible_subject_too_small",
+    ],
+    [
+      "canvas-filling",
+      '<svg viewBox="0 0 64 64"><rect width="64" height="64" fill="#1a1f1c"/></svg>',
+      "overfilled_canvas",
+    ],
+  ])("rejects %s generated geometry", async (_label, svg, expectedReason) => {
+    const result = await evaluatePictogramPixelIntegrity(svg);
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons.join(" ")).toContain(expectedReason);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
@@ -9,6 +9,10 @@ import { recognizePictogramIcon } from "./critique-pictogram";
 import { resolveCuratedPictogram } from "./curated-pictograms";
 import { getIconFeatureHints } from "./icon-features";
 import { buildConcreteDrawingBrief, scorePictogramClarity } from "./pictogram-clarity";
+import {
+  evaluatePictogramPixelIntegrity,
+  type PictogramPixelIntegrityResult,
+} from "./pictogram-pixel-integrity";
 import { sanitizePictogramSvg } from "./sanitize-svg";
 import { INK_PICTOGRAM_PALETTE, INK_PICTOGRAM_STYLE_GUIDE, INK_PICTOGRAM_STYLE_ID } from "./style";
 
@@ -37,6 +41,7 @@ export type GeneratePictogramResult = {
   ok: boolean;
   clarityScore?: number;
   clarityReasons?: string[];
+  pixelIntegrity?: PictogramPixelIntegrityResult;
   seenAs?: string;
   recognitionConfidence?: number;
   recognitionProfiles?: Array<{ tileSize: number; seenAs: string; confidence: number }>;
@@ -323,11 +328,14 @@ export async function generatePictogram(
   let lastRecognitionProfiles:
     | Array<{ tileSize: number; seenAs: string; confidence: number }>
     | undefined;
+  let lastPixelIntegrity: PictogramPixelIntegrityResult | undefined;
 
   const curated = resolveCuratedPictogram(concept);
   if (curated) {
     const clarity = scorePictogramClarity(curated.svg);
-    if (input.skipRecognition || usage === "publication") {
+    const pixelIntegrity = await evaluatePictogramPixelIntegrity(curated.svg);
+    lastPixelIntegrity = pixelIntegrity;
+    if (clarity.ok && pixelIntegrity.ok && (input.skipRecognition || usage === "publication")) {
       return {
         styleId: INK_PICTOGRAM_STYLE_ID,
         concept,
@@ -337,48 +345,58 @@ export async function generatePictogram(
         ok: true,
         clarityScore: Math.max(90, clarity.score),
         clarityReasons: [],
+        pixelIntegrity,
         attempts: 0,
         source: "catalog",
         assetId: curated.assetId,
       };
     }
 
-    const recognition = await recognizePictogramIcon({
-      svg: curated.svg,
-      concept,
-    });
-    if (recognition.ok) {
-      return {
-        styleId: INK_PICTOGRAM_STYLE_ID,
-        concept,
-        role: input.role,
+    if (clarity.ok && pixelIntegrity.ok) {
+      const recognition = await recognizePictogramIcon({
         svg: curated.svg,
-        emojiFallback,
-        ok: true,
-        clarityScore: Math.max(90, clarity.score),
-        clarityReasons: [],
-        seenAs: recognition.seenLabel,
-        recognitionConfidence: recognition.confidence,
-        recognitionProfiles: recognition.profileResults?.map((profile) => ({
-          tileSize: profile.tileSize,
-          seenAs: profile.seenLabel,
-          confidence: profile.confidence,
-        })),
-        attempts: 0,
-        source: "catalog",
-        assetId: curated.assetId,
-      };
-    }
+        concept,
+      });
+      if (recognition.ok) {
+        return {
+          styleId: INK_PICTOGRAM_STYLE_ID,
+          concept,
+          role: input.role,
+          svg: curated.svg,
+          emojiFallback,
+          ok: true,
+          clarityScore: Math.max(90, clarity.score),
+          clarityReasons: [],
+          pixelIntegrity,
+          seenAs: recognition.seenLabel,
+          recognitionConfidence: recognition.confidence,
+          recognitionProfiles: recognition.profileResults?.map((profile) => ({
+            tileSize: profile.tileSize,
+            seenAs: profile.seenLabel,
+            confidence: profile.confidence,
+          })),
+          attempts: 0,
+          source: "catalog",
+          assetId: curated.assetId,
+        };
+      }
 
-    lastSeenAs = recognition.seenLabel;
-    lastRecognitionConfidence = recognition.confidence;
-    lastRecognitionProfiles = recognition.profileResults?.map((profile) => ({
-      tileSize: profile.tileSize,
-      seenAs: profile.seenLabel,
-      confidence: profile.confidence,
-    }));
-    lastRedrawAdvice = recognition.redrawAdvice;
-    lastReasons = [`catalog_seen_as:${recognition.seenLabel}`, "catalog_recognition_failed"];
+      lastSeenAs = recognition.seenLabel;
+      lastRecognitionConfidence = recognition.confidence;
+      lastRecognitionProfiles = recognition.profileResults?.map((profile) => ({
+        tileSize: profile.tileSize,
+        seenAs: profile.seenLabel,
+        confidence: profile.confidence,
+      }));
+      lastRedrawAdvice = recognition.redrawAdvice;
+      lastReasons = [`catalog_seen_as:${recognition.seenLabel}`, "catalog_recognition_failed"];
+    } else {
+      lastReasons = [
+        ...clarity.reasons,
+        ...pixelIntegrity.reasons,
+        "catalog_pixel_integrity_failed",
+      ];
+    }
   }
 
   if (!input.skipRecognition) {
@@ -387,11 +405,16 @@ export async function generatePictogram(
       const approved = await registry.findApproved(concept);
       if (approved) {
         const clarity = scorePictogramClarity(approved.svg);
-        const recognition = await recognizePictogramIcon({
-          svg: approved.svg,
-          concept,
-        });
-        if (clarity.ok && recognition.ok) {
+        const pixelIntegrity = await evaluatePictogramPixelIntegrity(approved.svg);
+        lastPixelIntegrity = pixelIntegrity;
+        const recognition =
+          clarity.ok && pixelIntegrity.ok
+            ? await recognizePictogramIcon({
+                svg: approved.svg,
+                concept,
+              })
+            : undefined;
+        if (clarity.ok && pixelIntegrity.ok && recognition?.ok) {
           return {
             styleId: INK_PICTOGRAM_STYLE_ID,
             concept,
@@ -401,6 +424,7 @@ export async function generatePictogram(
             ok: true,
             clarityScore: clarity.score,
             clarityReasons: clarity.reasons,
+            pixelIntegrity,
             seenAs: recognition.seenLabel,
             recognitionConfidence: recognition.confidence,
             recognitionProfiles: recognition.profileResults?.map((profile) => ({
@@ -415,19 +439,26 @@ export async function generatePictogram(
         }
         await registry.quarantine(
           approved.id,
-          recognition.ok
+          !clarity.ok
             ? `Runtime structural clarity regression: ${clarity.reasons.join(", ")}`
-            : `Runtime recognition regression: seen as ${recognition.seenLabel}`
+            : !pixelIntegrity.ok
+              ? `Runtime player-pixel regression: ${pixelIntegrity.reasons.join(", ")}`
+              : `Runtime recognition regression: seen as ${recognition?.seenLabel ?? "unclear"}`
         );
-        lastSeenAs = recognition.seenLabel;
-        lastRecognitionConfidence = recognition.confidence;
-        lastRecognitionProfiles = recognition.profileResults?.map((profile) => ({
+        lastSeenAs = recognition?.seenLabel;
+        lastRecognitionConfidence = recognition?.confidence;
+        lastRecognitionProfiles = recognition?.profileResults?.map((profile) => ({
           tileSize: profile.tileSize,
           seenAs: profile.seenLabel,
           confidence: profile.confidence,
         }));
-        lastRedrawAdvice = recognition.redrawAdvice;
-        lastReasons = ["approved_cache_regression", `seen_as:${recognition.seenLabel}`];
+        lastRedrawAdvice = recognition?.redrawAdvice;
+        lastReasons = [
+          "approved_cache_regression",
+          ...clarity.reasons,
+          ...pixelIntegrity.reasons,
+          ...(recognition ? [`seen_as:${recognition.seenLabel}`] : []),
+        ];
       }
     } catch (error) {
       logger.warn("Generated pictogram registry unavailable", {
@@ -447,6 +478,7 @@ export async function generatePictogram(
       ok: false,
       clarityScore: lastScore,
       clarityReasons: lastReasons,
+      pixelIntegrity: lastPixelIntegrity,
       seenAs: lastSeenAs,
       recognitionConfidence: lastRecognitionConfidence,
       recognitionProfiles: lastRecognitionProfiles,
@@ -480,6 +512,14 @@ export async function generatePictogram(
       continue;
     }
 
+    const pixelIntegrity = await evaluatePictogramPixelIntegrity(drawn.svg);
+    lastPixelIntegrity = pixelIntegrity;
+    if (!pixelIntegrity.ok) {
+      lastReasons = [...clarity.reasons, ...pixelIntegrity.reasons];
+      lastError = `pixel_integrity:${pixelIntegrity.reasons.join(",")}`;
+      continue;
+    }
+
     if (!input.skipRecognition) {
       const recognition = await recognizePictogramIcon({
         svg: drawn.svg,
@@ -505,7 +545,6 @@ export async function generatePictogram(
       }
 
       let candidateAssetId: string | undefined;
-      let candidateQueued = false;
       try {
         const registry = await loadGeneratedPictogramRegistry();
         const candidate = await registry.submitCandidate({
@@ -517,7 +556,6 @@ export async function generatePictogram(
           recognitionProfiles: lastRecognitionProfiles,
         });
         candidateAssetId = candidate?.id;
-        candidateQueued = Boolean(candidate);
       } catch (error) {
         logger.warn("Failed to queue generated pictogram for blind human review", {
           concept,
@@ -534,6 +572,7 @@ export async function generatePictogram(
         ok: true,
         clarityScore: clarity.score,
         clarityReasons: clarity.reasons,
+        pixelIntegrity,
         seenAs: recognition.seenLabel,
         recognitionConfidence: recognition.confidence,
         recognitionProfiles: lastRecognitionProfiles,
@@ -552,6 +591,7 @@ export async function generatePictogram(
       ok: true,
       clarityScore: clarity.score,
       clarityReasons: clarity.reasons,
+      pixelIntegrity,
       attempts: attempt + 1,
       source: "generated",
     };
@@ -566,6 +606,7 @@ export async function generatePictogram(
     ok: false,
     clarityScore: lastScore,
     clarityReasons: lastReasons,
+    pixelIntegrity: lastPixelIntegrity,
     seenAs: lastSeenAs,
     recognitionConfidence: lastRecognitionConfidence,
     recognitionProfiles: lastRecognitionProfiles,

--- a/apps/web/src/ai/puzzle-agent/visual/index.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/index.ts
@@ -16,6 +16,10 @@ export {
   VisualLayerSchema,
 } from "./composition";
 export {
+  type IconRecognitionResult,
+  recognizePictogramIcon,
+} from "./critique-pictogram";
+export {
   type GenerateImageTileInput,
   type GenerateImageTileResult,
   generateImageTile,
@@ -26,6 +30,14 @@ export {
   generatePictogram,
 } from "./generate-pictogram";
 export {
+  conceptMatchesSeen,
+  getIconFeatureHints,
+  ICON_FEATURES,
+  lookupIconFeatures,
+  OVERUSED_REBUS_TROPES,
+} from "./icon-features";
+export { inventLabBrief, type LabBrief } from "./invent-lab-brief";
+export {
   buildLabLayers,
   guessEmoji,
   isVisualLabMode,
@@ -34,26 +46,21 @@ export {
   type VisualLabMode,
   type VisualLabModeMeta,
 } from "./lab-recipes";
-export { inventLabBrief, type LabBrief } from "./invent-lab-brief";
-export { type RunVisualLabInput, type RunVisualLabResult, runVisualLab } from "./run-visual-lab";
-export {
-  recognizePictogramIcon,
-  type IconRecognitionResult,
-} from "./critique-pictogram";
-export {
-  conceptMatchesSeen,
-  getIconFeatureHints,
-  ICON_FEATURES,
-  OVERUSED_REBUS_TROPES,
-  lookupIconFeatures,
-} from "./icon-features";
 export {
   buildConcreteDrawingBrief,
   isAbstractPictogramConcept,
+  type PictogramClarityResult,
   passesPictogramClarity,
   scorePictogramClarity,
-  type PictogramClarityResult,
 } from "./pictogram-clarity";
+export {
+  evaluatePictogramPixelIntegrity,
+  PICTOGRAM_PIXEL_INTEGRITY_SIZES,
+  PICTOGRAM_PIXEL_INTEGRITY_VERSION,
+  type PictogramPixelIntegrityProfile,
+  type PictogramPixelIntegrityResult,
+} from "./pictogram-pixel-integrity";
+export { type RunVisualLabInput, type RunVisualLabResult, runVisualLab } from "./run-visual-lab";
 export {
   IMAGE_TILE_STYLE_GUIDE,
   INK_PICTOGRAM_EXAMPLE_BEE,

--- a/apps/web/src/ai/puzzle-agent/visual/pictogram-pixel-integrity.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/pictogram-pixel-integrity.ts
@@ -1,0 +1,145 @@
+import sharp from "sharp";
+import { PICTOGRAM_CANVAS, rasterizePictogramAtPlayerSize } from "./rasterize-pictogram";
+
+export const PICTOGRAM_PIXEL_INTEGRITY_VERSION = "pictogram-pixels-v1";
+export const PICTOGRAM_PIXEL_INTEGRITY_SIZES = [36, 72] as const;
+
+const REQUIRED_CONTRAST = 3;
+const MIN_FOREGROUND_RATIO = 0.06;
+const MAX_FOREGROUND_RATIO = 0.55;
+const MIN_BOUNDS_AREA_RATIO = 0.18;
+
+export type PictogramPixelIntegrityProfile = {
+  tileSize: number;
+  foregroundRatio: number;
+  boundsWidthRatio: number;
+  boundsHeightRatio: number;
+  maximumContrast: number;
+  ok: boolean;
+  reasons: string[];
+};
+
+export type PictogramPixelIntegrityResult = {
+  version: typeof PICTOGRAM_PIXEL_INTEGRITY_VERSION;
+  ok: boolean;
+  reasons: string[];
+  profiles: PictogramPixelIntegrityProfile[];
+};
+
+function linearChannel(value: number): number {
+  const normalized = value / 255;
+  return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(red: number, green: number, blue: number): number {
+  return 0.2126 * linearChannel(red) + 0.7152 * linearChannel(green) + 0.0722 * linearChannel(blue);
+}
+
+function contrastRatio(left: number, right: number): number {
+  return (Math.max(left, right) + 0.05) / (Math.min(left, right) + 0.05);
+}
+
+const CANVAS_RGB = [
+  Number.parseInt(PICTOGRAM_CANVAS.slice(1, 3), 16),
+  Number.parseInt(PICTOGRAM_CANVAS.slice(3, 5), 16),
+  Number.parseInt(PICTOGRAM_CANVAS.slice(5, 7), 16),
+] as const;
+const CANVAS_LUMINANCE = relativeLuminance(...CANVAS_RGB);
+
+async function inspectProfile(
+  svg: string,
+  tileSize: number
+): Promise<PictogramPixelIntegrityProfile> {
+  try {
+    const playerPixels = await rasterizePictogramAtPlayerSize(svg, tileSize);
+    const { data, info } = await sharp(playerPixels)
+      .removeAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    let foregroundPixels = 0;
+    let minX = info.width;
+    let minY = info.height;
+    let maxX = -1;
+    let maxY = -1;
+    let maximumContrast = 1;
+
+    for (let y = 0; y < info.height; y += 1) {
+      for (let x = 0; x < info.width; x += 1) {
+        const index = (y * info.width + x) * info.channels;
+        const luminance = relativeLuminance(
+          data[index] ?? CANVAS_RGB[0],
+          data[index + 1] ?? CANVAS_RGB[1],
+          data[index + 2] ?? CANVAS_RGB[2]
+        );
+        const contrast = contrastRatio(luminance, CANVAS_LUMINANCE);
+        maximumContrast = Math.max(maximumContrast, contrast);
+        if (contrast < REQUIRED_CONTRAST) continue;
+        foregroundPixels += 1;
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x);
+        maxY = Math.max(maxY, y);
+      }
+    }
+
+    const pixelCount = info.width * info.height;
+    const foregroundRatio = pixelCount ? foregroundPixels / pixelCount : 0;
+    const boundsWidthRatio = maxX >= 0 ? (maxX - minX + 1) / info.width : 0;
+    const boundsHeightRatio = maxY >= 0 ? (maxY - minY + 1) / info.height : 0;
+    const boundsAreaRatio = boundsWidthRatio * boundsHeightRatio;
+    const reasons = [
+      ...(maximumContrast < REQUIRED_CONTRAST ? ["insufficient_contrast"] : []),
+      ...(foregroundRatio < MIN_FOREGROUND_RATIO ? ["too_little_visible_ink"] : []),
+      ...(foregroundRatio > MAX_FOREGROUND_RATIO ? ["overfilled_canvas"] : []),
+      ...(foregroundPixels > 0 && boundsAreaRatio < MIN_BOUNDS_AREA_RATIO
+        ? ["visible_subject_too_small"]
+        : []),
+      ...(foregroundPixels > 0 &&
+      (minX === 0 || minY === 0 || maxX === info.width - 1 || maxY === info.height - 1)
+        ? ["content_touches_canvas_edge"]
+        : []),
+    ];
+
+    return {
+      tileSize,
+      foregroundRatio,
+      boundsWidthRatio,
+      boundsHeightRatio,
+      maximumContrast,
+      ok: reasons.length === 0,
+      reasons,
+    };
+  } catch {
+    return {
+      tileSize,
+      foregroundRatio: 0,
+      boundsWidthRatio: 0,
+      boundsHeightRatio: 0,
+      maximumContrast: 1,
+      ok: false,
+      reasons: ["rasterization_failed"],
+    };
+  }
+}
+
+/**
+ * Inspect the exact compact and large player rasters before asking a model to
+ * name them. This catches invisible, off-canvas, tiny, and canvas-filling SVGs
+ * that source-markup heuristics cannot reliably detect.
+ */
+export async function evaluatePictogramPixelIntegrity(
+  svg: string
+): Promise<PictogramPixelIntegrityResult> {
+  const profiles = await Promise.all(
+    PICTOGRAM_PIXEL_INTEGRITY_SIZES.map((tileSize) => inspectProfile(svg, tileSize))
+  );
+  const reasons = profiles.flatMap((profile) =>
+    profile.reasons.map((reason) => `${profile.tileSize}px:${reason}`)
+  );
+  return {
+    version: PICTOGRAM_PIXEL_INTEGRITY_VERSION,
+    ok: profiles.length === PICTOGRAM_PIXEL_INTEGRITY_SIZES.length && reasons.length === 0,
+    reasons,
+    profiles,
+  };
+}

--- a/apps/web/src/ai/puzzle-agent/visual/rasterize-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/rasterize-pictogram.ts
@@ -1,7 +1,22 @@
 import sharp from "sharp";
 
 const REVIEW_SCALE = 4;
-const CANVAS = "#f4f6f3";
+export const PICTOGRAM_CANVAS = "#f4f6f3";
+
+/** Render exactly the pixels available to a player before evaluator enlargement. */
+export async function rasterizePictogramAtPlayerSize(
+  svg: string,
+  playerTileSize: number
+): Promise<Uint8Array> {
+  return sharp(Buffer.from(svg), { density: 144 })
+    .resize(playerTileSize, playerTileSize, {
+      fit: "contain",
+      background: PICTOGRAM_CANVAS,
+    })
+    .flatten({ background: PICTOGRAM_CANVAS })
+    .png()
+    .toBuffer();
+}
 
 /**
  * Render the SVG at the same 72px size used by the large player board, then
@@ -12,14 +27,7 @@ export async function rasterizePictogramForRecognition(
   svg: string,
   playerTileSize = 72
 ): Promise<Uint8Array> {
-  const playerPixels = await sharp(Buffer.from(svg), { density: 144 })
-    .resize(playerTileSize, playerTileSize, {
-      fit: "contain",
-      background: CANVAS,
-    })
-    .flatten({ background: CANVAS })
-    .png()
-    .toBuffer();
+  const playerPixels = await rasterizePictogramAtPlayerSize(svg, playerTileSize);
 
   return sharp(playerPixels)
     .resize(playerTileSize * REVIEW_SCALE, playerTileSize * REVIEW_SCALE, {

--- a/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/run-visual-lab.ts
@@ -15,6 +15,7 @@ import {
   VISUAL_LAB_MODE_META,
   type VisualLabMode,
 } from "./lab-recipes";
+import type { PictogramPixelIntegrityResult } from "./pictogram-pixel-integrity";
 import { INK_PICTOGRAM_STYLE_ID } from "./style";
 
 export type RunVisualLabInput = {
@@ -46,6 +47,7 @@ export type RunVisualLabResult = {
     emojiFallback: string;
     clarityScore?: number;
     clarityReasons?: string[];
+    pixelIntegrity?: PictogramPixelIntegrityResult;
     seenAs?: string;
     recognitionConfidence?: number;
     attempts?: number;
@@ -221,6 +223,7 @@ export async function runVisualLab(input: RunVisualLabInput): Promise<RunVisualL
         emojiFallback: pictogram.emojiFallback,
         clarityScore: pictogram.clarityScore,
         clarityReasons: pictogram.clarityReasons,
+        pixelIntegrity: pictogram.pixelIntegrity,
         seenAs: pictogram.seenAs,
         recognitionConfidence: pictogram.recognitionConfidence,
         attempts: pictogram.attempts,

--- a/apps/web/src/components/DevVisualLab.tsx
+++ b/apps/web/src/components/DevVisualLab.tsx
@@ -45,6 +45,16 @@ type LabResult = {
     emojiFallback: string;
     clarityScore?: number;
     clarityReasons?: string[];
+    pixelIntegrity?: {
+      ok: boolean;
+      reasons: string[];
+      profiles: Array<{
+        tileSize: number;
+        foregroundRatio: number;
+        boundsWidthRatio: number;
+        boundsHeightRatio: number;
+      }>;
+    };
     seenAs?: string;
     recognitionConfidence?: number;
     attempts?: number;
@@ -141,8 +151,7 @@ const FALLBACK_MODES: ModeMeta[] = [
   {
     id: "apex-tournament",
     label: "Apex tournament",
-    description:
-      "Multi-candidate generation with critique, player sim, and rubric — preview only.",
+    description: "Multi-candidate generation with critique, player sim, and rubric — preview only.",
     usesAi: true,
     estimatedCost: "high",
   },
@@ -265,11 +274,9 @@ export function DevVisualLab() {
   }
 
   const previewVisual = result?.visual || result?.puzzle?.visual;
-  const previewFallback =
-    result?.puzzle?.rebusPuzzle || result?.visual?.unicodeFallback || "◆";
+  const previewFallback = result?.puzzle?.rebusPuzzle || result?.visual?.unicodeFallback || "◆";
   const revealedAnswer = result?.puzzle?.answer || result?.seed?.answer || "";
-  const revealedDifficulty =
-    result?.puzzle?.difficulty ?? result?.seed?.difficulty ?? null;
+  const revealedDifficulty = result?.puzzle?.difficulty ?? result?.seed?.difficulty ?? null;
   const revealedConcept = result?.seed?.concept || result?.pictogram?.concept || "";
 
   return (
@@ -284,8 +291,8 @@ export function DevVisualLab() {
         </div>
         <p className="text-muted-foreground text-sm">
           Exercise every generative path — custom pictograms, text devices, unicode emoji, image
-          tiles, hybrid boards, composed rebuses, or a full Eve / Apex puzzle. The AI picks
-          concept, answer, and difficulty. Nothing here replaces today&apos;s published puzzle.
+          tiles, hybrid boards, composed rebuses, or a full Eve / Apex puzzle. The AI picks concept,
+          answer, and difficulty. Nothing here replaces today&apos;s published puzzle.
         </p>
       </div>
 
@@ -366,9 +373,13 @@ export function DevVisualLab() {
               </p>
               <div className="mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-muted-foreground text-xs">
                 {revealedConcept ? <span>Concept: {revealedConcept}</span> : null}
-                {revealedDifficulty != null ? <span>Difficulty {revealedDifficulty}/10</span> : null}
+                {revealedDifficulty != null ? (
+                  <span>Difficulty {revealedDifficulty}/10</span>
+                ) : null}
                 {puzzleId ? (
-                  <span className="font-mono text-[10px] text-subtle">saved · {puzzleId.slice(0, 8)}</span>
+                  <span className="font-mono text-[10px] text-subtle">
+                    saved · {puzzleId.slice(0, 8)}
+                  </span>
                 ) : (
                   <span className="text-subtle">not saved</span>
                 )}
@@ -449,25 +460,35 @@ export function DevVisualLab() {
             {result.pictogram && (
               <MetaCard
                 title="Pictogram"
-                lines={[
-                  `${result.pictogram.ok ? "ok" : "failed"} · ${result.pictogram.concept}`,
-                  typeof result.pictogram.clarityScore === "number"
-                    ? `clarity ${result.pictogram.clarityScore}${
-                        result.pictogram.attempts ? ` · tries ${result.pictogram.attempts}` : ""
-                      }`
-                    : "clarity n/a",
-                  result.pictogram.seenAs
-                    ? `seen as “${result.pictogram.seenAs}”${
-                        typeof result.pictogram.recognitionConfidence === "number"
-                          ? ` (${Math.round(result.pictogram.recognitionConfidence * 100)}%)`
-                          : ""
-                      }`
-                    : null,
-                  result.pictogram.clarityReasons?.length
-                    ? `reasons: ${result.pictogram.clarityReasons.join(", ")}`
-                    : `fallback ${result.pictogram.emojiFallback}`,
-                  result.pictogram.error || (result.pictogram.svg ? "svg ready" : "no svg"),
-                ].filter(Boolean) as string[]}
+                lines={
+                  [
+                    `${result.pictogram.ok ? "ok" : "failed"} · ${result.pictogram.concept}`,
+                    typeof result.pictogram.clarityScore === "number"
+                      ? `clarity ${result.pictogram.clarityScore}${
+                          result.pictogram.attempts ? ` · tries ${result.pictogram.attempts}` : ""
+                        }`
+                      : "clarity n/a",
+                    result.pictogram.seenAs
+                      ? `seen as “${result.pictogram.seenAs}”${
+                          typeof result.pictogram.recognitionConfidence === "number"
+                            ? ` (${Math.round(result.pictogram.recognitionConfidence * 100)}%)`
+                            : ""
+                        }`
+                      : null,
+                    result.pictogram.pixelIntegrity
+                      ? `pixels ${result.pictogram.pixelIntegrity.ok ? "ok" : "failed"} · ${result.pictogram.pixelIntegrity.profiles
+                          .map(
+                            (profile) =>
+                              `${profile.tileSize}px ${Math.round(profile.foregroundRatio * 100)}% ink, ${Math.round(profile.boundsWidthRatio * 100)}×${Math.round(profile.boundsHeightRatio * 100)}% bounds`
+                          )
+                          .join(" · ")}`
+                      : "pixels n/a",
+                    result.pictogram.clarityReasons?.length
+                      ? `reasons: ${result.pictogram.clarityReasons.join(", ")}`
+                      : `fallback ${result.pictogram.emojiFallback}`,
+                    result.pictogram.error || (result.pictogram.svg ? "svg ready" : "no svg"),
+                  ].filter(Boolean) as string[]
+                }
               />
             )}
             {result.image && (


### PR DESCRIPTION
## Summary
- inspect exact 36px and 72px player rasters before any vision-model recognition
- reject low-contrast, nearly empty, tiny, edge-touching, overfilled, and unrasterizable pictograms
- enforce the gate for curated assets, new long-tail candidates, and approved-cache retrieval; quarantine regressions
- expose per-size ink and visible-bounds evidence in the Visual Lab
- advance the frozen generator contract to `2026-08-02.8` and document measured thresholds

## Evidence
- all 98 publication catalog assets pass both player-size profiles
- adversarial off-canvas, low-contrast, tiny, and canvas-filling SVGs fail
- a structurally valid off-canvas SVG is rejected before either vision judge is called
- a hash-valid approved asset is quarantined when its player raster regresses

## Validation
- 74 Jest suites / 431 tests passed
- TypeScript `--noEmit --incremental false` passed
- changed-file Biome checks passed
- Next.js 16.2.12 production build passed (131 pages)
- `git diff --check` passed