### PR TITLE
fix(ai): Qualify drafts before final rubric

### DIFF
--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
@@ -82,6 +82,23 @@ describe("Apex rendered finalist selection", () => {
     expect(evaluated).toEqual(["top"]);
   });
 
+  it("evaluates a hard-gate-passing draft before requiring the final rubric", async () => {
+    const draft = candidate("draft", 74);
+
+    const result = await selectQualifiedFinalist({
+      candidates: [draft],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      evaluate: async (value) => ({
+        ...value,
+        rubric: { ...value.rubric!, fairness: 90, overall: 82 },
+      }),
+    });
+
+    expect(result.winner?.id).toBe("draft");
+    expect(result.winner?.rubric?.overall).toBe(82);
+  });
+
   it("evaluates the runner-up only after the first finalist is rejected", async () => {
     const evaluated: string[] = [];
     const top = candidate("top", 92);

--- a/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
@@ -23,7 +23,12 @@ export async function selectQualifiedFinalist(input: {
 }): Promise<FinalistSelectionResult> {
   const preRanked = rankCandidates(input.candidates, input.minRubricOverall);
   const eligible = preRanked.filter(
-    (candidate) => candidate.publishable && (candidate.tournamentScore ?? -1) >= 0
+    (candidate) =>
+      candidate.publishable &&
+      candidate.isUnique &&
+      candidate.solvable &&
+      candidate.inBand &&
+      candidate.critique?.verdict !== "reject"
   );
   const evaluatedById = new Map<string, ApexCandidate>();
   const failures: string[] = [];


### PR DESCRIPTION
## Summary
- let hard-gate-passing drafts receive rendered player evidence before the final rubric cutoff
- continue enforcing the final tournament score after rendered qualification
- add a regression test for a draft that rises above the threshold after evaluation

## Production evidence
The first post-merge run completed in 113 seconds, but every draft was eliminated by the preliminary rubric before rendered evaluation. This follow-up corrects that ordering without weakening any final publish gate.

## Verification
- 82 Jest suites / 470 tests pass
- TypeScript check passes with no emit and incremental state disabled
- Next.js 16.2.12 production build passes
- Biome and git diff checks pass