### PR TITLE
feat(ai): add no-spend generator preflight

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -208,6 +208,14 @@ Production defaults bound the expensive portion of a daily generation to two Ape
 
 Gateway account/project budget exhaustion is terminal, not a transient quota. The client must stop model fallback immediately, the puzzle agent must stop its attempt loop, Apex must stop remaining candidate slots, and the daily workflow must skip the downstream blog call. Public workflow responses use the sanitized `AI_BUDGET_EXCEEDED` code and never expose spend or limit details.
 
+Before any credentialed benchmark or live canary, run the no-spend static preflight:
+
+```bash
+pnpm --filter @rebuzzle/web benchmark:puzzles:static
+```
+
+It renders the frozen positive solve corpus and catalog-grounded reserve inventory at every production board profile, rechecks local schema/provenance and answer-leak invariants, and reruns 36px/72px pictogram pixel-integrity checks. A passing report proves mechanical renderability only; semantic recognition, fairness, diversity, and player outcomes still require independent model and human evidence.
+
 The current provisional SLOs are 1% player-reported unrecognizable, 2% ambiguous or unfair, 20% dislike, and 5% attempted-generation failure/fallback. A player metric needs at least 20 fast-window or 50 slow-window votes; generation health uses 5 and 14 attempts because production generation is approximately daily. A critical halt requires statistically confirmed breaches in both windows, at least three/five player events (two/three generation events), at least 4x fast burn, and at least 2x slow burn. Slow-only or lower-burn confirmed drift blocks evaluator/model promotion and triggers review, but does not replace a potentially good AI puzzle with reserve content.
 
 When any metric is critical, the daily generation action does not call the AI generator. It persists an unused, catalog-grounded reserve puzzle through the same novelty archive and publication locks, records the reason, and reevaluates the rolling windows on the next generation opportunity. Circuit-open reserve days are not counted as failed AI attempts because no AI attempt occurred. If quality telemetry itself is unavailable, the health endpoint fails visibly; the generation path logs the monitoring loss and retains all candidate-level fail-closed recognition, solve, editorial, novelty, and persistence gates.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "benchmark:puzzles:live-canary": "tsx scripts/benchmark-live-generator.ts",
     "benchmark:puzzles:catalog-sheet": "tsx scripts/render-curated-catalog.ts",
     "benchmark:puzzles:reserve-sheet": "tsx scripts/render-reserve-puzzles.ts",
+    "benchmark:puzzles:static": "tsx scripts/benchmark-static-puzzles.ts",
     "benchmark:puzzles:solve": "tsx scripts/benchmark-puzzle-solving.ts",
     "benchmark:puzzles:external:import": "tsx scripts/import-external-puzzle-corpus.ts",
     "benchmark:puzzles:external:review-template": "tsx scripts/create-external-review-template.ts",

--- a/apps/web/scripts/benchmark-static-puzzles.ts
+++ b/apps/web/scripts/benchmark-static-puzzles.ts
@@ -1,0 +1,32 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { auditStaticPuzzleCorpus } from "../src/ai/puzzle-agent/benchmark/static-audit";
+
+function arg(name: string, fallback: string): string {
+  return process.argv.find((value) => value.startsWith(`--${name}=`))?.slice(name.length + 3) ?? fallback;
+}
+
+async function main(): Promise<void> {
+  const output = path.resolve(arg("output", "artifacts/puzzle-generator/static-audit.json"));
+  const report = await auditStaticPuzzleCorpus();
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(
+    output,
+    `${JSON.stringify({ generatedAt: new Date().toISOString(), report }, null, 2)}\n`,
+    "utf8"
+  );
+
+  console.log(
+    `[static-audit] promotion=${report.promotion.passed} puzzles=${report.puzzlePassCount}/${report.puzzleCount} profiles=${report.renderedProfileCount}/${report.expectedRenderedProfileCount} assets=${report.assetPassCount}/${report.assetCount}`
+  );
+  console.log(`[static-audit] report: ${output}`);
+  if (!report.promotion.passed) {
+    report.promotion.failures.forEach((failure) => console.error(`[static-audit] ${failure}`));
+    process.exitCode = 1;
+  }
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/web/src/ai/puzzle-agent/benchmark/__tests__/static-audit.test.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/__tests__/static-audit.test.ts
@@ -1,0 +1,41 @@
+import { auditStaticPuzzleCorpus } from "../static-audit";
+
+describe("static puzzle preflight", () => {
+  it("passes the complete no-spend corpus across every production profile", async () => {
+    const report = await auditStaticPuzzleCorpus();
+
+    expect(report.promotion).toEqual({ passed: true, failures: [] });
+    expect(report.puzzleCount).toBe(93);
+    expect(report.puzzlePassCount).toBe(93);
+    expect(report.renderedProfileCount).toBe(279);
+    expect(report.expectedRenderedProfileCount).toBe(279);
+    expect(report.assetCount).toBe(47);
+    expect(report.assetPassCount).toBe(47);
+  });
+
+  it("fails closed on answer leakage, fallback drift, and unknown techniques", async () => {
+    const report = await auditStaticPuzzleCorpus({
+      puzzles: [
+        {
+          id: "bad:static-preflight",
+          source: "solve-corpus",
+          answer: "answer",
+          rebusPuzzle: "different",
+          techniqueId: "not-a-technique",
+          visual: {
+            styleId: "ink-pictogram-v1",
+            mode: "composed",
+            layout: "row",
+            unicodeFallback: "ANSWER",
+            layers: [{ kind: "text", content: "ANSWER", emphasis: "normal" }],
+          },
+        },
+      ],
+    });
+
+    expect(report.promotion.passed).toBe(false);
+    expect(report.failures.join(" ")).toContain("does not equal");
+    expect(report.failures.join(" ")).toContain("leaks the answer");
+    expect(report.failures.join(" ")).toContain("Unknown technique");
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/benchmark/index.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/index.ts
@@ -50,6 +50,15 @@ export {
 } from "./quality-score";
 export { compareIconBenchmarkReports, scoreIconBenchmark } from "./score";
 export {
+  auditStaticPuzzleCorpus,
+  STATIC_PUZZLE_AUDIT_VERSION,
+  type StaticAssetAuditItem,
+  type StaticAuditPuzzle,
+  type StaticPuzzleAuditOptions,
+  type StaticPuzzleAuditItem,
+  type StaticPuzzleAuditReport,
+} from "./static-audit";
+export {
   ICON_BENCHMARK_TILE_SIZES,
   type IconBenchmarkCase,
   type IconBenchmarkObservation,

--- a/apps/web/src/ai/puzzle-agent/benchmark/static-audit.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/static-audit.ts
@@ -1,0 +1,184 @@
+import { displayLeaksAnswer, evaluateVisualForPublish, isKnownTechniqueId } from "../quality";
+import {
+  RESERVE_PUZZLES,
+  type ReservePuzzle,
+  validateReservePuzzleCorpus,
+} from "../reserve-puzzles";
+import { type PuzzleVisual, PuzzleVisualSchema } from "../visual/composition";
+import { evaluatePictogramPixelIntegrity } from "../visual/pictogram-pixel-integrity";
+import { PUZZLE_BOARD_RECOGNITION_PROFILES } from "../visual/presentation";
+import { renderPuzzleVisualProfiles } from "../visual/render-board";
+import { buildPuzzleSolveBenchmarkCorpus } from "./puzzle-corpus";
+import { PUZZLE_GENERATOR_BENCHMARK_VERSION } from "./types";
+
+export const STATIC_PUZZLE_AUDIT_VERSION = "static-puzzle-audit-v1";
+
+export type StaticAuditPuzzle = {
+  id: string;
+  answer: string;
+  rebusPuzzle: string;
+  techniqueId: string;
+  visual: PuzzleVisual;
+  source: "solve-corpus" | "reserve";
+};
+
+export type StaticPuzzleAuditItem = {
+  id: string;
+  source: StaticAuditPuzzle["source"];
+  profilesRendered: number;
+  passed: boolean;
+  failures: string[];
+};
+
+export type StaticAssetAuditItem = {
+  concept: string;
+  passed: boolean;
+  failures: string[];
+};
+
+export type StaticPuzzleAuditReport = {
+  version: typeof STATIC_PUZZLE_AUDIT_VERSION;
+  benchmarkVersion: string;
+  puzzleCount: number;
+  puzzlePassCount: number;
+  renderedProfileCount: number;
+  expectedRenderedProfileCount: number;
+  assetCount: number;
+  assetPassCount: number;
+  sourceCounts: Record<StaticAuditPuzzle["source"], number>;
+  puzzleItems: StaticPuzzleAuditItem[];
+  assetItems: StaticAssetAuditItem[];
+  failures: string[];
+  promotion: { passed: boolean; failures: string[] };
+};
+
+export type StaticPuzzleAuditOptions = {
+  puzzles?: readonly StaticAuditPuzzle[];
+  reserveCorpus?: readonly ReservePuzzle[];
+};
+
+function defaultCorpus(): StaticAuditPuzzle[] {
+  const solveCorpus = buildPuzzleSolveBenchmarkCorpus().map((entry) => ({
+    id: entry.id,
+    answer: entry.answer,
+    rebusPuzzle: entry.visual.unicodeFallback,
+    techniqueId: entry.techniqueId,
+    visual: entry.visual,
+    source: "solve-corpus" as const,
+  }));
+  const reserveCorpus = RESERVE_PUZZLES.map((entry) => ({
+    id: entry.id,
+    answer: entry.answer,
+    rebusPuzzle: entry.rebusPuzzle,
+    techniqueId: entry.techniqueId,
+    visual: entry.visual,
+    source: "reserve" as const,
+  }));
+  return [...solveCorpus, ...reserveCorpus];
+}
+
+function uniquePictograms(puzzles: readonly StaticAuditPuzzle[]) {
+  const bySvg = new Map<string, { concept: string; svg: string }>();
+  for (const puzzle of puzzles) {
+    for (const layer of puzzle.visual.layers) {
+      if (layer.kind !== "pictogram" || !layer.svg) continue;
+      const key = `${layer.assetId ?? layer.concept}\u0000${layer.svg}`;
+      if (!bySvg.has(key)) bySvg.set(key, { concept: layer.concept, svg: layer.svg });
+    }
+  }
+  return [...bySvg.values()].sort((left, right) => left.concept.localeCompare(right.concept));
+}
+
+async function auditPuzzle(puzzle: StaticAuditPuzzle): Promise<StaticPuzzleAuditItem> {
+  const failures: string[] = [];
+  const parsed = PuzzleVisualSchema.safeParse(puzzle.visual);
+  if (!parsed.success) {
+    failures.push(`Invalid visual schema: ${parsed.error.message}`);
+    return { id: puzzle.id, source: puzzle.source, profilesRendered: 0, passed: false, failures };
+  }
+
+  const visualCheck = evaluateVisualForPublish(puzzle.visual);
+  if (!visualCheck.ok) failures.push(visualCheck.reason ?? "Visual failed publish preflight");
+  if (puzzle.rebusPuzzle !== puzzle.visual.unicodeFallback) {
+    failures.push("rebusPuzzle does not equal visual.unicodeFallback");
+  }
+  if (displayLeaksAnswer(puzzle.visual.unicodeFallback, puzzle.answer)) {
+    failures.push("Rendered fallback leaks the answer");
+  }
+  if (!isKnownTechniqueId(puzzle.techniqueId)) {
+    failures.push(`Unknown technique: ${puzzle.techniqueId}`);
+  }
+
+  let profilesRendered = 0;
+  try {
+    profilesRendered = (await renderPuzzleVisualProfiles(puzzle.visual)).length;
+    if (profilesRendered !== PUZZLE_BOARD_RECOGNITION_PROFILES.length) {
+      failures.push(
+        `Rendered ${profilesRendered}/${PUZZLE_BOARD_RECOGNITION_PROFILES.length} production profiles`
+      );
+    }
+  } catch (error) {
+    failures.push(
+      `Production profile rendering failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  return {
+    id: puzzle.id,
+    source: puzzle.source,
+    profilesRendered,
+    passed: failures.length === 0,
+    failures,
+  };
+}
+
+/**
+ * Run all deterministic generation checks that are safe to execute without
+ * Gateway, database, or human-review credentials. This is mechanical evidence
+ * only; it intentionally does not claim semantic recognition or playability.
+ */
+export async function auditStaticPuzzleCorpus(
+  options: StaticPuzzleAuditOptions = {}
+): Promise<StaticPuzzleAuditReport> {
+  const puzzles = options.puzzles ?? defaultCorpus();
+  const puzzleItems = await Promise.all(puzzles.map((puzzle) => auditPuzzle(puzzle)));
+  const assetItems = await Promise.all(
+    uniquePictograms(puzzles).map(async ({ concept, svg }): Promise<StaticAssetAuditItem> => {
+      const result = await evaluatePictogramPixelIntegrity(svg);
+      return { concept, passed: result.ok, failures: result.reasons };
+    })
+  );
+  const reserveFailures =
+    options.puzzles && !options.reserveCorpus
+      ? []
+      : validateReservePuzzleCorpus(options.reserveCorpus ?? RESERVE_PUZZLES);
+  const failures = [
+    ...reserveFailures.map((failure) => `reserve-corpus: ${failure}`),
+    ...puzzleItems.flatMap((item) =>
+      item.failures.map((failure) => `${item.source}:${item.id}: ${failure}`)
+    ),
+    ...assetItems.flatMap((item) =>
+      item.failures.map((failure) => `asset:${item.concept}: ${failure}`)
+    ),
+  ];
+  const sourceCounts = {
+    "solve-corpus": puzzles.filter((puzzle) => puzzle.source === "solve-corpus").length,
+    reserve: puzzles.filter((puzzle) => puzzle.source === "reserve").length,
+  };
+
+  return {
+    version: STATIC_PUZZLE_AUDIT_VERSION,
+    benchmarkVersion: PUZZLE_GENERATOR_BENCHMARK_VERSION,
+    puzzleCount: puzzles.length,
+    puzzlePassCount: puzzleItems.filter((item) => item.passed).length,
+    renderedProfileCount: puzzleItems.reduce((sum, item) => sum + item.profilesRendered, 0),
+    expectedRenderedProfileCount: puzzles.length * PUZZLE_BOARD_RECOGNITION_PROFILES.length,
+    assetCount: assetItems.length,
+    assetPassCount: assetItems.filter((item) => item.passed).length,
+    sourceCounts,
+    puzzleItems,
+    assetItems,
+    failures: Array.from(new Set(failures)),
+    promotion: { passed: failures.length === 0, failures: Array.from(new Set(failures)) },
+  };
+}


### PR DESCRIPTION
## Summary

- add `benchmark:puzzles:static`, a no-Gateway/no-database preflight for the generator quality corpus
- render all 24 frozen solve cases and 69 catalog-grounded reserve puzzles at compact, mobile, and desktop production profiles
- recheck local schema/provenance, fallback drift, answer leakage, known techniques, and 36px/72px pictogram pixel integrity
- add a machine-readable report and regression coverage while explicitly keeping semantic recognition and human playability evidence separate

## Verification

- `pnpm.cmd --filter @rebuzzle/web benchmark:puzzles:static` — 93/93 puzzles, 279/279 profile renders, 47/47 assets
- `pnpm.cmd exec turbo test -- --runInBand` — 85 suites, 482 tests passed
- `pnpm.cmd --filter @rebuzzle/web build` — passed; existing Mongo/Dynamic API, dotenv, and browser-baseline warnings remain
- targeted Biome check — passed
- `git diff --check` — passed

This preflight does not call the AI Gateway and is intended to run before credentialed live benchmarks.