### PR TITLE
Expose actionable Apex rejection reasons

### DIFF
--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
@@ -153,4 +153,30 @@ describe("Apex rendered finalist selection", () => {
       "Rendered finalist evaluation stopped before runner-up to preserve the runtime deadline",
     ]);
   });
+
+  it("reports why every draft was excluded before rendered evaluation", async () => {
+    const rejected = {
+      ...candidate("rejected", 90),
+      publishable: false,
+      critique: {
+        ...candidate("rejected", 90).critique!,
+        verdict: "revise" as const,
+        summary: "The visual metaphor is ambiguous",
+        reviseInstructions: ["Replace the abstract icon with a concrete silhouette"],
+      },
+      rejectReasons: ["Critique revise: Replace the abstract icon with a concrete silhouette"],
+    };
+
+    const result = await selectQualifiedFinalist({
+      candidates: [rejected],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      evaluate: async (value) => value,
+    });
+
+    expect(result.winner).toBeNull();
+    expect(result.failures).toContain(
+      "rejected: Critique revise: Replace the abstract icon with a concrete silhouette"
+    );
+  });
 });

--- a/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
@@ -3,12 +3,52 @@ import type { ApexCandidate } from "./types";
 
 const RUNTIME_GUARD_FAILURE =
   "Rendered finalist evaluation stopped before runner-up to preserve the runtime deadline";
+const MAX_FAILURE_DETAIL_LENGTH = 320;
 
 export type FinalistSelectionResult = {
   winner: ApexCandidate | null;
   ranked: ApexCandidate[];
   failures: string[];
 };
+
+function isEligibleForRenderedEvaluation(candidate: ApexCandidate): boolean {
+  return (
+    candidate.publishable &&
+    candidate.isUnique &&
+    candidate.solvable &&
+    candidate.inBand &&
+    candidate.critique?.verdict !== "reject"
+  );
+}
+
+function compactFailureDetail(detail: string): string {
+  const compact = detail.replace(/\s+/g, " ").trim();
+  return compact.length > MAX_FAILURE_DETAIL_LENGTH
+    ? `${compact.slice(0, MAX_FAILURE_DETAIL_LENGTH - 1)}…`
+    : compact;
+}
+
+function preRankingFailure(candidate: ApexCandidate, minRubricOverall: number): string {
+  const reasons = [...candidate.rejectReasons];
+  if (!candidate.publishable && !reasons.length) reasons.push("publishable gate failed");
+  if (!candidate.isUnique) reasons.push("uniqueness gate failed");
+  if (!candidate.solvable) reasons.push("solvability gate failed");
+  if (!candidate.inBand) reasons.push("difficulty band gate failed");
+  if (
+    candidate.critique?.verdict === "reject" &&
+    !reasons.some((reason) => reason.startsWith("Critique reject:"))
+  ) {
+    reasons.push(`Critique reject: ${candidate.critique.summary}`);
+  }
+  if (candidate.rubric && candidate.rubric.overall < minRubricOverall) {
+    reasons.push(`Preliminary rubric ${candidate.rubric.overall} below ${minRubricOverall}`);
+  }
+
+  const detail = reasons.length
+    ? reasons.slice(0, 3).map(compactFailureDetail).join("; ")
+    : "candidate failed a rendered-evaluation eligibility gate";
+  return `${candidate.id}: ${detail}`;
+}
 
 /**
  * Pre-rank cheap candidate drafts and spend rendered-evaluation work only on
@@ -22,14 +62,10 @@ export async function selectQualifiedFinalist(input: {
   evaluate: (candidate: ApexCandidate) => Promise<ApexCandidate>;
 }): Promise<FinalistSelectionResult> {
   const preRanked = rankCandidates(input.candidates, input.minRubricOverall);
-  const eligible = preRanked.filter(
-    (candidate) =>
-      candidate.publishable &&
-      candidate.isUnique &&
-      candidate.solvable &&
-      candidate.inBand &&
-      candidate.critique?.verdict !== "reject"
-  );
+  const eligible = preRanked.filter(isEligibleForRenderedEvaluation);
+  const preRankingFailures = preRanked
+    .filter((candidate) => !isEligibleForRenderedEvaluation(candidate))
+    .map((candidate) => preRankingFailure(candidate, input.minRubricOverall));
   const evaluatedById = new Map<string, ApexCandidate>();
   const failures: string[] = [];
 
@@ -58,6 +94,6 @@ export async function selectQualifiedFinalist(input: {
   return {
     winner: null,
     ranked: preRanked.map((value) => evaluatedById.get(value.id) ?? value),
-    failures,
+    failures: [...preRankingFailures, ...failures],
   };
 }


### PR DESCRIPTION
## What changed
- Preserve concise, candidate-scoped rejection evidence when every Apex draft is excluded before rendered evaluation.
- Surface critique, uniqueness, solvability, difficulty-band, and preliminary rubric failures instead of falling back to `gates/rubric`.
- Add regression coverage for the all-drafts-rejected path.

## Why
The production workflow was correctly refusing weak puzzles, but the error contained no reason for the generator team to improve the next attempt. This makes the fail-closed quality gate observable without weakening recognizability or playability requirements.

## Validation
- `pnpm.cmd exec turbo test -- --runInBand` — 82 suites, 471 tests passed
- `pnpm.cmd --filter @rebuzzle/web exec tsc --noEmit --incremental false` — passed
- `pnpm.cmd --filter @rebuzzle/web build` — passed
- `pnpm.cmd --filter @rebuzzle/web exec biome check src/ai/puzzle-agent/apex/finalist-selection.ts src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts` — passed

The monorepo-wide typecheck remains blocked by the pre-existing `@rebuzzle/config` `uuid` type-definition resolution issue; the affected web app typecheck is clean.