### PR TITLE
Authorize operational playtest backfill

### DIFF
--- a/apps/web/src/app/api/admin/ai/puzzle-playtests/backfill/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/ai/puzzle-playtests/backfill/__tests__/route.test.ts
@@ -1,15 +1,25 @@
 const verifyAdminAccess = jest.fn();
+const authorizeCron = jest.fn();
 const run = jest.fn();
 
 jest.mock("@/lib/admin-auth", () => ({ verifyAdminAccess }));
+jest.mock("@/lib/cron/auth", () => ({ authorizeCron }));
 jest.mock("@/ai/puzzle-agent/review/puzzle-playtest-backfill-server", () => ({
   puzzlePlaytestBackfillService: { run },
 }));
 
+import { NextResponse } from "next/server";
 import { POST } from "../route";
 
 describe("puzzle playtest historical backfill route", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeCron.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 }),
+    });
+    verifyAdminAccess.mockResolvedValue(null);
+  });
 
   it("rejects unauthenticated requests", async () => {
     verifyAdminAccess.mockResolvedValue(null);
@@ -38,6 +48,22 @@ describe("puzzle playtest historical backfill route", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(run).toHaveBeenCalledWith({ dryRun: true, limit: 50 });
+  });
+
+  it("allows machine-authorized non-mutating audits without an admin session", async () => {
+    authorizeCron.mockReturnValue({ ok: true });
+    run.mockResolvedValue({ dryRun: true, eligibleUnqueued: 4, queued: 0 });
+    const response = await POST(
+      new Request("https://rebuzzle.test/api/admin/ai/puzzle-playtests/backfill", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ limit: 100 }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(verifyAdminAccess).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledWith({ dryRun: true, limit: 100 });
   });
 
   it("mutates only when apply is explicit", async () => {

--- a/apps/web/src/app/api/admin/ai/puzzle-playtests/backfill/route.ts
+++ b/apps/web/src/app/api/admin/ai/puzzle-playtests/backfill/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { puzzlePlaytestBackfillService } from "@/ai/puzzle-agent/review/puzzle-playtest-backfill-server";
 import { verifyAdminAccess } from "@/lib/admin-auth";
+import { authorizeCron } from "@/lib/cron/auth";
 
 const PRIVATE_NO_STORE = { "Cache-Control": "private, no-store" };
 
@@ -10,8 +11,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export async function POST(request: Request) {
   try {
-    const admin = await verifyAdminAccess(request);
-    if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 401 });
+    const cronAuthorization = authorizeCron(request);
+    const admin = cronAuthorization.ok ? null : await verifyAdminAccess(request);
+    if (!(cronAuthorization.ok || admin)) {
+      return NextResponse.json({ error: "Admin or machine access required" }, { status: 401 });
+    }
     const body: unknown = await request.json();
     if (!isRecord(body)) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- allow the existing playtest backfill endpoint to use production machine authorization or an admin session
- preserve dry-run as the default and require explicit `dryRun: false` for queue mutation
- add coverage for unauthorized, admin, and machine-authorized execution

## Validation
- Biome check
- `pnpm --filter @rebuzzle/web exec tsc --noEmit`
- full Jest suite
- Next.js production build: 132 pages/routes generated