### PR TITLE
perf(ai): Stage rendered finalist evaluation

### DIFF
--- a/apps/web/src/ai/__tests__/client-budget.test.ts
+++ b/apps/web/src/ai/__tests__/client-budget.test.ts
@@ -55,4 +55,25 @@ describe("AI client hard budget behavior", () => {
     });
     expect(operation).toHaveBeenCalledTimes(1);
   });
+
+  it("disables SDK retries and tags Gateway spend by operation", async () => {
+    generateText.mockResolvedValue({
+      text: "ok",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      finishReason: "stop",
+    });
+
+    await generateAIText({ prompt: "test", operation: "puzzle-critique" });
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxRetries: 0,
+        providerOptions: {
+          gateway: {
+            tags: ["rebuzzle", "operation:puzzle-critique"],
+          },
+        },
+      })
+    );
+  });
 });

--- a/apps/web/src/ai/client.ts
+++ b/apps/web/src/ai/client.ts
@@ -7,7 +7,7 @@
  * auth and causes "Unauthenticated" on production.
  */
 
-import { createGateway, gateway } from "@ai-sdk/gateway";
+import { createGateway, type GatewayProviderOptions, gateway } from "@ai-sdk/gateway";
 import { generateText, type LanguageModel, Output, streamText } from "ai";
 import type { z } from "zod";
 import { AI_CONFIG, validateApiKeys } from "./config";
@@ -51,6 +51,19 @@ export function getGatewayModelChain(tier: ModelTier = "smart"): string[] {
   return Array.from(new Set([primary, ...fallbacks]));
 }
 
+function gatewayProviderOptions(operation: string) {
+  const safeOperation = operation
+    .toLowerCase()
+    .replace(/[^a-z0-9:_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return {
+    gateway: {
+      tags: ["rebuzzle", `operation:${safeOperation || "unknown"}`],
+    } satisfies GatewayProviderOptions,
+  };
+}
+
 function usageFromResult(usage: {
   inputTokens?: number;
   outputTokens?: number;
@@ -90,6 +103,7 @@ export async function generateAIText(params: {
   temperature?: number;
   maxTokens?: number;
   modelType?: ModelTier;
+  operation?: string;
 }): Promise<{
   text: string;
   usage?: {
@@ -119,6 +133,8 @@ export async function generateAIText(params: {
         system: params.system,
         temperature: params.temperature ?? AI_CONFIG.generation.temperature.balanced,
         maxOutputTokens: params.maxTokens,
+        maxRetries: 0,
+        providerOptions: gatewayProviderOptions(params.operation ?? "text"),
         abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.default),
       });
 
@@ -149,6 +165,7 @@ export async function generateAIObject<T>(params: {
   schema: z.ZodType<T>;
   temperature?: number;
   modelType?: ModelTier;
+  operation?: string;
 }): Promise<T> {
   await enforceQuota();
   ensureGatewayKey();
@@ -169,6 +186,8 @@ export async function generateAIObject<T>(params: {
         system: params.system,
         temperature: params.temperature ?? AI_CONFIG.generation.temperature.balanced,
         output: Output.object({ schema: params.schema }),
+        maxRetries: 0,
+        providerOptions: gatewayProviderOptions(params.operation ?? "structured"),
         abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.default),
       });
 
@@ -202,6 +221,7 @@ export async function generateAIObjectFromImage<T>(params: {
   mediaType: string;
   modelId: string;
   temperature?: number;
+  operation?: string;
 }): Promise<T> {
   await enforceQuota();
   ensureGatewayKey();
@@ -221,6 +241,8 @@ export async function generateAIObjectFromImage<T>(params: {
     ],
     temperature: params.temperature ?? AI_CONFIG.generation.temperature.factual,
     output: Output.object({ schema: params.schema }),
+    maxRetries: 0,
+    providerOptions: gatewayProviderOptions(params.operation ?? "vision"),
     abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.default),
   });
 
@@ -240,6 +262,7 @@ export async function streamAIText(params: {
   temperature?: number;
   maxTokens?: number;
   modelType?: ModelTier;
+  operation?: string;
 }): Promise<ReturnType<typeof streamText>> {
   await enforceQuota();
   ensureGatewayKey();
@@ -251,6 +274,8 @@ export async function streamAIText(params: {
       system: params.system,
       temperature: params.temperature ?? AI_CONFIG.generation.temperature.balanced,
       maxOutputTokens: params.maxTokens,
+      maxRetries: 0,
+      providerOptions: gatewayProviderOptions(params.operation ?? "stream"),
       abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.streaming),
     });
   } catch (error) {

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-budget.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-budget.test.ts
@@ -5,6 +5,7 @@ jest.mock("../../run-generation", () => ({ runPuzzleAgentGeneration }));
 jest.mock("../../tool-impl", () => ({ stableId: jest.fn(() => "candidate-id") }));
 jest.mock("../curriculum", () => ({ buildGenerationBrief }));
 jest.mock("../critique", () => ({ critiqueCandidate: jest.fn() }));
+jest.mock("../rendered-qualification", () => ({ qualifyRenderedCandidate: jest.fn() }));
 jest.mock("../player-sim", () => ({
   applyPlayerSimHeuristics: jest.fn(),
   playerSimPublishBlockers: jest.fn(() => []),

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
@@ -1,0 +1,139 @@
+import { INK_PICTOGRAM_EXAMPLE_KEY } from "../../visual/style";
+import { selectQualifiedFinalist } from "../finalist-selection";
+import type { ApexCandidate } from "../types";
+
+function candidate(id: string, overall: number): ApexCandidate {
+  return {
+    id,
+    rebusPuzzle: "key over key",
+    answer: `${id} answer`,
+    difficulty: 5,
+    difficultyLevel: "Hard",
+    explanation: "A literal spatial rebus.",
+    category: "phrases",
+    hints: ["Look at position.", "Read the objects together.", "It is a phrase."],
+    techniqueId: "positional_phrase",
+    visual: {
+      styleId: "ink-pictogram-v1",
+      mode: "composed",
+      layout: "stack",
+      unicodeFallback: "key\nkey",
+      layers: [
+        {
+          kind: "pictogram",
+          concept: "key",
+          emojiFallback: "key",
+          svg: INK_PICTOGRAM_EXAMPLE_KEY,
+        },
+      ],
+    },
+    fingerprint: `fingerprint-${id}`,
+    uniquenessScore: 90,
+    calibratedDifficulty: 5,
+    inBand: true,
+    isUnique: true,
+    solvable: true,
+    qualityOverall: overall,
+    funScore: 80,
+    publishable: true,
+    critique: {
+      verdict: "ship",
+      summary: "Strong candidate",
+      strengths: ["clear"],
+      flaws: [],
+      reviseInstructions: [],
+      falseLeadQuality: 70,
+      ahaPredicted: overall,
+      creativityScore: overall,
+      iconRecognizability: 85,
+      overusedTrope: false,
+    },
+    rubric: {
+      ahaMoment: overall,
+      fairness: overall,
+      novelty: overall,
+      visualCraft: overall,
+      shareability: overall,
+      techniqueFit: overall,
+      hintCraft: overall,
+      overall,
+    },
+    rejectReasons: [],
+  };
+}
+
+describe("Apex rendered finalist selection", () => {
+  it("fully evaluates only the top-ranked finalist when it qualifies", async () => {
+    const evaluated: string[] = [];
+    const top = candidate("top", 92);
+    const runnerUp = candidate("runner-up", 84);
+
+    const result = await selectQualifiedFinalist({
+      candidates: [runnerUp, top],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      evaluate: async (value) => {
+        evaluated.push(value.id);
+        return value;
+      },
+    });
+
+    expect(result.winner?.id).toBe("top");
+    expect(evaluated).toEqual(["top"]);
+  });
+
+  it("evaluates the runner-up only after the first finalist is rejected", async () => {
+    const evaluated: string[] = [];
+    const top = candidate("top", 92);
+    const runnerUp = candidate("runner-up", 84);
+
+    const result = await selectQualifiedFinalist({
+      candidates: [top, runnerUp],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      evaluate: async (value) => {
+        evaluated.push(value.id);
+        return value.id === "top"
+          ? {
+              ...value,
+              publishable: false,
+              rejectReasons: ["Rendered board objects not recognized: door"],
+            }
+          : value;
+      },
+    });
+
+    expect(result.winner?.id).toBe("runner-up");
+    expect(evaluated).toEqual(["top", "runner-up"]);
+    expect(result.failures).toContain("Rendered board objects not recognized: door");
+  });
+
+  it("does not start another expensive evaluation after the runtime guard closes", async () => {
+    const evaluated: string[] = [];
+    let capacityChecks = 0;
+
+    const result = await selectQualifiedFinalist({
+      candidates: [candidate("top", 92), candidate("runner-up", 84)],
+      minRubricOverall: 78,
+      canStartEvaluation: () => {
+        capacityChecks += 1;
+        return capacityChecks === 1;
+      },
+      evaluate: async (value) => {
+        evaluated.push(value.id);
+        return {
+          ...value,
+          publishable: false,
+          rejectReasons: ["Rendered board has clipped visual content"],
+        };
+      },
+    });
+
+    expect(result.winner).toBeNull();
+    expect(evaluated).toEqual(["top"]);
+    expect(result.failures).toEqual([
+      "Rendered board has clipped visual content",
+      "Rendered finalist evaluation stopped before runner-up to preserve the runtime deadline",
+    ]);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/rendered-qualification.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/rendered-qualification.test.ts
@@ -1,0 +1,73 @@
+const recognizePuzzleBoard = jest.fn();
+const simulatePlayerSolve = jest.fn();
+
+jest.mock("../../visual/critique-board", () => ({ recognizePuzzleBoard }));
+jest.mock("../player-sim", () => ({
+  applyPlayerSimHeuristics: jest.fn(),
+  playerSimPublishBlockers: jest.fn(() => []),
+  simulatePlayerSolve,
+}));
+
+import { INK_PICTOGRAM_EXAMPLE_KEY } from "../../visual/style";
+import { qualifyRenderedCandidate } from "../rendered-qualification";
+import type { ApexCandidate } from "../types";
+
+function candidate(): ApexCandidate {
+  return {
+    id: "finalist",
+    rebusPuzzle: "door over door",
+    answer: "door to door",
+    difficulty: 5,
+    difficultyLevel: "Hard",
+    explanation: "Two doors are positioned one above the other to form the phrase.",
+    category: "phrases",
+    hints: ["Look at position.", "Read both objects.", "It is a phrase."],
+    techniqueId: "positional_phrase",
+    visual: {
+      styleId: "ink-pictogram-v1",
+      mode: "composed",
+      layout: "stack",
+      unicodeFallback: "door\ndoor",
+      layers: [
+        {
+          kind: "pictogram",
+          concept: "door",
+          emojiFallback: "door",
+          svg: INK_PICTOGRAM_EXAMPLE_KEY,
+        },
+      ],
+    },
+    fingerprint: "fingerprint-finalist",
+    uniquenessScore: 90,
+    calibratedDifficulty: 5,
+    inBand: true,
+    isUnique: true,
+    solvable: true,
+    qualityOverall: 88,
+    funScore: 82,
+    publishable: true,
+    rejectReasons: [],
+  };
+}
+
+describe("rendered finalist qualification", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects an unrecognized board before spending on player simulation", async () => {
+    recognizePuzzleBoard.mockResolvedValue({
+      ok: false,
+      reason: "Rendered board objects not recognized: door",
+      perceptions: [],
+      conceptVotes: {},
+      textVotes: {},
+      operatorVotes: {},
+      profileResults: [],
+    });
+
+    const result = await qualifyRenderedCandidate(candidate());
+
+    expect(result.publishable).toBe(false);
+    expect(result.rejectReasons).toContain("Rendered board objects not recognized: door");
+    expect(simulatePlayerSolve).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/critique.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/critique.ts
@@ -20,6 +20,7 @@ export async function critiqueCandidate(input: {
 }): Promise<CritiqueResult> {
   try {
     const raw = await generateAIObject({
+      operation: "puzzle-critique",
       modelType: "smart",
       temperature: AI_CONFIG.generation.temperature.balanced,
       schema: CritiqueProviderSchema,

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -18,13 +18,9 @@ import { stableId } from "../tool-impl";
 import { toPlayabilityEvidence } from "./blind-solve-consensus";
 import { critiqueCandidate } from "./critique";
 import { buildGenerationBrief } from "./curriculum";
-import {
-  applyPlayerSimHeuristics,
-  playerSimPublishBlockers,
-  simulatePlayerSolve,
-} from "./player-sim";
+import { selectQualifiedFinalist } from "./finalist-selection";
+import { qualifyRenderedCandidate } from "./rendered-qualification";
 import { scoreRubric } from "./rubric";
-import { pickWinner } from "./tournament";
 import type { ApexCandidate, ApexEngineResult, GenerationBrief } from "./types";
 
 function toCandidate(
@@ -100,8 +96,7 @@ function toCandidate(
 
 async function enrichCandidate(
   candidate: ApexCandidate,
-  brief: GenerationBrief,
-  simCalibration?: { adjustment: number; sampleSize: number }
+  brief: GenerationBrief
 ): Promise<ApexCandidate> {
   const apex = AI_CONFIG.puzzleAgent.apex;
   let next = { ...candidate };
@@ -168,46 +163,6 @@ async function enrichCandidate(
     }
   }
 
-  if (apex.playerSimEnabled) {
-    let playerSim = next.playerSim;
-    if (!playerSim) {
-      const rawSim = await simulatePlayerSolve({
-        rebusPuzzle: candidate.rebusPuzzle,
-        answer: candidate.answer,
-        explanation: candidate.explanation,
-        hints: candidate.hints,
-        techniqueId: candidate.techniqueId,
-        tierLabel: brief.tierLabel,
-        visual: candidate.visual,
-      });
-      playerSim = applyPlayerSimHeuristics(rawSim, {
-        answer: candidate.answer,
-        hints: candidate.hints,
-        tierLabel: brief.tierLabel,
-      });
-    }
-    if (
-      simCalibration &&
-      simCalibration.sampleSize >= 6 &&
-      Math.abs(simCalibration.adjustment) >= 0.02
-    ) {
-      const { applySimCalibration } = await import("../../learning/sim-calibration");
-      playerSim = {
-        ...playerSim,
-        estimatedSolveRate: applySimCalibration(playerSim.estimatedSolveRate, simCalibration),
-      };
-    }
-    next = { ...next, playerSim };
-    const screenshotBlockers = playerSimPublishBlockers(playerSim);
-    if (screenshotBlockers.length) {
-      next = {
-        ...next,
-        publishable: false,
-        rejectReasons: [...next.rejectReasons, ...screenshotBlockers],
-      };
-    }
-  }
-
   const rubric = scoreRubric(next);
   return { ...next, rubric };
 }
@@ -265,6 +220,7 @@ export async function runApexGeneration(
         candidateIndex: slot,
         candidateCount: brief.candidateCount,
         useLearningFeedback: params.useLearningFeedback,
+        deferRenderedEvaluation: true,
       });
 
       candidates.push(toCandidate(result, brief, slot));
@@ -295,13 +251,40 @@ export async function runApexGeneration(
   } catch {
     simCalibration = undefined;
   }
-  const enriched = await Promise.all(
-    candidates.map((c) => enrichCandidate(c, brief, simCalibration))
-  );
+  const enriched = await Promise.all(candidates.map((c) => enrichCandidate(c, brief)));
   const critiqueMs = Date.now() - critiqueStarted;
 
   const selectStarted = Date.now();
-  const { winner, ranked } = pickWinner(enriched, brief.minRubricOverall);
+  const configuredRuntimeBudgetMs = Number(process.env.REBUZZLE_APEX_RUNTIME_BUDGET_MS);
+  const runtimeBudgetMs = Math.max(
+    120_000,
+    Math.min(
+      280_000,
+      Number.isFinite(configuredRuntimeBudgetMs) && configuredRuntimeBudgetMs > 0
+        ? configuredRuntimeBudgetMs
+        : 260_000
+    )
+  );
+  let lastEvaluationMs = 0;
+  const selection = await selectQualifiedFinalist({
+    candidates: enriched,
+    minRubricOverall: brief.minRubricOverall,
+    canStartEvaluation: () => {
+      const remaining = runtimeBudgetMs - (Date.now() - started);
+      const required = lastEvaluationMs > 0 ? lastEvaluationMs + 10_000 : 65_000;
+      return remaining >= required;
+    },
+    evaluate: async (candidate) => {
+      const evaluationStarted = Date.now();
+      try {
+        return await qualifyRenderedCandidate(candidate, simCalibration);
+      } finally {
+        lastEvaluationMs = Date.now() - evaluationStarted;
+      }
+    },
+  });
+  const { winner, ranked } = selection;
+  failures.push(...selection.failures);
   const selectMs = Date.now() - selectStarted;
 
   if (!winner) {
@@ -339,7 +322,14 @@ async function finalizeWinner(
   let chosen = winner;
   const archiveHit = await isAnswerRegistered(chosen.answer);
   if (archiveHit.taken) {
-    const alternate = ranked.find((c) => c.id !== chosen.id && (c.tournamentScore ?? -1) >= 0);
+    const alternate = ranked.find(
+      (candidate) =>
+        candidate.id !== chosen.id &&
+        candidate.publishable &&
+        candidate.playerSim !== undefined &&
+        (candidate.boardRecognitionProfiles?.length ?? 0) > 0 &&
+        (candidate.tournamentScore ?? -1) >= 0
+    );
     if (!alternate) {
       throw new Error(
         `Apex winner answer already archived (${archiveHit.puzzleId}). No alternate candidate.`

--- a/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
@@ -1,0 +1,58 @@
+import { rankCandidates } from "./tournament";
+import type { ApexCandidate } from "./types";
+
+const RUNTIME_GUARD_FAILURE =
+  "Rendered finalist evaluation stopped before runner-up to preserve the runtime deadline";
+
+export type FinalistSelectionResult = {
+  winner: ApexCandidate | null;
+  ranked: ApexCandidate[];
+  failures: string[];
+};
+
+/**
+ * Pre-rank cheap candidate drafts and spend rendered-evaluation work only on
+ * the strongest eligible finalist. A runner-up is evaluated only when the
+ * prior finalist fails a rendered publish gate.
+ */
+export async function selectQualifiedFinalist(input: {
+  candidates: ApexCandidate[];
+  minRubricOverall: number;
+  canStartEvaluation: () => boolean;
+  evaluate: (candidate: ApexCandidate) => Promise<ApexCandidate>;
+}): Promise<FinalistSelectionResult> {
+  const preRanked = rankCandidates(input.candidates, input.minRubricOverall);
+  const eligible = preRanked.filter(
+    (candidate) => candidate.publishable && (candidate.tournamentScore ?? -1) >= 0
+  );
+  const evaluatedById = new Map<string, ApexCandidate>();
+  const failures: string[] = [];
+
+  for (const candidate of eligible) {
+    if (!input.canStartEvaluation()) {
+      failures.push(RUNTIME_GUARD_FAILURE);
+      break;
+    }
+
+    const evaluated = await input.evaluate(candidate);
+    const rescored = rankCandidates([evaluated], input.minRubricOverall)[0];
+    if (!rescored) {
+      failures.push("Rendered finalist evaluation returned no candidate");
+      continue;
+    }
+    evaluatedById.set(candidate.id, rescored);
+
+    if (rescored.publishable && (rescored.tournamentScore ?? -1) >= 0) {
+      const ranked = preRanked.map((value) => evaluatedById.get(value.id) ?? value);
+      return { winner: rescored, ranked, failures };
+    }
+
+    failures.push(...rescored.rejectReasons);
+  }
+
+  return {
+    winner: null,
+    ranked: preRanked.map((value) => evaluatedById.get(value.id) ?? value),
+    failures,
+  };
+}

--- a/apps/web/src/ai/puzzle-agent/apex/player-sim.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/player-sim.ts
@@ -57,6 +57,7 @@ export async function runBlindSolveImageTournament(input: {
         image: input.image,
         mediaType: input.mediaType,
         temperature: 0.35,
+        operation: "vision-blind-solve",
         schema: BlindSolveSchema,
         system: `You are a clever but non-expert player seeing a rebus puzzle for the first time.
 You do not know the intended answer, icon labels, technique, explanation, or hints.

--- a/apps/web/src/ai/puzzle-agent/apex/rendered-qualification.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/rendered-qualification.ts
@@ -1,0 +1,103 @@
+import { recognizePuzzleBoard } from "../visual/critique-board";
+import {
+  applyPlayerSimHeuristics,
+  playerSimPublishBlockers,
+  simulatePlayerSolve,
+} from "./player-sim";
+import { scoreRubric } from "./rubric";
+import type { ApexCandidate } from "./types";
+
+type SimCalibration = { adjustment: number; sampleSize: number };
+
+/** Attach the rendered evidence required for publication to one pre-ranked finalist. */
+export async function qualifyRenderedCandidate(
+  candidate: ApexCandidate,
+  simCalibration?: SimCalibration
+): Promise<ApexCandidate> {
+  const boardRecognition = await recognizePuzzleBoard(candidate.visual);
+  if (!boardRecognition.ok) {
+    const rejected = {
+      ...candidate,
+      publishable: false,
+      rejectReasons: [
+        ...candidate.rejectReasons,
+        boardRecognition.reason ?? "Rendered board recognition failed",
+      ],
+    };
+    return { ...rejected, rubric: scoreRubric(rejected) };
+  }
+
+  const rawSim = await simulatePlayerSolve({
+    rebusPuzzle: candidate.rebusPuzzle,
+    answer: candidate.answer,
+    explanation: candidate.explanation,
+    hints: candidate.hints,
+    techniqueId: candidate.techniqueId,
+    tierLabel: candidate.difficultyLevel,
+    visual: candidate.visual,
+  });
+  let playerSim = applyPlayerSimHeuristics(rawSim, {
+    answer: candidate.answer,
+    hints: candidate.hints,
+    tierLabel: candidate.difficultyLevel,
+  });
+
+  if (
+    simCalibration &&
+    simCalibration.sampleSize >= 6 &&
+    Math.abs(simCalibration.adjustment) >= 0.02
+  ) {
+    const { applySimCalibration } = await import("../../learning/sim-calibration");
+    playerSim = {
+      ...playerSim,
+      estimatedSolveRate: applySimCalibration(playerSim.estimatedSolveRate, simCalibration),
+    };
+  }
+
+  const blockers = playerSimPublishBlockers(playerSim);
+  const profileResults = boardRecognition.profileResults ?? [];
+  const qualified: ApexCandidate = {
+    ...candidate,
+    playerSim,
+    publishable: candidate.publishable && blockers.length === 0,
+    rejectReasons: [...candidate.rejectReasons, ...blockers],
+    boardRecognitionConfidence: boardRecognition.perceptions.length
+      ? Math.min(
+          ...boardRecognition.perceptions.map((perception) =>
+            Math.max(0, Math.min(1, perception.overallConfidence))
+          )
+        )
+      : undefined,
+    boardRecognitionModels: boardRecognition.perceptions.length
+      ? boardRecognition.perceptions.map((perception) => perception.model)
+      : undefined,
+    boardConceptVotes: boardRecognition.perceptions.length
+      ? boardRecognition.conceptVotes
+      : undefined,
+    boardTextVotes: boardRecognition.perceptions.length ? boardRecognition.textVotes : undefined,
+    boardOperatorVotes: boardRecognition.perceptions.length
+      ? boardRecognition.operatorVotes
+      : undefined,
+    boardRecognitionProfiles: profileResults.length
+      ? profileResults.map((profile) => ({
+          profileId: profile.profileId,
+          viewportWidth: profile.viewportWidth,
+          tileSize: profile.tileSize,
+          confidence: profile.perceptions.length
+            ? Math.min(
+                ...profile.perceptions.map((perception) =>
+                  Math.max(0, Math.min(1, perception.overallConfidence))
+                )
+              )
+            : 0,
+          models: profile.perceptions.map((perception) => perception.model),
+          conceptVotes: profile.conceptVotes,
+          textVotes: profile.textVotes,
+          operatorVotes: profile.operatorVotes,
+          wrappedRows: profile.wrappedRows,
+        }))
+      : undefined,
+  };
+
+  return { ...qualified, rubric: scoreRubric(qualified) };
+}

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -80,6 +80,8 @@ export interface PuzzleGenerationParams {
   /** Tournament candidate slot (1-based) — encourages diversity across slots */
   candidateIndex?: number;
   candidateCount?: number;
+  /** Apex pre-ranking can defer costly rendered recognition and play simulation. */
+  deferRenderedEvaluation?: boolean;
 }
 
 export class PuzzleCandidateRejectedError extends Error {
@@ -247,6 +249,10 @@ export async function runPuzzleAgentGeneration(
           activeTools: [...PUBLICATION_AGENT_TOOLS],
           temperature: AI_CONFIG.generation.temperature.creative,
           maxOutputTokens: AI_CONFIG.generation.maxTokens.blog,
+          maxRetries: 0,
+          providerOptions: {
+            gateway: { tags: ["rebuzzle", "operation:puzzle-agent"] },
+          },
           stopWhen: stepCountIs(AI_CONFIG.puzzleAgent.maxSteps),
           output: Output.object({ schema: PuzzleAgentDraftSchema }),
           onStepEnd: ({ toolCalls }) => {
@@ -353,22 +359,6 @@ export async function runPuzzleAgentGeneration(
           continue;
         }
 
-        const boardRecognition = await recognizePuzzleBoard(puzzle.visual);
-        if (!boardRecognition.ok) {
-          priorFailure = boardRecognition.reason ?? "Rendered board recognition failed";
-          lastCandidateError = new PuzzleCandidateRejectedError(priorFailure, puzzle);
-          lastError = lastCandidateError;
-          if (process.env.REBUZZLE_GENERATOR_TRACE === "1") {
-            console.warn("[Puzzle Agent] candidate rejected", {
-              modelId,
-              attempt,
-              stage: "board-recognition",
-              reason: priorFailure,
-            });
-          }
-          continue;
-        }
-
         const gate = evaluatePublishGates({
           rebusPuzzle: puzzle.rebusPuzzle,
           answer: puzzle.answer,
@@ -408,6 +398,63 @@ export async function runPuzzleAgentGeneration(
           continue;
         }
 
+        const level = getDifficultyLevelForScore(targetDifficulty);
+        const fingerprint =
+          uniqueness.fingerprint ||
+          fingerprintCandidate({
+            rebusPuzzle: puzzle.rebusPuzzle,
+            answer: puzzle.answer,
+            category: puzzle.category,
+            visual: puzzle.visual,
+          });
+        const difficultyLevel = puzzle.difficultyLevel || level.label;
+        // Prefer measured in-band calibration; fall back to tier target only if already gated in-band.
+        const calibrated = calibration.inBand ? calibration.calibratedDifficulty : level.target;
+
+        if (params.deferRenderedEvaluation) {
+          return {
+            puzzle: {
+              ...puzzle,
+              difficulty: calibrated,
+              difficultyLevel,
+              techniqueId: puzzle.techniqueId,
+            },
+            metadata: {
+              fingerprint,
+              uniquenessScore: uniqueness.uniquenessScore,
+              noveltyEvidence: uniqueness.noveltyEvidence,
+              calibratedDifficulty: calibrated,
+              difficultyLevel,
+              qualityScore: quality.overall,
+              qualityVerdict: quality.verdict,
+              funScore: quality.funScore,
+              visualStyleId: puzzle.visual?.styleId,
+              generationAttempts: attempt,
+              thinkingSummary:
+                output.thinkingSummary ??
+                `${difficultyLevel} puzzle draft via Eve ToolLoopAgent + AI Gateway (${modelId}) in ${Date.now() - start}ms`,
+            },
+            status: "success",
+            recommendations: output.recommendations,
+          };
+        }
+
+        const boardRecognition = await recognizePuzzleBoard(puzzle.visual);
+        if (!boardRecognition.ok) {
+          priorFailure = boardRecognition.reason ?? "Rendered board recognition failed";
+          lastCandidateError = new PuzzleCandidateRejectedError(priorFailure, puzzle);
+          lastError = lastCandidateError;
+          if (process.env.REBUZZLE_GENERATOR_TRACE === "1") {
+            console.warn("[Puzzle Agent] candidate rejected", {
+              modelId,
+              attempt,
+              stage: "board-recognition",
+              reason: priorFailure,
+            });
+          }
+          continue;
+        }
+
         const rawSim = await simulatePlayerSolve({
           rebusPuzzle: puzzle.rebusPuzzle,
           answer: puzzle.answer,
@@ -437,21 +484,6 @@ export async function runPuzzleAgentGeneration(
           }
           continue;
         }
-
-        const level = getDifficultyLevelForScore(targetDifficulty);
-        const fingerprint =
-          uniqueness.fingerprint ||
-          fingerprintCandidate({
-            rebusPuzzle: puzzle.rebusPuzzle,
-            answer: puzzle.answer,
-            category: puzzle.category,
-            visual: puzzle.visual,
-          });
-
-        const difficultyLevel = puzzle.difficultyLevel || level.label;
-
-        // Prefer measured in-band calibration; fall back to tier target only if already gated in-band
-        const calibrated = calibration.inBand ? calibration.calibratedDifficulty : level.target;
 
         return {
           puzzle: {

--- a/apps/web/src/ai/puzzle-agent/visual/critique-board.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/critique-board.ts
@@ -47,6 +47,7 @@ async function judgeRenderedProfile(
         image: rendered.pixels,
         mediaType: "image/png",
         temperature: 0.1,
+        operation: "vision-board",
         schema: BoardPerceptionSchema,
         system: `You are inspecting a rendered rebus board exactly as a player sees it.
 Report only visible evidence. Do not infer hidden creator intent or solve from metadata.

--- a/apps/web/src/ai/puzzle-agent/visual/critique-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/critique-pictogram.ts
@@ -37,6 +37,7 @@ async function recognizeAtSize(input: {
   const settled = await Promise.allSettled(
     AI_CONFIG.visualRecognition.models.map(async (modelId) => ({
       ...(await generateAIObjectFromImage({
+        operation: "vision-pictogram",
         modelId,
         image: pixels,
         mediaType: "image/png",

--- a/apps/web/src/ai/puzzle-agent/visual/editorial-review.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/editorial-review.ts
@@ -30,6 +30,7 @@ export async function runPuzzleEditorialTournament(input: {
     renderedProfiles.flatMap((rendered) =>
       AI_CONFIG.visualRecognition.models.map(async (modelId) => {
         const review = await generateAIObjectFromImage({
+          operation: "vision-editorial",
           modelId,
           image: rendered.pixels,
           mediaType: "image/png",

--- a/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-image-tile.ts
@@ -3,6 +3,7 @@
  * Uses Vercel AI Gateway image models with a locked Rebuzzle illustration style.
  */
 
+import type { GatewayProviderOptions } from "@ai-sdk/gateway";
 import { generateImage } from "ai";
 import { ensureGatewayKey, getAiGateway } from "@/ai/client";
 import { IMAGE_TILE_STYLE_GUIDE } from "./style";
@@ -54,6 +55,12 @@ export async function generateImageTile(
         model: getAiGateway().image(modelId),
         prompt,
         aspectRatio: "1:1",
+        maxRetries: 0,
+        providerOptions: {
+          gateway: {
+            tags: ["rebuzzle", "operation:puzzle-image"],
+          } satisfies GatewayProviderOptions,
+        },
       });
 
       const file = result.image;

--- a/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
@@ -279,6 +279,7 @@ async function drawOnce(input: {
 }): Promise<{ svg: string | null; rawError?: string }> {
   try {
     const response = await generateAIText({
+      operation: "puzzle-pictogram",
       modelType: "creative",
       temperature: input.attempt === 0 ? 0.45 : 0.7,
       system: [

--- a/apps/web/src/ai/services/blog-generator.ts
+++ b/apps/web/src/ai/services/blog-generator.ts
@@ -206,6 +206,7 @@ export async function generateBlogPost(
 
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       const parsedResponse: AIBlogResponse = await generateAIObject({
+        operation: "blog",
         system,
         prompt: [
           BLOG_CONFIG.prompts.generatePost(puzzleData),


### PR DESCRIPTION
## Summary
- pre-rank puzzle drafts before expensive rendered board and player-simulation evaluation
- evaluate the runner-up only after the leading finalist fails a rendered publish gate
- preserve the 300-second production deadline with an adaptive runtime guard
- disable implicit AI SDK retries and tag Gateway usage by operation for cost attribution
- keep board recognition, blind solving, editorial review, rubric, and archive checks fail-closed

## Production evidence
- the Gateway key budget was raised from  to 
- the prior workflow duplicated rendered evaluation across candidates and reached the 300-second function timeout
- observed quality failures (unrecognized door and clipped mobile board) remain hard rejections

## Verification
- 82 Jest suites / 469 tests pass
- TypeScript check passes with no emit and incremental state disabled
- Next.js 16.2.12 production build passes
- Biome passes on all changed source files
- git diff --check passes