### PR TITLE
perf(ai): reject unapproved assets before evaluation

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -204,7 +204,7 @@ Per-puzzle gates prevent an individual bad candidate from publishing; the longit
 
 ### Operational AI cost envelope
 
-Production defaults bound the expensive portion of a daily generation to two Apex candidates, one complete agent attempt per candidate, and one generator model per attempt. The independent multi-model, multi-viewport recognition gates remain mandatory for every candidate that reaches them. Operators may deliberately widen the search with `EVE_APEX_CANDIDATES`, `REBUZZLE_GENERATOR_MODEL_CHAIN_LIMIT`, or an explicit `maxAttempts`, but those changes are cost decisions and must be benchmarked before production use.
+Production defaults bound the expensive portion of a daily generation to two Apex candidates, one complete agent attempt per candidate, and one generator model per attempt. Authoritative asset provenance is checked immediately after composition, before novelty, difficulty, or quality evaluation, so unapproved artwork cannot consume the rest of the candidate budget. The independent multi-model, multi-viewport recognition gates remain mandatory for every candidate that reaches them. Operators may deliberately widen the search with `EVE_APEX_CANDIDATES`, `REBUZZLE_GENERATOR_MODEL_CHAIN_LIMIT`, or an explicit `maxAttempts`, but those changes are cost decisions and must be benchmarked before production use.
 
 Gateway account/project budget exhaustion is terminal, not a transient quota. The client must stop model fallback immediately, the puzzle agent must stop its attempt loop, Apex must stop remaining candidate slots, and the daily workflow must skip the downstream blog call. Public workflow responses use the sanitized `AI_BUDGET_EXCEEDED` code and never expose spend or limit details.
 

--- a/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
@@ -1,0 +1,130 @@
+const generate = jest.fn();
+const verifyPublicationAssets = jest.fn();
+const checkUniqueness = jest.fn();
+const calibratePuzzleDifficulty = jest.fn();
+const stressTestSolvability = jest.fn();
+const scorePuzzleQuality = jest.fn();
+const evaluatePublishGates = jest.fn();
+
+jest.mock("ai", () => ({
+  Output: { object: jest.fn(() => ({})) },
+  ToolLoopAgent: jest.fn().mockImplementation((options) => ({
+    generate: (...args: unknown[]) => generate(options, ...args),
+  })),
+  stepCountIs: jest.fn(() => () => false),
+}));
+jest.mock("../../client", () => ({
+  assertGatewayAuthConfigured: jest.fn(),
+  ensureGatewayKey: jest.fn(),
+  getAiGateway: jest.fn(() => jest.fn(() => "mock-model")),
+  getGatewayModelChain: jest.fn(() => []),
+}));
+jest.mock("../../config", () => ({
+  AI_CONFIG: {
+    puzzleAgent: { qualityThreshold: 74, minFunScore: 68, maxAttempts: 1, maxSteps: 8 },
+    generation: { temperature: { creative: 0.7 }, maxTokens: { blog: 1000 } },
+    timeouts: { agent: 1000 },
+  },
+}));
+jest.mock("../../errors", () => ({
+  isHardAIBudgetError: jest.fn(() => false),
+  parseAIError: jest.fn((error) => error),
+}));
+jest.mock("../../quota-manager", () => ({ enforceQuota: jest.fn(async () => undefined) }));
+jest.mock("../authoritative-draft", () => ({
+  applyAuthoritativeComposition: jest.fn((puzzle) => puzzle),
+}));
+jest.mock("../difficulty-levels", () => ({
+  getDifficultyLevelForScore: jest.fn(() => ({
+    label: "Hard",
+    min: 4,
+    max: 6,
+    target: 5,
+    techniques: ["simple_compound"],
+    componentBudget: { min: 1, max: 4 },
+  })),
+}));
+jest.mock("../quality", () => ({
+  evaluatePublishGates,
+}));
+jest.mock("../schemas", () => ({
+  normalizePuzzleAgentDraft: jest.fn((output) => output),
+  PuzzleAgentDraftSchema: {},
+}));
+jest.mock("../tool-impl", () => ({
+  calibratePuzzleDifficulty,
+  checkUniqueness,
+  fingerprintCandidate: jest.fn(() => "fingerprint"),
+  scorePuzzleQuality,
+  stressTestSolvability,
+}));
+jest.mock("../tools", () => ({ puzzleAgentTools: {} }));
+jest.mock("../visual/composition", () => ({
+  PuzzleVisualSchema: { safeParse: jest.fn((visual) => ({ success: true, data: visual })) },
+}));
+jest.mock("../visual/critique-board", () => ({ recognizePuzzleBoard: jest.fn() }));
+jest.mock("../visual/publication-assets", () => ({ verifyPublicationAssets }));
+
+import { PuzzleCandidateRejectedError, runPuzzleAgentGeneration } from "../run-generation";
+
+const visual = {
+  styleId: "ink-pictogram-v1",
+  mode: "composed",
+  layout: "row",
+  unicodeFallback: "🔑 + BOARD",
+  layers: [
+    {
+      kind: "pictogram",
+      concept: "key",
+      emojiFallback: "🔑",
+      svg: "<svg />",
+      source: "generated",
+    },
+  ],
+};
+
+const draft = {
+  puzzle: {
+    rebusPuzzle: "🔑 + BOARD",
+    answer: "keyboard",
+    difficulty: 5,
+    difficultyLevel: "Hard",
+    explanation: "A key plus board forms the compound answer.",
+    category: "phrases",
+    hints: ["Think of a compound word.", "The first part is a key.", "It starts with K."],
+    techniqueId: "simple_compound",
+    visual,
+  },
+};
+
+describe("runPuzzleAgentGeneration asset gate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    generate.mockImplementation(
+      async (options: { onToolExecutionEnd?: (event: unknown) => void }) => {
+        options.onToolExecutionEnd?.({
+          toolCall: { toolName: "compose_puzzle_visual", input: { answer: "keyboard" } },
+          toolOutput: { type: "tool-result", output: { visual } },
+        });
+        return { output: draft };
+      }
+    );
+    verifyPublicationAssets.mockResolvedValue({
+      ok: false,
+      reason: 'Pictogram "key" is not catalog-backed or human-approved',
+    });
+  });
+
+  it("rejects unapproved artwork before expensive novelty and scoring work", async () => {
+    await expect(
+      runPuzzleAgentGeneration({ targetDifficulty: 5, maxAttempts: 1, modelChainLimit: 1 })
+    ).rejects.toBeInstanceOf(PuzzleCandidateRejectedError);
+
+    expect(verifyPublicationAssets).toHaveBeenCalledTimes(1);
+    expect(checkUniqueness).not.toHaveBeenCalled();
+    expect(calibratePuzzleDifficulty).not.toHaveBeenCalled();
+    expect(stressTestSolvability).not.toHaveBeenCalled();
+    expect(scorePuzzleQuality).not.toHaveBeenCalled();
+    expect(evaluatePublishGates).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -313,6 +313,25 @@ export async function runPuzzleAgentGeneration(
         }
         const puzzle = applyAuthoritativeComposition(output.puzzle, capturedComposition);
 
+        // Asset provenance is a cheap, fail-closed gate. Run it before novelty
+        // and difficulty evaluation so an unapproved/generated pictogram cannot
+        // consume additional database or model budget.
+        const assetApproval = await verifyPublicationAssets(puzzle.visual);
+        if (!assetApproval.ok) {
+          priorFailure = assetApproval.reason;
+          lastCandidateError = new PuzzleCandidateRejectedError(priorFailure, puzzle);
+          lastError = lastCandidateError;
+          if (process.env.REBUZZLE_GENERATOR_TRACE === "1") {
+            console.warn("[Puzzle Agent] candidate rejected", {
+              modelId,
+              attempt,
+              stage: "asset-approval",
+              reason: priorFailure,
+            });
+          }
+          continue;
+        }
+
         const targetDifficulty = params.targetDifficulty || puzzle.difficulty;
 
         const [uniqueness, calibration] = await Promise.all([
@@ -356,22 +375,6 @@ export async function runPuzzleAgentGeneration(
           techniqueId: puzzle.techniqueId,
           visual: puzzle.visual,
         });
-
-        const assetApproval = await verifyPublicationAssets(puzzle.visual);
-        if (!assetApproval.ok) {
-          priorFailure = assetApproval.reason;
-          lastCandidateError = new PuzzleCandidateRejectedError(priorFailure, puzzle);
-          lastError = lastCandidateError;
-          if (process.env.REBUZZLE_GENERATOR_TRACE === "1") {
-            console.warn("[Puzzle Agent] candidate rejected", {
-              modelId,
-              attempt,
-              stage: "asset-approval",
-              reason: priorFailure,
-            });
-          }
-          continue;
-        }
 
         const gate = evaluatePublishGates({
           rebusPuzzle: puzzle.rebusPuzzle,


### PR DESCRIPTION
## Summary

- run authoritative pictogram/image provenance checks immediately after composition
- reject generated or unapproved artwork before novelty, calibration, solvability, quality, or publish-gate work can spend more budget
- add a regression test proving the early fail-closed ordering
- document the cost envelope and ordering guarantee

## Verification

- `pnpm.cmd exec turbo test -- --runInBand` — 84 suites, 480 tests passed
- `pnpm.cmd --filter @rebuzzle/web build` — passed; existing Mongo/Dynamic API, dotenv, and browser-baseline warnings remain
- targeted Biome check — passed
- `git diff --check` — passed

This change is local and does not invoke the Gateway.