### PR TITLE
Pre-generate next-day puzzles for blind review

### DIFF
--- a/apps/web/src/app/api/workflows/daily-content/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/daily-content/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+const generateNextPuzzle = jest.fn();
+const getTodaysPuzzle = jest.fn();
+const runLearningCalibration = jest.fn();
+const findOne = jest.fn();
+const proposeBlogForPuzzle = jest.fn();
+const revalidateTag = jest.fn();
+
+jest.mock("@/app/actions/puzzleGenerationActions", () => ({
+  generateNextPuzzle,
+  getTodaysPuzzle,
+}));
+jest.mock("@/ai/learning", () => ({ runLearningCalibration }));
+jest.mock("@/db/mongodb", () => ({
+  getCollection: () => ({ findOne }),
+}));
+jest.mock("@/lib/blog/propose-puzzle-blog", () => ({ proposeBlogForPuzzle }));
+jest.mock("next/cache", () => ({ revalidateTag }));
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { nextUtcDateKey, POST } from "../route";
+
+describe("daily content workflow", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-02T23:59:00.000Z"));
+    process.env.CRON_SECRET = "test-cron-secret";
+    runLearningCalibration.mockResolvedValue({
+      adaptive: { target: 7, baseline: 6, delta: 1, reason: "test" },
+      eventId: "learning-event",
+    });
+    generateNextPuzzle.mockResolvedValue({
+      success: true,
+      cached: true,
+      puzzle: { id: "today-puzzle" },
+    });
+    getTodaysPuzzle.mockResolvedValue({
+      success: true,
+      cached: false,
+      aiGenerated: true,
+      puzzle: { id: "next-puzzle" },
+    });
+    findOne.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalCronSecret === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = originalCronSecret;
+  });
+
+  it("computes the next publication date in UTC", () => {
+    expect(nextUtcDateKey(new Date("2026-12-31T23:59:59.000Z"))).toBe("2027-01-01");
+  });
+
+  it("pre-generates tomorrow with fail-closed AI settings", async () => {
+    const response = await POST(
+      new Request("https://rebuzzle.test/api/workflows/daily-content", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-cron-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ triggeredBy: "test" }),
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getTodaysPuzzle).toHaveBeenCalledWith("rebus", "2026-08-03", {
+      allowAiGenerate: true,
+      failOnAiError: true,
+    });
+    expect(data.nextPuzzle).toEqual({
+      success: true,
+      date: "2026-08-03",
+      cached: false,
+      aiGenerated: true,
+      puzzleId: "next-puzzle",
+    });
+  });
+
+  it("reports next-day failure without taking today's workflow down", async () => {
+    getTodaysPuzzle.mockRejectedValue(new Error("gateway unavailable"));
+
+    const response = await POST(
+      new Request("https://rebuzzle.test/api/workflows/daily-content", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-cron-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ triggeredBy: "test" }),
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.nextPuzzle).toEqual({
+      success: false,
+      date: "2026-08-03",
+      error: "gateway unavailable",
+    });
+  });
+});

--- a/apps/web/src/app/api/workflows/daily-content/route.ts
+++ b/apps/web/src/app/api/workflows/daily-content/route.ts
@@ -1,6 +1,6 @@
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
-import { generateNextPuzzle } from "@/app/actions/puzzleGenerationActions";
+import { generateNextPuzzle, getTodaysPuzzle } from "@/app/actions/puzzleGenerationActions";
 import type { Puzzle } from "@/db/models";
 import { getCollection } from "@/db/mongodb";
 import { proposeBlogForPuzzle } from "@/lib/blog/propose-puzzle-blog";
@@ -11,7 +11,8 @@ import { logger } from "@/lib/logger";
  *
  * Midnight (via cron):
  * 1. Eve generates today's puzzle → Mongo `puzzles`
- * 2. Eve generates yesterday's blog → draft GitHub pull request
+ * 2. Eve pre-generates tomorrow's puzzle → blind playtest queue
+ * 3. Eve generates yesterday's blog → draft GitHub pull request
  */
 function authorizeWorkflow(request: Request): boolean {
   const authHeader = request.headers.get("authorization");
@@ -29,6 +30,12 @@ function authorizeWorkflow(request: Request): boolean {
 
   if (!(vercelCronSecretEnv || cronSecret)) return true;
   return vercelOk || bearerOk;
+}
+
+export function nextUtcDateKey(now = new Date()): string {
+  const next = new Date(now);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return next.toISOString().slice(0, 10);
 }
 
 export async function POST(request: Request) {
@@ -78,6 +85,48 @@ export async function POST(request: Request) {
       logger.error("Puzzle generation failed", new Error(errMsg));
     }
 
+    const nextDate = nextUtcDateKey();
+    let nextPuzzle: {
+      success: boolean;
+      date: string;
+      cached?: boolean;
+      fallback?: boolean;
+      aiGenerated?: boolean;
+      puzzleId?: string;
+      error?: string;
+    };
+    try {
+      logger.info("Pre-generating next-day puzzle for blind playtesting", { nextDate });
+      const result = await getTodaysPuzzle("rebus", nextDate, {
+        allowAiGenerate: true,
+        failOnAiError: true,
+      });
+      nextPuzzle = {
+        success: result.success,
+        date: nextDate,
+        cached: "cached" in result ? result.cached : undefined,
+        fallback: "fallback" in result ? result.fallback : undefined,
+        aiGenerated: "aiGenerated" in result ? result.aiGenerated : undefined,
+        puzzleId:
+          result.success && result.puzzle ? (result.puzzle as { id?: string }).id : undefined,
+        error:
+          !result.success && "error" in result && typeof result.error === "string"
+            ? result.error
+            : undefined,
+      };
+    } catch (error) {
+      nextPuzzle = {
+        success: false,
+        date: nextDate,
+        error: error instanceof Error ? error.message : "Next-day generation failed",
+      };
+      logger.error(
+        "Next-day puzzle pre-generation failed",
+        error instanceof Error ? error : new Error(String(error)),
+        { nextDate }
+      );
+    }
+
     logger.info("Revalidating puzzle cache");
     revalidateTag("daily-puzzle", "max");
 
@@ -96,6 +145,7 @@ export async function POST(request: Request) {
             ? (puzzleResult.puzzle as { id?: string }).id
             : undefined,
       },
+      nextPuzzle,
       blog: blogResult,
       completedAt: new Date().toISOString(),
     });


### PR DESCRIPTION
## Summary
- pre-generate the next UTC day's rebus during the daily workflow
- persist successful AI puzzles early so they enter blind human playtesting before publication
- keep today's workflow and blog generation available when next-day generation fails
- return an explicit, answer-free next-day operational result

## Validation
- Biome check
- `pnpm --filter @rebuzzle/web exec tsc --noEmit`
- Jest: 77 suites / 456 tests
- Next.js production build: 132 pages/routes generated