### PR TITLE
Add read-only production playtest evidence audit

### DIFF
--- a/apps/web/src/ai/puzzle-agent/review/__tests__/puzzle-playtest-service.test.ts
+++ b/apps/web/src/ai/puzzle-agent/review/__tests__/puzzle-playtest-service.test.ts
@@ -171,6 +171,21 @@ describe("blind human generated-puzzle playtesting", () => {
     renderedVisuals.length = 0;
   });
 
+  it("builds an operational report without creating or completing evidence", async () => {
+    const { repository, store } = inMemoryRepository();
+    const service = createPuzzlePlaytestService(repository, renderer);
+
+    const report = await service.getReport("operational-audit", new Date(0), {
+      readOnly: true,
+    });
+
+    expect(store.candidates).toEqual([]);
+    expect(store.reviews).toEqual([]);
+    expect(report.candidateCount).toBe(0);
+    expect(report.controlCandidateCount).toBe(0);
+    expect(report.generatedAt).toBe(new Date(0).toISOString());
+  });
+
   it("returns only an opaque rendered-board payload", async () => {
     const { repository, store } = inMemoryRepository();
     const service = createPuzzlePlaytestService(repository, renderer);

--- a/apps/web/src/ai/puzzle-agent/review/puzzle-playtest-service.ts
+++ b/apps/web/src/ai/puzzle-agent/review/puzzle-playtest-service.ts
@@ -525,11 +525,18 @@ export function createPuzzlePlaytestService(
       : existingCandidates;
   }
 
-  async function loadEvidence(): Promise<{
+  async function loadEvidence(options?: { ensureControls?: boolean }): Promise<{
     candidates: PuzzlePlaytestCandidate[];
     reviews: PuzzlePlaytestReview[];
   }> {
-    const controls = await ensureControlCandidates();
+    const controls =
+      options?.ensureControls === false
+        ? await repository.listCandidates({
+            contractVersion: PUZZLE_PLAYTEST_CONTRACT_VERSION,
+            evidenceRoles: ["control"],
+            limit: 100,
+          })
+        : await ensureControlCandidates();
     const [generated, reviews] = await Promise.all([
       repository.listCandidates({
         contractVersion: PUZZLE_PLAYTEST_CONTRACT_VERSION,
@@ -786,11 +793,17 @@ export function createPuzzlePlaytestService(
       return (await getNextAssignment(reviewerId)).progress;
     },
 
-    async getReport(reviewerIdInput: string, now = new Date()): Promise<PuzzlePlaytestReport> {
+    async getReport(
+      reviewerIdInput: string,
+      now = new Date(),
+      options?: { readOnly?: boolean }
+    ): Promise<PuzzlePlaytestReport> {
       const reviewerId = reviewerIdInput.trim().slice(0, 100);
       if (!reviewerId) throw new Error("Reviewer is required");
-      await refreshCandidateCompletions();
-      const { candidates, reviews } = await loadEvidence();
+      if (!options?.readOnly) await refreshCandidateCompletions();
+      const { candidates, reviews } = await loadEvidence({
+        ensureControls: !options?.readOnly,
+      });
       const reviewerReviews = reviews.filter((review) => review.reviewerId === reviewerId);
       const controlCandidates = candidates.filter(
         (candidate) => candidate.evidenceRole === "control"

--- a/apps/web/src/app/api/admin/ai/puzzle-playtests/audit/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/ai/puzzle-playtests/audit/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+const authorizeCron = jest.fn();
+const getReport = jest.fn();
+
+jest.mock("@/lib/cron/auth", () => ({ authorizeCron }));
+jest.mock("@/ai/puzzle-agent/review/puzzle-playtest-server", () => ({
+  puzzlePlaytestService: { getReport },
+}));
+
+import { NextResponse } from "next/server";
+import { GET } from "../route";
+
+describe("puzzle playtest evidence audit route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects requests without machine authorization", async () => {
+    authorizeCron.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 }),
+    });
+
+    const response = await GET(
+      new Request("https://rebuzzle.test/api/admin/ai/puzzle-playtests/audit")
+    );
+
+    expect(response.status).toBe(401);
+    expect(getReport).not.toHaveBeenCalled();
+  });
+
+  it("returns a read-only aggregate without candidate identities or answers", async () => {
+    authorizeCron.mockReturnValue({ ok: true });
+    getReport.mockResolvedValue({
+      contractVersion: "puzzle-playtest-v3",
+      candidateCount: 3,
+      completedCandidates: 1,
+      visibleCandidates: [
+        { candidateId: "candidate-secret", puzzleId: "puzzle-secret", answer: "sunflower" },
+      ],
+    });
+
+    const response = await GET(
+      new Request("https://rebuzzle.test/api/admin/ai/puzzle-playtests/audit")
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(getReport).toHaveBeenCalledWith("operational-audit", expect.any(Date), {
+      readOnly: true,
+    });
+    expect(data.report).toEqual({
+      contractVersion: "puzzle-playtest-v3",
+      candidateCount: 3,
+      completedCandidates: 1,
+    });
+    expect(JSON.stringify(data)).not.toContain("candidate-secret");
+    expect(JSON.stringify(data)).not.toContain("puzzle-secret");
+    expect(JSON.stringify(data)).not.toContain("sunflower");
+  });
+
+  it("returns a non-cacheable server error when the audit fails", async () => {
+    authorizeCron.mockReturnValue({ ok: true });
+    getReport.mockRejectedValue(new Error("database unavailable"));
+
+    const response = await GET(
+      new Request("https://rebuzzle.test/api/admin/ai/puzzle-playtests/audit")
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+});

--- a/apps/web/src/app/api/admin/ai/puzzle-playtests/audit/route.ts
+++ b/apps/web/src/app/api/admin/ai/puzzle-playtests/audit/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { puzzlePlaytestService } from "@/ai/puzzle-agent/review/puzzle-playtest-server";
+import { authorizeCron } from "@/lib/cron/auth";
+
+const PRIVATE_NO_STORE = { "Cache-Control": "private, no-store" };
+
+/**
+ * Read-only operational evidence snapshot.
+ *
+ * This route intentionally excludes candidate identities and answers. It is
+ * suitable for automated release audits and never advances candidate status.
+ */
+export async function GET(request: Request) {
+  const authorization = authorizeCron(request);
+  if (!authorization.ok) return authorization.response;
+
+  try {
+    const report = await puzzlePlaytestService.getReport("operational-audit", new Date(), {
+      readOnly: true,
+    });
+    const { visibleCandidates: _privateCandidates, ...aggregateReport } = report;
+
+    return NextResponse.json(
+      { success: true, report: aggregateReport },
+      { headers: PRIVATE_NO_STORE }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to audit puzzle playtests";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500, headers: PRIVATE_NO_STORE }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a read-only playtest report mode that never creates controls or advances candidate state
- expose a cron-authenticated aggregate audit endpoint for production evidence collection
- strip candidate IDs, puzzle IDs, and answers from the operational response
- cover authorization, privacy, error handling, and zero-write behavior

## Validation
- Biome check (changed files)
- TypeScript: `pnpm --filter @rebuzzle/web exec tsc --noEmit`
- Jest: 76 suites / 451 tests
- Next.js production build: 132 pages/routes generated