### PR TITLE
Stage Apex critique by finalist

### DIFF
--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
@@ -82,6 +82,48 @@ describe("Apex rendered finalist selection", () => {
     expect(evaluated).toEqual(["top"]);
   });
 
+  it("prepares only the top-ranked finalist when its rendered evidence qualifies", async () => {
+    const prepared: string[] = [];
+    const result = await selectQualifiedFinalist({
+      candidates: [candidate("runner-up", 84), candidate("top", 92)],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      evaluate: async (value) => value,
+      prepare: async (value: ApexCandidate) => {
+        prepared.push(value.id);
+        return value;
+      },
+    } as Parameters<typeof selectQualifiedFinalist>[0] & {
+      prepare: (value: ApexCandidate) => Promise<ApexCandidate>;
+    });
+
+    expect(result.winner?.id).toBe("top");
+    expect(prepared).toEqual(["top"]);
+  });
+
+  it("prepares the runner-up only after the first finalist fails rendered gates", async () => {
+    const prepared: string[] = [];
+    const result = await selectQualifiedFinalist({
+      candidates: [candidate("top", 92), candidate("runner-up", 84)],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      prepare: async (value: ApexCandidate) => {
+        prepared.push(value.id);
+        return value;
+      },
+      evaluate: async (value) => ({
+        ...value,
+        publishable: value.id !== "top",
+        rejectReasons: value.id === "top" ? ["Rendered board was not recognized"] : [],
+      }),
+    } as Parameters<typeof selectQualifiedFinalist>[0] & {
+      prepare: (value: ApexCandidate) => Promise<ApexCandidate>;
+    });
+
+    expect(result.winner?.id).toBe("runner-up");
+    expect(prepared).toEqual(["top", "runner-up"]);
+  });
+
   it("evaluates a hard-gate-passing draft before requiring the final rubric", async () => {
     const draft = candidate("draft", 74);
 

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -239,7 +239,6 @@ export async function runApexGeneration(
     );
   }
 
-  const critiqueStarted = Date.now();
   let simCalibration: { adjustment: number; sampleSize: number } | undefined;
   try {
     const { loadSimCalibration } = await import("../../learning/sim-calibration");
@@ -251,10 +250,9 @@ export async function runApexGeneration(
   } catch {
     simCalibration = undefined;
   }
-  const enriched = await Promise.all(candidates.map((c) => enrichCandidate(c, brief)));
-  const critiqueMs = Date.now() - critiqueStarted;
 
   const selectStarted = Date.now();
+  let critiqueMs = 0;
   const configuredRuntimeBudgetMs = Number(process.env.REBUZZLE_APEX_RUNTIME_BUDGET_MS);
   const runtimeBudgetMs = Math.max(
     120_000,
@@ -267,8 +265,16 @@ export async function runApexGeneration(
   );
   let lastEvaluationMs = 0;
   const selection = await selectQualifiedFinalist({
-    candidates: enriched,
+    candidates,
     minRubricOverall: brief.minRubricOverall,
+    prepare: async (candidate) => {
+      const critiqueStarted = Date.now();
+      try {
+        return await enrichCandidate(candidate, brief);
+      } finally {
+        critiqueMs += Date.now() - critiqueStarted;
+      }
+    },
     canStartEvaluation: () => {
       const remaining = runtimeBudgetMs - (Date.now() - started);
       const required = lastEvaluationMs > 0 ? lastEvaluationMs + 10_000 : 65_000;
@@ -285,7 +291,7 @@ export async function runApexGeneration(
   });
   const { winner, ranked } = selection;
   failures.push(...selection.failures);
-  const selectMs = Date.now() - selectStarted;
+  const selectMs = Math.max(0, Date.now() - selectStarted - critiqueMs);
 
   if (!winner) {
     throw new Error(

--- a/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
@@ -11,6 +11,8 @@ export type FinalistSelectionResult = {
   failures: string[];
 };
 
+type FinalistPreparation = (candidate: ApexCandidate) => Promise<ApexCandidate>;
+
 function isEligibleForRenderedEvaluation(candidate: ApexCandidate): boolean {
   return (
     candidate.publishable &&
@@ -60,31 +62,49 @@ export async function selectQualifiedFinalist(input: {
   minRubricOverall: number;
   canStartEvaluation: () => boolean;
   evaluate: (candidate: ApexCandidate) => Promise<ApexCandidate>;
+  prepare?: FinalistPreparation;
 }): Promise<FinalistSelectionResult> {
   const preRanked = rankCandidates(input.candidates, input.minRubricOverall);
-  const eligible = preRanked.filter(isEligibleForRenderedEvaluation);
-  const preRankingFailures = preRanked
-    .filter((candidate) => !isEligibleForRenderedEvaluation(candidate))
-    .map((candidate) => preRankingFailure(candidate, input.minRubricOverall));
+  const preparedById = new Map<string, ApexCandidate>();
   const evaluatedById = new Map<string, ApexCandidate>();
   const failures: string[] = [];
 
-  for (const candidate of eligible) {
+  for (const draft of preRanked) {
+    if (!isEligibleForRenderedEvaluation(draft)) {
+      failures.push(preRankingFailure(draft, input.minRubricOverall));
+      continue;
+    }
+
+    const candidate = input.prepare ? await input.prepare(draft) : draft;
+    const prepared = rankCandidates([candidate], input.minRubricOverall)[0];
+    if (!prepared) {
+      failures.push(`${draft.id}: finalist preparation returned no candidate`);
+      continue;
+    }
+    preparedById.set(prepared.id, prepared);
+
+    if (!isEligibleForRenderedEvaluation(prepared)) {
+      failures.push(preRankingFailure(prepared, input.minRubricOverall));
+      continue;
+    }
+
     if (!input.canStartEvaluation()) {
       failures.push(RUNTIME_GUARD_FAILURE);
       break;
     }
 
-    const evaluated = await input.evaluate(candidate);
+    const evaluated = await input.evaluate(prepared);
     const rescored = rankCandidates([evaluated], input.minRubricOverall)[0];
     if (!rescored) {
       failures.push("Rendered finalist evaluation returned no candidate");
       continue;
     }
-    evaluatedById.set(candidate.id, rescored);
+    evaluatedById.set(rescored.id, rescored);
 
     if (rescored.publishable && (rescored.tournamentScore ?? -1) >= 0) {
-      const ranked = preRanked.map((value) => evaluatedById.get(value.id) ?? value);
+      const ranked = preRanked.map(
+        (value) => evaluatedById.get(value.id) ?? preparedById.get(value.id) ?? value
+      );
       return { winner: rescored, ranked, failures };
     }
 
@@ -93,7 +113,9 @@ export async function selectQualifiedFinalist(input: {
 
   return {
     winner: null,
-    ranked: preRanked.map((value) => evaluatedById.get(value.id) ?? value),
-    failures: [...preRankingFailures, ...failures],
+    ranked: preRanked.map(
+      (value) => evaluatedById.get(value.id) ?? preparedById.get(value.id) ?? value
+    ),
+    failures,
   };
 }


### PR DESCRIPTION
## What changed
- Rank cheap deterministic drafts first, then critique only the strongest finalist that is about to receive rendered evaluation.
- Critique the runner-up only if the first finalist fails rendered recognition or playability gates.
- Preserve prepared/evaluated candidates in ranked output and keep exact rejection evidence.

## Why
The prior Apex engine paid for critique on every draft before knowing which draft would receive expensive rendered evidence. This staged path reduces duplicate Gateway spend and latency while preserving a properly critiqued fallback and all fail-closed quality gates.

## Validation
- `pnpm.cmd exec turbo test -- --runInBand` — 82 suites, 473 tests passed
- `pnpm.cmd --filter @rebuzzle/web exec tsc --noEmit --incremental false` — passed
- `pnpm.cmd --filter @rebuzzle/web build` — passed
- Targeted Biome checks — passed

Vercel preview checks are currently infrastructure-rate-limited for 24 hours; local production build is green.