### PR TITLE
feat(ai): add bounded critique-guided repair

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -154,7 +154,7 @@ The first implementation slice now includes:
 - an independent answer-aware screenshot rejection lane for missing cues, answer leakage, wrong objects, unreadability, broken layout, and stronger alternate answers;
 - fail-closed behavior for unavailable recognition/solve judges;
 - fail-closed master generation: Apex rejection can no longer fall through to a less-verified Eve result, and explicitly selected Eve generation must pass the same screenshot playability gates;
-- hard rejection of low-recognition, revise, unfair-hint, and below-rubric Apex candidates;
+- hard rejection of low-recognition, unfair-hint, and below-rubric Apex candidates, with at most one bounded model-backed repair for an actionable `revise` critique before rejection;
 - persisted per-size and per-profile model, confidence, vote, and wrapping evidence;
 - a frozen 196-specimen publication icon evaluator corpus producing 392 required decisions, plus an opt-in diagnostic lane for quarantined candidates;
 - an admin-only blind human naming panel for all 196 publication catalog/size specimens, with opaque fixture IDs and browser payloads that contain no concept, alias, asset ID, or correctness signal;

--- a/apps/web/src/ai/puzzle-agent/apex/README.md
+++ b/apps/web/src/ai/puzzle-agent/apex/README.md
@@ -6,10 +6,11 @@ Rebuzzle’s next-gen daily puzzle generator. Designed as a **tournament**, not 
 
 1. **Curriculum brief** — diversity memory (techniques/categories/answers), learning digest from recent attempts, curated phrase-bank seeds
 2. **Multi-candidate Eve slots** — each slot gets a distinct technique focus + phrase slice
-3. **Adversarial critique** — ship / revise / reject with predicted aha
-4. **Player simulation** — wrong parses + hint fairness + estimated solve rate
-5. **Rubric** — aha, fairness, novelty, visual craft, shareability, technique fit, hint craft
-6. **Winner selection** — only publishable, unique, solvable, in-band candidates compete
+3. **Lazy adversarial critique** — critique only the strongest eligible finalist first
+4. **Bounded repair** — one model-backed `revise` critique may trigger one fresh board, only when the runtime reserve allows it; fallback critiques never spend a repair
+5. **Rendered player evidence** — board recognition, wrong parses, hint fairness, and estimated solve rate
+6. **Rubric** — aha, fairness, novelty, visual craft, shareability, technique fit, hint craft
+7. **Winner selection** — only publishable, unique, solvable, in-band candidates compete
 
 Falls back to classic Eve ToolLoopAgent if the tournament yields nothing.
 
@@ -18,10 +19,18 @@ Falls back to classic Eve ToolLoopAgent if the tournament yields nothing.
 | Env | Default | Meaning |
 | --- | --- | --- |
 | `EVE_APEX_ENGINE` | on | Set `0` / `false` to force classic Eve |
-| `EVE_APEX_CANDIDATES` | `3` | Tournament slots (2–5) |
+| `EVE_APEX_CANDIDATES` | `2` | Tournament slots (2–5) |
 | `EVE_APEX_MIN_RUBRIC` | `78` | Minimum rubric overall to win |
 | `EVE_APEX_CRITIQUE` | on | Set `0` to skip critique LLM calls |
 | `EVE_APEX_PLAYER_SIM` | on | Set `0` to skip player-sim LLM calls |
+| `REBUZZLE_APEX_REVISION_RESERVE_MS` | `155000` | Minimum remaining runtime reserved for one critique-guided repair plus final evidence |
+
+The repair lane is deliberately bounded: it bans the original answer, uses one
+model chain and one generation attempt, re-critiques the repaired board, and
+still must pass the same rendered recognition and blind-solve gates. A critique
+provider failure is marked as a fallback and is rejected without attempting a
+repair, so an unavailable judge cannot silently multiply spend or lower the
+publication bar.
 
 ## Visual Lab
 

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/critique.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/critique.test.ts
@@ -1,0 +1,52 @@
+const generateAIObject = jest.fn();
+
+jest.mock("../../../client", () => ({ generateAIObject }));
+
+import { critiqueCandidate } from "../critique";
+
+const input = {
+  rebusPuzzle: "key over key",
+  answer: "keynote",
+  explanation: "A positional phrase.",
+  hints: ["Look at the layout."],
+  techniqueId: "positional_phrase",
+  difficulty: 5,
+  tierLabel: "Hard",
+  unicodeFallback: "key\nkey",
+  pictogramConcepts: ["key"],
+};
+
+const modelResponse = {
+  verdict: "ship" as const,
+  summary: "Clear and fair",
+  strengths: ["Concrete cue"],
+  flaws: [],
+  reviseInstructions: [],
+  falseLeadQuality: 85,
+  ahaPredicted: 84,
+  creativityScore: 80,
+  iconRecognizability: 90,
+  overusedTrope: false,
+};
+
+describe("critique source tracking", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("marks a successful model critique as actionable model evidence", async () => {
+    generateAIObject.mockResolvedValue(modelResponse);
+
+    await expect(critiqueCandidate(input)).resolves.toMatchObject({
+      source: "model",
+      verdict: "ship",
+    });
+  });
+
+  it("marks an unavailable critique as fallback evidence", async () => {
+    generateAIObject.mockRejectedValue(new Error("provider unavailable"));
+
+    await expect(critiqueCandidate(input)).resolves.toMatchObject({
+      source: "fallback",
+      verdict: "revise",
+    });
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-budget.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-budget.test.ts
@@ -1,19 +1,78 @@
 const runPuzzleAgentGeneration = jest.fn();
 const buildGenerationBrief = jest.fn();
+const critiqueCandidate = jest.fn();
+const qualifyRenderedCandidate = jest.fn();
 
 jest.mock("../../run-generation", () => ({ runPuzzleAgentGeneration }));
-jest.mock("../../tool-impl", () => ({ stableId: jest.fn(() => "candidate-id") }));
+jest.mock("../../tool-impl", () => ({
+  stableId: jest.fn((...parts: string[]) => parts.join("-")),
+}));
 jest.mock("../curriculum", () => ({ buildGenerationBrief }));
-jest.mock("../critique", () => ({ critiqueCandidate: jest.fn() }));
-jest.mock("../rendered-qualification", () => ({ qualifyRenderedCandidate: jest.fn() }));
+jest.mock("../critique", () => ({ critiqueCandidate }));
+jest.mock("../rendered-qualification", () => ({ qualifyRenderedCandidate }));
 jest.mock("../player-sim", () => ({
   applyPlayerSimHeuristics: jest.fn(),
   playerSimPublishBlockers: jest.fn(() => []),
   simulatePlayerSolve: jest.fn(),
 }));
+jest.mock("../../../learning/answer-registry", () => ({
+  isAnswerRegistered: jest.fn(async () => ({ taken: false })),
+}));
+jest.mock("../../../learning/sim-calibration", () => ({
+  loadSimCalibration: jest.fn(async () => ({ adjustment: 0, sampleSize: 0 })),
+}));
 
 import { AIBudgetExceededError } from "../../../errors";
+import { INK_PICTOGRAM_EXAMPLE_KEY } from "../../visual/style";
 import { runApexGeneration } from "../engine";
+
+function puzzleResult(answer: string) {
+  return {
+    puzzle: {
+      rebusPuzzle: `${answer} visual`,
+      answer,
+      difficulty: 5,
+      difficultyLevel: "Hard" as const,
+      explanation: "A clean positional mechanism.",
+      category: "phrases",
+      hints: ["Look at the layout.", "Read the objects together.", "It is a phrase."],
+      techniqueId: "simple_compound" as const,
+      visual: {
+        styleId: "ink-pictogram-v1" as const,
+        mode: "composed" as const,
+        layout: "row" as const,
+        unicodeFallback: "key",
+        layers: [
+          {
+            kind: "pictogram" as const,
+            concept: "key",
+            emojiFallback: "🔑",
+            source: "catalog" as const,
+            assetId: "key",
+            svg: INK_PICTOGRAM_EXAMPLE_KEY,
+          },
+        ],
+      },
+    },
+    metadata: {
+      fingerprint: `fingerprint-${answer}`,
+      uniquenessScore: 90,
+      calibratedDifficulty: 5,
+      difficultyLevel: "Hard" as const,
+      qualityScore: 92,
+      qualityVerdict: "good" as const,
+      funScore: 82,
+      visualStyleId: "ink-pictogram-v1" as const,
+      thinkingSummary: "test",
+    },
+    status: "success" as const,
+    recommendations: [],
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("Apex spending-cap behavior", () => {
   it("stops remaining tournament slots after the first hard budget error", async () => {
@@ -35,5 +94,84 @@ describe("Apex spending-cap behavior", () => {
       code: "AI_BUDGET_EXCEEDED",
     });
     expect(runPuzzleAgentGeneration).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs at most one model-backed critique repair and bans the original answer", async () => {
+    buildGenerationBrief.mockResolvedValue({
+      targetDifficulty: 5,
+      tierLabel: "Hard",
+      qualityThreshold: 74,
+      minRubricOverall: 78,
+      candidateCount: 2,
+      preferredTechniques: ["simple_compound"],
+      avoidTechniques: [],
+      phraseSuggestions: [],
+      diversity: { bannedAnswerKeys: [] },
+      briefSummary: "test",
+      learning: {
+        enabled: false,
+        avoidPatterns: [],
+        preferPatterns: [],
+        difficultyDriftNotes: [],
+        sampleSize: 0,
+        targetDifficultyDelta: 0,
+        tooEasy: false,
+        tooHard: false,
+        medianSolveSeconds: null,
+        solveRate: null,
+      },
+      requireNovelty: true,
+      minFunScore: 68,
+      componentBudget: { min: 1, max: 4 },
+      puzzleType: "rebus",
+    });
+    runPuzzleAgentGeneration
+      .mockResolvedValueOnce(puzzleResult("top"))
+      .mockResolvedValueOnce(puzzleResult("runner"))
+      .mockResolvedValueOnce(puzzleResult("repaired"));
+    critiqueCandidate
+      .mockResolvedValueOnce({
+        source: "model",
+        verdict: "revise",
+        summary: "Use a concrete icon",
+        strengths: [],
+        flaws: ["The cue is abstract"],
+        reviseInstructions: ["Replace the abstract icon with a concrete silhouette"],
+        falseLeadQuality: 60,
+        ahaPredicted: 70,
+        creativityScore: 70,
+        iconRecognizability: 45,
+        overusedTrope: false,
+      })
+      .mockResolvedValueOnce({
+        source: "model",
+        verdict: "ship",
+        summary: "Clear repair",
+        strengths: ["Concrete"],
+        flaws: [],
+        reviseInstructions: [],
+        falseLeadQuality: 85,
+        ahaPredicted: 86,
+        creativityScore: 82,
+        iconRecognizability: 90,
+        overusedTrope: false,
+      });
+    qualifyRenderedCandidate.mockImplementation(async (value: unknown) => value);
+
+    const result = await runApexGeneration({ targetDifficulty: 5 });
+
+    expect(result.status).toBe("success");
+    expect(result.puzzle.answer).toBe("repaired");
+    expect(runPuzzleAgentGeneration).toHaveBeenCalledTimes(3);
+    expect(runPuzzleAgentGeneration.mock.calls[2][0]).toMatchObject({
+      maxAttempts: 1,
+      modelChainLimit: 1,
+      revisionInstructions: ["Replace the abstract icon with a concrete silhouette"],
+      bannedAnswerKeys: ["top"],
+      candidateIndex: undefined,
+      candidateCount: undefined,
+    });
+    expect(critiqueCandidate).toHaveBeenCalledTimes(2);
+    expect(qualifyRenderedCandidate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/finalist-selection.test.ts
@@ -124,6 +124,81 @@ describe("Apex rendered finalist selection", () => {
     expect(prepared).toEqual(["top", "runner-up"]);
   });
 
+  it("uses one actionable critique revision before falling back to the runner-up", async () => {
+    const prepared: string[] = [];
+    const evaluated: string[] = [];
+    const revisions: string[] = [];
+    const top = candidate("top", 92);
+    const runnerUp = candidate("runner-up", 84);
+    const revised = candidate("top-revision", 91);
+
+    const result = await selectQualifiedFinalist({
+      candidates: [top, runnerUp],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      canStartRevision: () => true,
+      prepare: async (value: ApexCandidate) => {
+        prepared.push(value.id);
+        if (value.id !== "top") return value;
+        return {
+          ...value,
+          publishable: false,
+          critique: {
+            ...value.critique!,
+            source: "model" as const,
+            verdict: "revise" as const,
+            summary: "The icon needs a more concrete silhouette",
+            reviseInstructions: ["Replace the abstract icon with a concrete silhouette"],
+          },
+          rejectReasons: ["Critique revise: Replace the abstract icon with a concrete silhouette"],
+        };
+      },
+      revise: async (value: ApexCandidate) => {
+        revisions.push(value.id);
+        return revised;
+      },
+      evaluate: async (value) => {
+        evaluated.push(value.id);
+        return value;
+      },
+    });
+
+    expect(result.winner?.id).toBe("top-revision");
+    expect(result.ranked.map((value) => value.id)).toEqual(["top-revision", "runner-up"]);
+    expect(prepared).toEqual(["top", "top-revision"]);
+    expect(revisions).toEqual(["top"]);
+    expect(evaluated).toEqual(["top-revision"]);
+  });
+
+  it("does not spend a revision when critique is only a fallback", async () => {
+    const revise = jest.fn(async () => candidate("revision", 90));
+    const fallback = {
+      ...candidate("fallback", 92),
+      publishable: false,
+      critique: {
+        ...candidate("fallback", 92).critique!,
+        source: "fallback" as const,
+        verdict: "revise" as const,
+        summary: "Critique unavailable — treat as provisional",
+        reviseInstructions: ["Retry later"],
+      },
+      rejectReasons: ["Critique unavailable — treat as provisional"],
+    };
+
+    const result = await selectQualifiedFinalist({
+      candidates: [fallback],
+      minRubricOverall: 78,
+      canStartEvaluation: () => true,
+      canStartRevision: () => true,
+      revise,
+      evaluate: async (value) => value,
+    });
+
+    expect(result.winner).toBeNull();
+    expect(revise).not.toHaveBeenCalled();
+    expect(result.failures).toContain("fallback: Critique unavailable — treat as provisional");
+  });
+
   it("evaluates a hard-gate-passing draft before requiring the final rubric", async () => {
     const draft = candidate("draft", 74);
 

--- a/apps/web/src/ai/puzzle-agent/apex/critique.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/critique.ts
@@ -52,6 +52,7 @@ Be specific and ruthless but fair.`,
 
     return {
       ...raw,
+      source: "model",
       creativityScore: raw.creativityScore ?? 60,
       iconRecognizability: raw.iconRecognizability ?? 70,
       overusedTrope: raw.overusedTrope ?? false,
@@ -60,6 +61,7 @@ Be specific and ruthless but fair.`,
     // Soft fallback — don't block the pipeline if critique model fails
     return {
       verdict: "revise",
+      source: "fallback",
       summary: "Critique unavailable — treat as provisional",
       strengths: [],
       flaws: ["Automated critique failed; rely on deterministic gates"],

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -10,7 +10,7 @@
 
 import { AI_CONFIG } from "../../config";
 import { isHardAIBudgetError, parseAIError } from "../../errors";
-import { isKnownTechniqueId } from "../quality";
+import { isKnownTechniqueId, normalizeAnswerKey } from "../quality";
 import { type PuzzleGenerationParams, runPuzzleAgentGeneration } from "../run-generation";
 import type { PuzzleAgentResult } from "../schemas";
 import type { TechniqueId } from "../technique-library";
@@ -264,6 +264,16 @@ export async function runApexGeneration(
     )
   );
   let lastEvaluationMs = 0;
+  const configuredRevisionReserveMs = Number(process.env.REBUZZLE_APEX_REVISION_RESERVE_MS);
+  const revisionReserveMs = Math.max(
+    120_000,
+    Math.min(
+      210_000,
+      Number.isFinite(configuredRevisionReserveMs) && configuredRevisionReserveMs > 0
+        ? configuredRevisionReserveMs
+        : 155_000
+    )
+  );
   const selection = await selectQualifiedFinalist({
     candidates,
     minRubricOverall: brief.minRubricOverall,
@@ -279,6 +289,36 @@ export async function runApexGeneration(
       const remaining = runtimeBudgetMs - (Date.now() - started);
       const required = lastEvaluationMs > 0 ? lastEvaluationMs + 10_000 : 65_000;
       return remaining >= required;
+    },
+    canStartRevision: () => runtimeBudgetMs - (Date.now() - started) >= revisionReserveMs,
+    maxRevisions: 1,
+    revise: async (candidate) => {
+      try {
+        const result = await runPuzzleAgentGeneration({
+          ...params,
+          maxAttempts: 1,
+          modelChainLimit: 1,
+          qualityThreshold: brief.qualityThreshold,
+          briefSummary: brief.briefSummary,
+          preferredTechniques: [
+            candidate.techniqueId,
+            ...brief.preferredTechniques.filter((technique) => technique !== candidate.techniqueId),
+          ],
+          avoidTechniques: brief.avoidTechniques,
+          phraseSeeds: brief.phraseSuggestions.slice(0, 3).map((phrase) => phrase.answer),
+          bannedAnswerKeys: Array.from(
+            new Set([...brief.diversity.bannedAnswerKeys, normalizeAnswerKey(candidate.answer)])
+          ),
+          candidateIndex: undefined,
+          candidateCount: undefined,
+          deferRenderedEvaluation: true,
+          revisionInstructions: candidate.critique?.reviseInstructions,
+        });
+        return toCandidate(result, brief, brief.candidateCount + 1);
+      } catch (error) {
+        if (isHardAIBudgetError(error)) throw parseAIError(error);
+        return null;
+      }
     },
     evaluate: async (candidate) => {
       const evaluationStarted = Date.now();
@@ -311,7 +351,8 @@ export async function runApexGeneration(
       totalMs: Date.now() - started,
     },
     failures,
-    simCalibration
+    simCalibration,
+    selection.revisionAttempts
   );
 }
 
@@ -321,7 +362,8 @@ async function finalizeWinner(
   brief: GenerationBrief,
   phases: ApexEngineResult["phases"],
   failures: string[],
-  simCalibration?: { adjustment: number; sampleSize: number }
+  simCalibration?: { adjustment: number; sampleSize: number },
+  revisionAttempts = 0
 ): Promise<PuzzleAgentResult> {
   // Final archive uniqueness gate — never ship a recycled answer
   const { isAnswerRegistered } = await import("../../learning/answer-registry");
@@ -354,6 +396,7 @@ async function finalizeWinner(
     `rubric ${chosen.rubric?.overall ?? "?"}/100`,
     `technique ${chosen.techniqueId}`,
     `candidates ${ranked.length}`,
+    revisionAttempts ? `critique revisions ${revisionAttempts}` : null,
     failures.length ? `slot failures ${failures.length}` : null,
     learningNote(brief),
     `${phases.totalMs}ms`,

--- a/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/finalist-selection.ts
@@ -9,9 +9,11 @@ export type FinalistSelectionResult = {
   winner: ApexCandidate | null;
   ranked: ApexCandidate[];
   failures: string[];
+  revisionAttempts: number;
 };
 
 type FinalistPreparation = (candidate: ApexCandidate) => Promise<ApexCandidate>;
+type FinalistRevision = (candidate: ApexCandidate) => Promise<ApexCandidate | null>;
 
 function isEligibleForRenderedEvaluation(candidate: ApexCandidate): boolean {
   return (
@@ -20,6 +22,14 @@ function isEligibleForRenderedEvaluation(candidate: ApexCandidate): boolean {
     candidate.solvable &&
     candidate.inBand &&
     candidate.critique?.verdict !== "reject"
+  );
+}
+
+function canAttemptCritiqueRevision(candidate: ApexCandidate): boolean {
+  return (
+    candidate.critique?.source === "model" &&
+    candidate.critique.verdict === "revise" &&
+    candidate.critique.reviseInstructions.length > 0
   );
 }
 
@@ -63,11 +73,16 @@ export async function selectQualifiedFinalist(input: {
   canStartEvaluation: () => boolean;
   evaluate: (candidate: ApexCandidate) => Promise<ApexCandidate>;
   prepare?: FinalistPreparation;
+  canStartRevision?: () => boolean;
+  revise?: FinalistRevision;
+  maxRevisions?: number;
 }): Promise<FinalistSelectionResult> {
   const preRanked = rankCandidates(input.candidates, input.minRubricOverall);
   const preparedById = new Map<string, ApexCandidate>();
   const evaluatedById = new Map<string, ApexCandidate>();
   const failures: string[] = [];
+  const maxRevisions = Math.min(1, Math.max(0, input.maxRevisions ?? 1));
+  let revisionAttempts = 0;
 
   for (const draft of preRanked) {
     if (!isEligibleForRenderedEvaluation(draft)) {
@@ -76,7 +91,7 @@ export async function selectQualifiedFinalist(input: {
     }
 
     const candidate = input.prepare ? await input.prepare(draft) : draft;
-    const prepared = rankCandidates([candidate], input.minRubricOverall)[0];
+    let prepared = rankCandidates([candidate], input.minRubricOverall)[0];
     if (!prepared) {
       failures.push(`${draft.id}: finalist preparation returned no candidate`);
       continue;
@@ -84,8 +99,44 @@ export async function selectQualifiedFinalist(input: {
     preparedById.set(prepared.id, prepared);
 
     if (!isEligibleForRenderedEvaluation(prepared)) {
-      failures.push(preRankingFailure(prepared, input.minRubricOverall));
-      continue;
+      const canRevise =
+        Boolean(input.revise) &&
+        revisionAttempts < maxRevisions &&
+        canAttemptCritiqueRevision(prepared);
+
+      if (!canRevise) {
+        failures.push(preRankingFailure(prepared, input.minRubricOverall));
+        continue;
+      }
+
+      if (input.canStartRevision && !input.canStartRevision()) {
+        failures.push(
+          `${preRankingFailure(prepared, input.minRubricOverall)}; critique-guided revision skipped by runtime guard`
+        );
+        continue;
+      }
+
+      revisionAttempts += 1;
+      const revised = await input.revise!(prepared);
+      if (!revised) {
+        failures.push(
+          `${preRankingFailure(prepared, input.minRubricOverall)}; critique-guided revision returned no candidate`
+        );
+        continue;
+      }
+
+      const revisedCandidate = input.prepare ? await input.prepare(revised) : revised;
+      prepared = rankCandidates([revisedCandidate], input.minRubricOverall)[0];
+      if (!prepared) {
+        failures.push(`${revised.id}: finalist revision returned no candidate`);
+        continue;
+      }
+      preparedById.set(prepared.id, prepared);
+
+      if (!isEligibleForRenderedEvaluation(prepared)) {
+        failures.push(preRankingFailure(prepared, input.minRubricOverall));
+        continue;
+      }
     }
 
     if (!input.canStartEvaluation()) {
@@ -105,7 +156,12 @@ export async function selectQualifiedFinalist(input: {
       const ranked = preRanked.map(
         (value) => evaluatedById.get(value.id) ?? preparedById.get(value.id) ?? value
       );
-      return { winner: rescored, ranked, failures };
+      const withoutReplacedDraft = ranked.filter((value) => value.id !== draft.id);
+      const outputRanked = [rescored, ...withoutReplacedDraft].filter(
+        (value, index, values) =>
+          values.findIndex((candidate) => candidate.id === value.id) === index
+      );
+      return { winner: rescored, ranked: outputRanked, failures, revisionAttempts };
     }
 
     failures.push(...rescored.rejectReasons);
@@ -117,5 +173,6 @@ export async function selectQualifiedFinalist(input: {
       (value) => evaluatedById.get(value.id) ?? preparedById.get(value.id) ?? value
     ),
     failures,
+    revisionAttempts,
   };
 }

--- a/apps/web/src/ai/puzzle-agent/apex/types.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/types.ts
@@ -23,6 +23,8 @@ export type RubricScores = z.infer<typeof RubricScoresSchema>;
 
 export const CritiqueSchema = z.object({
   verdict: z.enum(["ship", "revise", "reject"]),
+  /** Whether the critique came from the model or the fail-closed fallback. */
+  source: z.enum(["model", "fallback"]).optional(),
   summary: z.string(),
   strengths: z.array(z.string()).max(6),
   flaws: z.array(z.string()).max(8),

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -82,6 +82,10 @@ export interface PuzzleGenerationParams {
   candidateCount?: number;
   /** Apex pre-ranking can defer costly rendered recognition and play simulation. */
   deferRenderedEvaluation?: boolean;
+  /** Specific model-backed critique instructions for one bounded repair pass. */
+  revisionInstructions?: string[];
+  /** Keep a repair pass from silently multiplying spend through model fallbacks. */
+  modelChainLimit?: number;
 }
 
 export class PuzzleCandidateRejectedError extends Error {
@@ -166,6 +170,13 @@ function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string)
       ? `Banned answer keys (normalized): ${params.bannedAnswerKeys.slice(0, 30).join(", ")}.`
       : null,
     params.briefSummary ? `Curriculum brief: ${params.briefSummary}` : null,
+    params.revisionInstructions?.length
+      ? [
+          "Bounded repair pass: address every critique instruction below with a new, cleaner board.",
+          "Do not defend or copy the previous mechanism; use a concrete catalog-backed pictogram and preserve a fair hint ladder.",
+          `Critique instructions: ${params.revisionInstructions.slice(0, 4).join("; ")}`,
+        ].join("\n")
+      : null,
     slot,
     params.requireNovelty !== false
       ? "Novelty is required — avoid recent answers and similar visuals."
@@ -226,7 +237,10 @@ export async function runPuzzleAgentGeneration(
     1,
     // A model fallback repeats the complete agent loop. Default to one model so
     // a single daily puzzle cannot silently multiply premium-model spend.
-    Math.min(3, Number(process.env.REBUZZLE_GENERATOR_MODEL_CHAIN_LIMIT || 1) || 1)
+    Math.min(
+      3,
+      params.modelChainLimit ?? (Number(process.env.REBUZZLE_GENERATOR_MODEL_CHAIN_LIMIT || 1) || 1)
+    )
   );
   const modelChain = Array.from(
     new Set([AI_CONFIG.puzzleAgent.model, ...getGatewayModelChain("creative")])

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/icon-features.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/icon-features.test.ts
@@ -19,4 +19,10 @@ describe("icon features", () => {
     expect(conceptMatchesSeen("wristwatch", "watch")).toBe(true);
     expect(conceptMatchesSeen("computer mouse", "mouse device")).toBe(true);
   });
+
+  it("does not grant recognition from an accidental substring", () => {
+    expect(conceptMatchesSeen("car", "carpet")).toBe(false);
+    expect(conceptMatchesSeen("car", "cartoon")).toBe(false);
+    expect(conceptMatchesSeen("bus", "business")).toBe(false);
+  });
 });

--- a/apps/web/src/ai/puzzle-agent/visual/icon-features.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/icon-features.ts
@@ -319,6 +319,25 @@ function normalizeLabel(value: string): string {
     .trim();
 }
 
+function tokenizeLabel(value: string): string[] {
+  return normalizeLabel(value).split(/\s+/).filter(Boolean);
+}
+
+function containsTokenSequence(haystack: string[], needle: string[]): boolean {
+  if (!haystack.length || !needle.length || needle.length > haystack.length) return false;
+  return Array.from({ length: haystack.length - needle.length + 1 }).some((_, start) =>
+    needle.every((token, offset) => haystack[start + offset] === token)
+  );
+}
+
+function labelsMatchByTokens(left: string, right: string): boolean {
+  const leftTokens = tokenizeLabel(left);
+  const rightTokens = tokenizeLabel(right);
+  return (
+    containsTokenSequence(leftTokens, rightTokens) || containsTokenSequence(rightTokens, leftTokens)
+  );
+}
+
 export function lookupIconFeatures(concept: string): IconFeatureEntry | null {
   const key = normalizeLabel(concept).replace(/\s+/g, "");
   if (ICON_FEATURES[key]) return ICON_FEATURES[key]!;
@@ -350,28 +369,11 @@ export function conceptMatchesSeen(concept: string, seenLabel: string): boolean 
   const intended = normalizeLabel(concept);
   const seen = normalizeLabel(seenLabel);
   if (!intended || !seen) return false;
-  if (seen === intended) return true;
-  if (seen.includes(intended) || intended.includes(seen)) return true;
+  if (labelsMatchByTokens(intended, seen)) return true;
 
   const curatedAliases = getCuratedPictogramAliases(concept);
-  if (
-    curatedAliases.some((alias) => {
-      const normalized = normalizeLabel(alias);
-      return seen === normalized || seen.includes(normalized) || normalized.includes(seen);
-    })
-  ) {
-    return true;
-  }
+  if (curatedAliases.some((alias) => labelsMatchByTokens(alias, seen))) return true;
 
   const entry = lookupIconFeatures(concept);
-  if (entry) {
-    return entry.aliases.some((alias) => {
-      const a = normalizeLabel(alias);
-      return seen === a || seen.includes(a) || a.includes(seen);
-    });
-  }
-
-  const intendedTokens = new Set(intended.split(" ").filter((t) => t.length > 2));
-  const seenTokens = seen.split(" ").filter((t) => t.length > 2);
-  return seenTokens.some((t) => intendedTokens.has(t));
+  return Boolean(entry?.aliases.some((alias) => labelsMatchByTokens(alias, seen)));
 }


### PR DESCRIPTION
## Summary

- add one bounded model-backed critique repair before rejecting an otherwise strong Apex finalist
- keep fallback critiques fail-closed, cap repair work to one attempt and one model chain, ban the original answer, and re-run the normal critique/rendered gates
- tighten icon recognition matching to token boundaries so accidental substrings such as `car`/`carpet` cannot pass
- add engine, finalist-selection, critique-source, and recognition regression coverage

## Verification

- `pnpm.cmd exec turbo test -- --runInBand` — 83 suites, 479 tests passed
- `pnpm.cmd --filter @rebuzzle/web build` — passed; existing Mongo/Dynamic API and browser-baseline warnings remain
- targeted Biome check — passed
- `git diff --check` — passed

Live production rerun remains gated on the Vercel deployment quota reset; this change does not spend Gateway credits.