### PR TITLE
Require complete board cue consensus

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -81,7 +81,7 @@ The pixel thresholds are deliberately wider than the measured publication catalo
 
 ## Whole-board gate
 
-Object recognition alone is insufficient. Render the same component used by the game at 375px, 768px, and 1280px widths and evaluate screenshots for:
+Object recognition alone is insufficient. Render the same component used by the game at compact 320px, mobile 375px, and desktop 768px widths and evaluate screenshots for:
 
 - clipped, overlapping, or tiny cues;
 - spatial relationships surviving flex wrapping;
@@ -92,6 +92,8 @@ Object recognition alone is insufficient. Render the same component used by the 
 - accessibility fallback matching the visual meaning without exposing the answer.
 
 The current `flex-wrap` row renderer can change visual topology across widths, so generation must either lock a composition grid or validate each responsive state.
+
+Every board-perception judge must independently inventory pictograms, visible text, and operator symbols. Consensus requires every declared cue in every responsive profile; repeated cues retain their multiplicity, because one visible `GO` cannot prove a board intended to show `GO GO GO`. Text matching normalizes case, spacing, and stacked letters without granting short-substring credit, while operator matching accepts only explicit symbol equivalents such as `plus` for `+`. Per-profile concept, text, and operator vote maps are persisted with the generated puzzle.
 
 ## Blind solve tournament
 
@@ -144,6 +146,7 @@ The first implementation slice now includes:
 - two independent blind vision judges at every icon size;
 - one shared presentation specification used by the React player and server renderer;
 - independent board perception at compact 320px, mobile 375px, and desktop 768px;
+- two-judge visibility consensus for every pictogram, text cue, and operator at its declared multiplicity in every responsive profile;
 - screenshot-only solve tournaments across every production profile, separated from answer-aware hint review;
 - rank-aware two-judge solve consensus that requires the intended answer to be top-ranked and dominant for every judge in every profile;
 - an independent answer-aware screenshot rejection lane for missing cues, answer leakage, wrong objects, unreadability, broken layout, and stronger alternate answers;
@@ -269,7 +272,7 @@ The evaluator commands write versioned JSON evidence under `artifacts/puzzle-gen
 
 Live vision preflight fails before scoring when any configured independent judge is unavailable. The failure now identifies the player size, model ID, and a sanitized provider error for every missing judge; benchmark artifacts retain the same diagnostics. This keeps publication fail-closed while distinguishing revoked credentials, unavailable model IDs, provider limits, and unsupported requests from an ordinary recognition miss.
 
-The solve report distinguishes answer presence from actual playability. A profile counts as detected only when both independent judges agree; one-of-two agreement is a failure, not half credit. Promotion currently requires at least 80% answer presence, 75% top-answer detection, 70% dominant-answer detection, 70% compact top-answer detection, mean reciprocal rank of at least 0.75, and no more than 10% ambiguous observations. These are provisional automated screening thresholds; human calibration remains authoritative. Benchmark contract `2026-08-02.8` also binds live-generator evidence to the deterministic player-pixel gate; reports from earlier contracts cannot promote this generator.
+The solve report distinguishes answer presence from actual playability. A profile counts as detected only when both independent judges agree; one-of-two agreement is a failure, not half credit. Promotion currently requires at least 80% answer presence, 75% top-answer detection, 70% dominant-answer detection, 70% compact top-answer detection, mean reciprocal rank of at least 0.75, and no more than 10% ambiguous observations. These are provisional automated screening thresholds; human calibration remains authoritative. Benchmark contract `2026-08-02.9` binds live-generator evidence to both deterministic player-pixel integrity and complete multiplicity-aware board-cue consensus; reports from earlier contracts cannot promote this generator.
 
 The editorial report prevents trivial evaluators from winning: known-good acceptance must remain at least 95%, known-failure detection at least 99%, two-judge failure consensus at least 90%, compact failure detection at least 99%, and all critical fixtures must pass. Market-readiness remains false until the corpus contains at least 150 vetted positives, 100 vetted failures, complete technique coverage, and at least 10 failures per failure class. The current 24-positive/12-failure seed is executable infrastructure, not market-leading evidence.
 

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -88,6 +88,8 @@ function toCandidate(
     boardRecognitionConfidence: result.metadata.boardRecognitionConfidence,
     boardRecognitionModels: result.metadata.boardRecognitionModels,
     boardConceptVotes: result.metadata.boardConceptVotes,
+    boardTextVotes: result.metadata.boardTextVotes,
+    boardOperatorVotes: result.metadata.boardOperatorVotes,
     boardRecognitionProfiles: result.metadata.boardRecognitionProfiles,
     playerSim,
     publishable: result.metadata.qualityVerdict !== "reject",
@@ -391,6 +393,8 @@ async function finalizeWinner(
       boardRecognitionConfidence: chosen.boardRecognitionConfidence,
       boardRecognitionModels: chosen.boardRecognitionModels,
       boardConceptVotes: chosen.boardConceptVotes,
+      boardTextVotes: chosen.boardTextVotes,
+      boardOperatorVotes: chosen.boardOperatorVotes,
       boardRecognitionProfiles: chosen.boardRecognitionProfiles,
       simCalibrationBias:
         simCalibration && simCalibration.sampleSize >= 6 ? simCalibration.adjustment : undefined,

--- a/apps/web/src/ai/puzzle-agent/apex/types.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/types.ts
@@ -164,6 +164,8 @@ export type ApexCandidate = {
   boardRecognitionConfidence?: number;
   boardRecognitionModels?: string[];
   boardConceptVotes?: Record<string, number>;
+  boardTextVotes?: Record<string, number>;
+  boardOperatorVotes?: Record<string, number>;
   boardRecognitionProfiles?: Array<{
     profileId: string;
     viewportWidth: number;
@@ -171,6 +173,8 @@ export type ApexCandidate = {
     confidence: number;
     models: string[];
     conceptVotes: Record<string, number>;
+    textVotes: Record<string, number>;
+    operatorVotes: Record<string, number>;
     wrappedRows: number;
   }>;
   publishable: boolean;

--- a/apps/web/src/ai/puzzle-agent/benchmark/types.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/types.ts
@@ -1,6 +1,6 @@
 import type { EditorialFailureKind } from "../visual/editorial-consensus";
 
-export const PUZZLE_GENERATOR_BENCHMARK_VERSION = "2026-08-02.8";
+export const PUZZLE_GENERATOR_BENCHMARK_VERSION = "2026-08-02.9";
 export const ICON_BENCHMARK_TILE_SIZES = [36, 72] as const;
 
 export type IconBenchmarkExpectation = "accept" | "reject";

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -480,6 +480,12 @@ export async function runPuzzleAgentGeneration(
             boardConceptVotes: boardRecognition.perceptions.length
               ? boardRecognition.conceptVotes
               : undefined,
+            boardTextVotes: boardRecognition.perceptions.length
+              ? boardRecognition.textVotes
+              : undefined,
+            boardOperatorVotes: boardRecognition.perceptions.length
+              ? boardRecognition.operatorVotes
+              : undefined,
             boardRecognitionProfiles: boardRecognition.profileResults?.length
               ? boardRecognition.profileResults.map((profile) => ({
                   profileId: profile.profileId,
@@ -494,6 +500,8 @@ export async function runPuzzleAgentGeneration(
                     : 0,
                   models: profile.perceptions.map((perception) => perception.model),
                   conceptVotes: profile.conceptVotes,
+                  textVotes: profile.textVotes,
+                  operatorVotes: profile.operatorVotes,
                   wrappedRows: profile.wrappedRows,
                 }))
               : undefined,

--- a/apps/web/src/ai/puzzle-agent/schemas.ts
+++ b/apps/web/src/ai/puzzle-agent/schemas.ts
@@ -147,6 +147,8 @@ export const PuzzleAgentResultSchema = z.object({
     boardRecognitionConfidence: z.number().min(0).max(1).optional(),
     boardRecognitionModels: z.array(z.string()).optional(),
     boardConceptVotes: z.record(z.string(), z.number().int().nonnegative()).optional(),
+    boardTextVotes: z.record(z.string(), z.number().int().nonnegative()).optional(),
+    boardOperatorVotes: z.record(z.string(), z.number().int().nonnegative()).optional(),
     boardRecognitionProfiles: z
       .array(
         z.object({
@@ -156,6 +158,8 @@ export const PuzzleAgentResultSchema = z.object({
           confidence: z.number().min(0).max(1),
           models: z.array(z.string()),
           conceptVotes: z.record(z.string(), z.number().int().nonnegative()),
+          textVotes: z.record(z.string(), z.number().int().nonnegative()),
+          operatorVotes: z.record(z.string(), z.number().int().nonnegative()),
           wrappedRows: z.number().int().nonnegative(),
         })
       )

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/critique-board.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/critique-board.test.ts
@@ -13,15 +13,21 @@ const visual: PuzzleVisual = {
   layers: [
     { kind: "pictogram", concept: "car", emojiFallback: "🚗" },
     { kind: "operator", symbol: "+" },
+    { kind: "text", content: "GO", emphasis: "normal" },
     { kind: "pictogram", concept: "key", emojiFallback: "🔑" },
   ],
 };
 
-function perception(model: string, objects: string[]) {
+function perception(
+  model: string,
+  objects: string[],
+  options: { visibleText?: string[]; visibleOperators?: string[] } = {}
+) {
   return {
     model,
     objects: objects.map((label) => ({ label, confidence: 0.9 })),
-    visibleText: [],
+    visibleText: options.visibleText ?? ["GO"],
+    visibleOperators: options.visibleOperators ?? ["+"],
     relationships: ["two objects separated by a plus sign"],
     hasClipping: false,
     hasAccidentalOverlap: false,
@@ -59,6 +65,120 @@ describe("board perception consensus", () => {
 
     expect(result.ok).toBe(true);
     expect(result.conceptVotes).toEqual({ car: 2, key: 2 });
+    expect(result.textVotes).toEqual({ GO: 2 });
+    expect(result.operatorVotes).toEqual({ "+": 2 });
+  });
+
+  it("rejects a board when required text is not independently visible", () => {
+    const result = evaluateBoardPerceptionConsensus({
+      visual,
+      perceptions: [
+        perception("vision-a", ["car", "key"], { visibleText: [] }),
+        perception("vision-b", ["car", "key"], { visibleText: [] }),
+      ],
+      requiredVotes: 2,
+      minConfidence: 0.68,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("text not recognized: GO");
+    expect(result.textVotes).toEqual({ GO: 0 });
+  });
+
+  it("rejects a board when an operator is missing or misread", () => {
+    const result = evaluateBoardPerceptionConsensus({
+      visual,
+      perceptions: [
+        perception("vision-a", ["car", "key"], { visibleOperators: [] }),
+        perception("vision-b", ["car", "key"], { visibleOperators: ["-"] }),
+      ],
+      requiredVotes: 2,
+      minConfidence: 0.68,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("operators not recognized: +");
+    expect(result.operatorVotes).toEqual({ "+": 0 });
+  });
+
+  it("normalizes stacked text and common operator names without fuzzy substring credit", () => {
+    const stackedVisual: PuzzleVisual = {
+      ...visual,
+      layers: [
+        { kind: "text", content: "BACK", emphasis: "stacked" },
+        { kind: "operator", symbol: "→" },
+      ],
+    };
+    const result = evaluateBoardPerceptionConsensus({
+      visual: stackedVisual,
+      perceptions: [
+        perception("vision-a", [], { visibleText: ["B A C K"], visibleOperators: ["arrow"] }),
+        perception("vision-b", [], { visibleText: ["BACK"], visibleOperators: ["right arrow"] }),
+      ],
+      requiredVotes: 2,
+      minConfidence: 0.68,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.textVotes).toEqual({ BACK: 2 });
+    expect(result.operatorVotes).toEqual({ "→": 2 });
+  });
+
+  it("does not treat a short text cue as a substring of a different word", () => {
+    const result = evaluateBoardPerceptionConsensus({
+      visual,
+      perceptions: [
+        perception("vision-a", ["car", "key"], { visibleText: ["GOLD"] }),
+        perception("vision-b", ["car", "key"], { visibleText: ["GONE"] }),
+      ],
+      requiredVotes: 2,
+      minConfidence: 0.68,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.textVotes).toEqual({ GO: 0 });
+  });
+
+  it("requires repeated object, text, and operator cues at their visible multiplicity", () => {
+    const repeatedVisual: PuzzleVisual = {
+      ...visual,
+      layers: [
+        { kind: "pictogram", concept: "car", emojiFallback: "🚗" },
+        { kind: "pictogram", concept: "car", emojiFallback: "🚗" },
+        { kind: "text", content: "GO", emphasis: "normal" },
+        { kind: "text", content: "GO", emphasis: "normal" },
+        { kind: "operator", symbol: "+" },
+        { kind: "operator", symbol: "+" },
+      ],
+    };
+    const undercounted = evaluateBoardPerceptionConsensus({
+      visual: repeatedVisual,
+      perceptions: [perception("vision-a", ["car"]), perception("vision-b", ["car"])],
+      requiredVotes: 2,
+      minConfidence: 0.68,
+    });
+    const complete = evaluateBoardPerceptionConsensus({
+      visual: repeatedVisual,
+      perceptions: [
+        perception("vision-a", ["car", "automobile"], {
+          visibleText: ["GO", "GO"],
+          visibleOperators: ["plus", "+"],
+        }),
+        perception("vision-b", ["automobile", "car"], {
+          visibleText: ["GO GO"],
+          visibleOperators: ["+", "+"],
+        }),
+      ],
+      requiredVotes: 2,
+      minConfidence: 0.68,
+    });
+
+    expect(undercounted.ok).toBe(false);
+    expect(undercounted.reason).toContain("car ×2");
+    expect(complete.ok).toBe(true);
+    expect(complete.conceptVotes).toEqual({ car: 2 });
+    expect(complete.textVotes).toEqual({ GO: 2 });
+    expect(complete.operatorVotes).toEqual({ "+": 2 });
   });
 
   it("rejects a board when an expected object is misread", () => {

--- a/apps/web/src/ai/puzzle-agent/visual/board-consensus.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/board-consensus.ts
@@ -6,6 +6,7 @@ export type BoardPerception = {
   model: string;
   objects: Array<{ label: string; confidence: number }>;
   visibleText: string[];
+  visibleOperators: string[];
   relationships: string[];
   hasClipping: boolean;
   hasAccidentalOverlap: boolean;
@@ -18,6 +19,8 @@ export type BoardRecognitionResult = {
   reason?: string;
   perceptions: BoardPerception[];
   conceptVotes: Record<string, number>;
+  textVotes: Record<string, number>;
+  operatorVotes: Record<string, number>;
   profileResults?: BoardProfileRecognitionResult[];
 };
 
@@ -29,6 +32,61 @@ export type BoardProfileRecognitionResult = Omit<BoardRecognitionResult, "profil
   height: number;
   wrappedRows: number;
 };
+
+function normalizeVisibleText(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function countTextCueOccurrences(expected: string, visibleText: string[]): number {
+  const normalizedExpected = normalizeVisibleText(expected);
+  if (!normalizedExpected) return 0;
+  const expectedTokens = normalizedExpected.split(" ");
+  const compactExpected = normalizedExpected.replaceAll(" ", "");
+  return visibleText.reduce((total, value) => {
+    const candidate = normalizeVisibleText(value);
+    if (!candidate) return total;
+    const candidateTokens = candidate.split(" ");
+    let matches = 0;
+    for (let index = 0; index <= candidateTokens.length - expectedTokens.length; index += 1) {
+      if (expectedTokens.every((token, offset) => candidateTokens[index + offset] === token)) {
+        matches += 1;
+      }
+    }
+    if (matches > 0) return total + matches;
+    return (
+      total +
+      (compactExpected.length >= 3 && candidate.replaceAll(" ", "") === compactExpected ? 1 : 0)
+    );
+  }, 0);
+}
+
+function normalizeOperator(value: string): string {
+  const normalized = value.normalize("NFKC").trim().toLocaleLowerCase("en-US");
+  if (["+", "plus", "add", "addition"].includes(normalized)) return "+";
+  if (["/", "slash", "divide", "division", "over"].includes(normalized)) return "/";
+  if (["→", "->", "arrow", "right arrow", "right-arrow"].includes(normalized)) return "→";
+  if (["×", "x", "multiply", "multiplication"].includes(normalized)) return "×";
+  if (["-", "−", "–", "—", "minus", "subtract", "subtraction"].includes(normalized)) {
+    return "-";
+  }
+  return normalized;
+}
+
+function countsByValue(values: string[]): Map<string, number> {
+  return values.reduce((counts, value) => {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+}
+
+function missingCueLabel(value: string, requiredCount: number): string {
+  return requiredCount > 1 ? `${value} ×${requiredCount}` : value;
+}
 
 export function evaluateBoardPerceptionConsensus(input: {
   visual: PuzzleVisual;
@@ -43,22 +101,53 @@ export function evaluateBoardPerceptionConsensus(input: {
       reason: "Not enough independent board perception judges",
       perceptions,
       conceptVotes: {},
+      textVotes: {},
+      operatorVotes: {},
     };
   }
 
-  const expectedConcepts = Array.from(
-    new Set(
-      input.visual.layers.flatMap((layer) => (layer.kind === "pictogram" ? [layer.concept] : []))
-    )
+  const expectedConceptCounts = countsByValue(
+    input.visual.layers.flatMap((layer) => (layer.kind === "pictogram" ? [layer.concept] : []))
   );
+  const expectedConcepts = Array.from(expectedConceptCounts.keys());
   const conceptVotes = Object.fromEntries(
     expectedConcepts.map((concept) => [
       concept,
-      perceptions.filter((perception) =>
-        perception.objects.some(
-          (object) =>
-            object.confidence >= input.minConfidence && conceptMatchesSeen(concept, object.label)
-        )
+      perceptions.filter(
+        (perception) =>
+          perception.objects.filter(
+            (object) =>
+              object.confidence >= input.minConfidence && conceptMatchesSeen(concept, object.label)
+          ).length >= (expectedConceptCounts.get(concept) ?? 1)
+      ).length,
+    ])
+  );
+  const expectedTextCounts = countsByValue(
+    input.visual.layers.flatMap((layer) => (layer.kind === "text" ? [layer.content] : []))
+  );
+  const expectedText = Array.from(expectedTextCounts.keys());
+  const textVotes = Object.fromEntries(
+    expectedText.map((content) => [
+      content,
+      perceptions.filter(
+        (perception) =>
+          countTextCueOccurrences(content, perception.visibleText) >=
+          (expectedTextCounts.get(content) ?? 1)
+      ).length,
+    ])
+  );
+  const expectedOperatorCounts = countsByValue(
+    input.visual.layers.flatMap((layer) => (layer.kind === "operator" ? [layer.symbol] : []))
+  );
+  const expectedOperators = Array.from(expectedOperatorCounts.keys());
+  const operatorVotes = Object.fromEntries(
+    expectedOperators.map((symbol) => [
+      symbol,
+      perceptions.filter(
+        (perception) =>
+          perception.visibleOperators.filter(
+            (visibleOperator) => normalizeOperator(visibleOperator) === normalizeOperator(symbol)
+          ).length >= (expectedOperatorCounts.get(symbol) ?? 1)
       ).length,
     ])
   );
@@ -69,9 +158,45 @@ export function evaluateBoardPerceptionConsensus(input: {
   if (missing.length) {
     return {
       ok: false,
-      reason: `Rendered board objects not recognized: ${missing.join(", ")}`,
+      reason: `Rendered board objects not recognized: ${missing
+        .map((concept) => missingCueLabel(concept, expectedConceptCounts.get(concept) ?? 1))
+        .join(", ")}`,
       perceptions,
       conceptVotes,
+      textVotes,
+      operatorVotes,
+    };
+  }
+
+  const missingText = expectedText.filter(
+    (content) => (textVotes[content] ?? 0) < input.requiredVotes
+  );
+  if (missingText.length) {
+    return {
+      ok: false,
+      reason: `Rendered board text not recognized: ${missingText
+        .map((content) => missingCueLabel(content, expectedTextCounts.get(content) ?? 1))
+        .join(", ")}`,
+      perceptions,
+      conceptVotes,
+      textVotes,
+      operatorVotes,
+    };
+  }
+
+  const missingOperators = expectedOperators.filter(
+    (symbol) => (operatorVotes[symbol] ?? 0) < input.requiredVotes
+  );
+  if (missingOperators.length) {
+    return {
+      ok: false,
+      reason: `Rendered board operators not recognized: ${missingOperators
+        .map((symbol) => missingCueLabel(symbol, expectedOperatorCounts.get(symbol) ?? 1))
+        .join(", ")}`,
+      perceptions,
+      conceptVotes,
+      textVotes,
+      operatorVotes,
     };
   }
 
@@ -81,6 +206,8 @@ export function evaluateBoardPerceptionConsensus(input: {
       reason: "Rendered board has clipped visual content",
       perceptions,
       conceptVotes,
+      textVotes,
+      operatorVotes,
     };
   }
   if (perceptions.some((perception) => perception.hasAccidentalOverlap)) {
@@ -89,6 +216,8 @@ export function evaluateBoardPerceptionConsensus(input: {
       reason: "Rendered board has accidental overlap",
       perceptions,
       conceptVotes,
+      textVotes,
+      operatorVotes,
     };
   }
   if (perceptions.some((perception) => perception.unreadableElements.length > 0)) {
@@ -97,10 +226,12 @@ export function evaluateBoardPerceptionConsensus(input: {
       reason: "Rendered board contains unreadable elements",
       perceptions,
       conceptVotes,
+      textVotes,
+      operatorVotes,
     };
   }
 
-  return { ok: true, perceptions, conceptVotes };
+  return { ok: true, perceptions, conceptVotes, textVotes, operatorVotes };
 }
 
 /** Require every production board profile to pass; aggregate the weakest evidence. */
@@ -125,6 +256,30 @@ export function evaluateBoardProfileConsensus(input: {
         : 0,
     ])
   );
+  const expectedText = Array.from(
+    new Set(input.visual.layers.flatMap((layer) => (layer.kind === "text" ? [layer.content] : [])))
+  );
+  const textVotes = Object.fromEntries(
+    expectedText.map((content) => [
+      content,
+      input.profileResults.length
+        ? Math.min(...input.profileResults.map((profile) => profile.textVotes[content] ?? 0))
+        : 0,
+    ])
+  );
+  const expectedOperators = Array.from(
+    new Set(
+      input.visual.layers.flatMap((layer) => (layer.kind === "operator" ? [layer.symbol] : []))
+    )
+  );
+  const operatorVotes = Object.fromEntries(
+    expectedOperators.map((symbol) => [
+      symbol,
+      input.profileResults.length
+        ? Math.min(...input.profileResults.map((profile) => profile.operatorVotes[symbol] ?? 0))
+        : 0,
+    ])
+  );
   const perceptions: BoardPerception[] = input.profileResults.flatMap((profile) =>
     profile.perceptions.map((perception) => ({
       ...perception,
@@ -141,6 +296,8 @@ export function evaluateBoardProfileConsensus(input: {
     reason: reasons.length ? reasons.join(" | ") : undefined,
     perceptions,
     conceptVotes,
+    textVotes,
+    operatorVotes,
     profileResults: input.profileResults,
   };
 }

--- a/apps/web/src/ai/puzzle-agent/visual/critique-board.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/critique-board.ts
@@ -19,8 +19,16 @@ const BoardPerceptionSchema = z.object({
         confidence: z.number().min(0).max(1),
       })
     )
-    .max(20),
-  visibleText: z.array(z.string().max(80)).max(20),
+    .max(20)
+    .describe("One entry per visible object occurrence; preserve repeated objects"),
+  visibleText: z
+    .array(z.string().max(80))
+    .max(20)
+    .describe("Visible text with repeated occurrences preserved rather than deduplicated"),
+  visibleOperators: z
+    .array(z.string().min(1).max(20))
+    .max(20)
+    .describe("Every visible operator or relation symbol, transcribed separately"),
   relationships: z.array(z.string().max(160)).max(10),
   hasClipping: z.boolean(),
   hasAccidentalOverlap: z.boolean(),
@@ -42,11 +50,12 @@ async function judgeRenderedProfile(
         schema: BoardPerceptionSchema,
         system: `You are inspecting a rendered rebus board exactly as a player sees it.
 Report only visible evidence. Do not infer hidden creator intent or solve from metadata.
-Name each concrete object literally, transcribe visible text, and describe spatial or typographic relationships.
+Name each concrete object literally, transcribe visible text, list every visible operator symbol separately, and describe spatial or typographic relationships.
+Preserve multiplicity: if an object, word, or operator appears more than once, report every visible occurrence rather than deduplicating it.
 When multiple marks form one familiar icon, name the whole symbol semantically (for example, a cloud with falling lines is a rain cloud) instead of splitting it into unrelated strokes.
 Flag clipping, accidental overlap, broken wrapping, or anything unreadable.`,
         prompt: [
-          "Inventory the visible objects, text, and relationships in this rebus board.",
+          "Inventory every visible object, text occurrence, operator occurrence, and relationship in this rebus board.",
           `This is the ${rendered.profileId} presentation: ${rendered.viewportWidth}px viewport and ${rendered.tileSize}px icon tiles.`,
         ].join("\n"),
       })),
@@ -76,7 +85,14 @@ Flag clipping, accidental overlap, broken wrapping, or anything unreadable.`,
 /** Blindly inspect every materially different production presentation. */
 export async function recognizePuzzleBoard(visual: PuzzleVisual): Promise<BoardRecognitionResult> {
   if (!AI_CONFIG.visualRecognition.boardEnabled) {
-    return { ok: true, perceptions: [], conceptVotes: {}, profileResults: [] };
+    return {
+      ok: true,
+      perceptions: [],
+      conceptVotes: {},
+      textVotes: {},
+      operatorVotes: {},
+      profileResults: [],
+    };
   }
 
   try {
@@ -95,6 +111,8 @@ export async function recognizePuzzleBoard(visual: PuzzleVisual): Promise<BoardR
       reason: error instanceof Error ? error.message : "Rendered board recognition failed",
       perceptions: [],
       conceptVotes: {},
+      textVotes: {},
+      operatorVotes: {},
       profileResults: [],
     };
   }

--- a/apps/web/src/ai/services/master-puzzle-orchestrator.ts
+++ b/apps/web/src/ai/services/master-puzzle-orchestrator.ts
@@ -65,6 +65,8 @@ export interface GeneratedPuzzleResult {
     boardRecognitionConfidence?: number;
     boardRecognitionModels?: string[];
     boardConceptVotes?: Record<string, number>;
+    boardTextVotes?: Record<string, number>;
+    boardOperatorVotes?: Record<string, number>;
     boardRecognitionProfiles?: Array<{
       profileId: string;
       viewportWidth: number;
@@ -72,6 +74,8 @@ export interface GeneratedPuzzleResult {
       confidence: number;
       models: string[];
       conceptVotes: Record<string, number>;
+      textVotes: Record<string, number>;
+      operatorVotes: Record<string, number>;
       wrappedRows: number;
     }>;
   };
@@ -129,6 +133,8 @@ function toGeneratedResult(
       boardRecognitionConfidence: result.metadata.boardRecognitionConfidence,
       boardRecognitionModels: result.metadata.boardRecognitionModels,
       boardConceptVotes: result.metadata.boardConceptVotes,
+      boardTextVotes: result.metadata.boardTextVotes,
+      boardOperatorVotes: result.metadata.boardOperatorVotes,
       boardRecognitionProfiles: result.metadata.boardRecognitionProfiles,
     },
     status: result.status,

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -328,6 +328,8 @@ async function getOrGenerateDailyPuzzle(
         boardRecognitionConfidence: result.metadata.boardRecognitionConfidence,
         boardRecognitionModels: result.metadata.boardRecognitionModels,
         boardConceptVotes: result.metadata.boardConceptVotes,
+        boardTextVotes: result.metadata.boardTextVotes,
+        boardOperatorVotes: result.metadata.boardOperatorVotes,
         boardRecognitionProfiles: result.metadata.boardRecognitionProfiles,
       },
     });

--- a/apps/web/src/db/models.ts
+++ b/apps/web/src/db/models.ts
@@ -236,6 +236,10 @@ export interface Puzzle {
     boardRecognitionModels?: string[];
     /** Number of independent judges that saw each declared concept. */
     boardConceptVotes?: Record<string, number>;
+    /** Number of independent judges that transcribed each text cue. */
+    boardTextVotes?: Record<string, number>;
+    /** Number of independent judges that transcribed each operator cue. */
+    boardOperatorVotes?: Record<string, number>;
     boardRecognitionProfiles?: Array<{
       profileId: string;
       viewportWidth: number;
@@ -243,6 +247,8 @@ export interface Puzzle {
       confidence: number;
       models: string[];
       conceptVotes: Record<string, number>;
+      textVotes: Record<string, number>;
+      operatorVotes: Record<string, number>;
       wrappedRows: number;
     }>;
     /** Dev Visual Lab preview (inactive) */


### PR DESCRIPTION
## What changed
- require two independent judges to recognize every pictogram, text cue, and operator in every production board profile
- preserve cue multiplicity so one visible occurrence cannot satisfy a repeated-cue puzzle
- normalize stacked text and common operator names without granting substring matches
- persist board text/operator vote evidence through generation, Apex selection, and puzzle metadata
- advance the generator benchmark contract to 2026-08-02.9

## Validation
- 74 Jest suites / 436 tests passed
- TypeScript passed with `tsc --noEmit --incremental false`
- Biome passed on all changed files
- optimized Next.js build passed and generated 131 routes