### PR TITLE
feat(ai): add deterministic semantic alignment preflight

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -36,7 +36,9 @@ The implementation owns these internal stages:
 curriculum brief
   -> concept candidates
   -> grounded visual plan
+  -> authoritative composition
   -> asset resolution
+  -> deterministic semantic alignment
   -> production-size render
   -> object recognition gate
   -> board perception gate
@@ -64,6 +66,14 @@ Long-tail concrete nouns may use a generated vector, but generation happens offl
 ### Tier 3: scene illustration
 
 Use a raster image only when the mechanism genuinely requires a scene or relationship that a single icon cannot express. Scene tiles must pass the same rendered recognition and board-solve gates. They should be exceptional, not a fallback for weak grounding.
+
+## Deterministic semantic-alignment gate
+
+After the tool-produced board becomes authoritative, the host runs `semantic-alignment-v1` before novelty, difficulty calibration, quality scoring, or any model-backed judge. This is a plausibility gate, not a solver and not recognition evidence. It rejects cheap, high-signal contradictions such as a `simple_compound` answer whose visible parts cannot concatenate into the answer, a typography technique with no styled answer token, a spatial technique flattened into an ordinary row, or a phonetic technique with no sound/letter mapping in its explanation.
+
+The check uses the same reviewed pictogram aliases and a small versioned rebus ontology for legitimate readings such as `clock → time`, `fire → hot`, and `wrench → tool`. Ordered compounds are matched by complete segmentation rather than substring coincidence, so a stray `car` inside `carpet` cannot pass as a car clue. Failures carry the rule and blocker in candidate telemetry and do not spend database, calibration, or vision-judge budget.
+
+Passing semantic alignment does not prove that a rendered car looks like a car. Every candidate must still pass the exact-size pixel, blind object-recognition, responsive board, blind-solve, editorial, novelty, and human-calibration gates below.
 
 ## Recognition gate
 
@@ -204,7 +214,7 @@ Per-puzzle gates prevent an individual bad candidate from publishing; the longit
 
 ### Operational AI cost envelope
 
-Production defaults bound the expensive portion of a daily generation to two Apex candidates, one complete agent attempt per candidate, and one generator model per attempt. Authoritative asset provenance is checked immediately after composition, before novelty, difficulty, or quality evaluation, so unapproved artwork cannot consume the rest of the candidate budget. The independent multi-model, multi-viewport recognition gates remain mandatory for every candidate that reaches them. Operators may deliberately widen the search with `EVE_APEX_CANDIDATES`, `REBUZZLE_GENERATOR_MODEL_CHAIN_LIMIT`, or an explicit `maxAttempts`, but those changes are cost decisions and must be benchmarked before production use.
+Production defaults bound the expensive portion of a daily generation to two Apex candidates, one complete agent attempt per candidate, and one generator model per attempt. Authoritative asset provenance and deterministic semantic alignment are checked immediately after composition, before novelty, difficulty, quality evaluation, or model-backed recognition, so unapproved or obviously mismatched boards cannot consume the rest of the candidate budget. The independent multi-model, multi-viewport recognition gates remain mandatory for every candidate that reaches them. Operators may deliberately widen the search with `EVE_APEX_CANDIDATES`, `REBUZZLE_GENERATOR_MODEL_CHAIN_LIMIT`, or an explicit `maxAttempts`, but those changes are cost decisions and must be benchmarked before production use.
 
 Gateway account/project budget exhaustion is terminal, not a transient quota. The client must stop model fallback immediately, the puzzle agent must stop its attempt loop, Apex must stop remaining candidate slots, and the daily workflow must skip the downstream blog call. Public workflow responses use the sanitized `AI_BUDGET_EXCEEDED` code and never expose spend or limit details.
 
@@ -214,7 +224,7 @@ Before any credentialed benchmark or live canary, run the no-spend static prefli
 pnpm --filter @rebuzzle/web benchmark:puzzles:static
 ```
 
-It renders the frozen positive solve corpus and catalog-grounded reserve inventory at every production board profile, rechecks local schema/provenance and answer-leak invariants, and reruns 36px/72px pictogram pixel-integrity checks. A passing report proves mechanical renderability only; semantic recognition, fairness, diversity, and player outcomes still require independent model and human evidence.
+It renders the frozen positive solve corpus and catalog-grounded reserve inventory at every production board profile, rechecks local schema/provenance, answer-leak, and deterministic semantic-alignment invariants, and reruns 36px/72px pictogram pixel-integrity checks. A passing report proves mechanical renderability and cheap semantic plausibility only; semantic recognition, fairness, diversity, and player outcomes still require independent model and human evidence.
 
 The current provisional SLOs are 1% player-reported unrecognizable, 2% ambiguous or unfair, 20% dislike, and 5% attempted-generation failure/fallback. A player metric needs at least 20 fast-window or 50 slow-window votes; generation health uses 5 and 14 attempts because production generation is approximately daily. A critical halt requires statistically confirmed breaches in both windows, at least three/five player events (two/three generation events), at least 4x fast burn, and at least 2x slow burn. Slow-only or lower-burn confirmed drift blocks evaluator/model promotion and triggers review, but does not replace a potentially good AI puzzle with reserve content.
 

--- a/apps/web/src/ai/puzzle-agent/__tests__/quality.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/quality.test.ts
@@ -269,11 +269,18 @@ describe("evaluatePublishGates", () => {
       mode: "composed" as const,
       layers: [
         {
-          kind: "pictogram" as const,
-          concept: "eye",
-          svg: catalogEye.svg,
-          source: "catalog" as const,
-          assetId: catalogEye.assetId,
+          kind: "text" as const,
+          content: "SUN",
+          emphasis: "normal" as const,
+        },
+        {
+          kind: "operator" as const,
+          symbol: "+",
+        },
+        {
+          kind: "text" as const,
+          content: "FLOWER",
+          emphasis: "normal" as const,
         },
       ],
       unicodeFallback: "☀️ + 🌻",

--- a/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
@@ -127,4 +127,19 @@ describe("runPuzzleAgentGeneration asset gate", () => {
     expect(scorePuzzleQuality).not.toHaveBeenCalled();
     expect(evaluatePublishGates).not.toHaveBeenCalled();
   });
+
+  it("rejects a semantically mismatched board after asset approval but before judges", async () => {
+    verifyPublicationAssets.mockResolvedValue({ ok: true });
+
+    await expect(
+      runPuzzleAgentGeneration({ targetDifficulty: 5, maxAttempts: 1, modelChainLimit: 1 })
+    ).rejects.toBeInstanceOf(PuzzleCandidateRejectedError);
+
+    expect(verifyPublicationAssets).toHaveBeenCalledTimes(1);
+    expect(checkUniqueness).not.toHaveBeenCalled();
+    expect(calibratePuzzleDifficulty).not.toHaveBeenCalled();
+    expect(stressTestSolvability).not.toHaveBeenCalled();
+    expect(scorePuzzleQuality).not.toHaveBeenCalled();
+    expect(evaluatePublishGates).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/ai/puzzle-agent/__tests__/semantic-alignment.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/semantic-alignment.test.ts
@@ -1,0 +1,117 @@
+import { evaluateSemanticAlignment } from "../semantic-alignment";
+import type { PuzzleVisual, VisualLayer } from "../visual/composition";
+import { resolveCuratedPictogram } from "../visual/curated-pictograms";
+
+function pictogram(concept: string): VisualLayer {
+  const asset = resolveCuratedPictogram(concept)!;
+  return {
+    kind: "pictogram",
+    concept,
+    emojiFallback: "◼️",
+    svg: asset.svg,
+    assetId: asset.assetId,
+    source: "catalog",
+  };
+}
+
+function text(
+  content: string,
+  emphasis: Extract<VisualLayer, { kind: "text" }>["emphasis"] = "normal"
+): VisualLayer {
+  return { kind: "text", content, emphasis };
+}
+
+function visual(layers: VisualLayer[], layout: PuzzleVisual["layout"] = "row"): PuzzleVisual {
+  return {
+    styleId: "ink-pictogram-v1",
+    mode: "composed",
+    layout,
+    layers,
+    unicodeFallback: "board",
+  };
+}
+
+describe("evaluateSemanticAlignment", () => {
+  it("requires ordered visible parts to form a simple compound", () => {
+    const passing = evaluateSemanticAlignment({
+      answer: "keyboard",
+      techniqueId: "simple_compound",
+      visual: visual([pictogram("key"), { kind: "operator", symbol: "+" }, text("BOARD")]),
+    });
+    expect(passing.ok).toBe(true);
+    expect(passing.cues.map((cue) => cue.matchedVariant)).toEqual(["key", "board"]);
+
+    const wrong = evaluateSemanticAlignment({
+      answer: "keyboard",
+      techniqueId: "simple_compound",
+      visual: visual([pictogram("car"), { kind: "operator", symbol: "+" }, text("BOARD")]),
+    });
+    expect(wrong.ok).toBe(false);
+    expect(wrong.blockers[0]).toContain("do not form the answer");
+  });
+
+  it("allows curated rebus readings such as clock → time", () => {
+    const result = evaluateSemanticAlignment({
+      answer: "bedtime",
+      techniqueId: "simple_compound",
+      visual: visual([pictogram("bed"), { kind: "operator", symbol: "+" }, pictogram("clock")]),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.cues.map((cue) => cue.matchedVariant)).toEqual(["bed", "time"]);
+  });
+
+  it("requires phonetic techniques to explain the sound or letter mapping", () => {
+    const passing = evaluateSemanticAlignment({
+      answer: "before",
+      techniqueId: "single_homophone",
+      explanation: "The letter B plus four, said aloud, sounds like before.",
+      visual: visual([text("B"), { kind: "operator", symbol: "+" }, text("4")]),
+    });
+    expect(passing.ok).toBe(true);
+
+    const missingMapping = evaluateSemanticAlignment({
+      answer: "before",
+      techniqueId: "single_homophone",
+      explanation: "The two visible parts make the answer.",
+      visual: visual([text("B"), { kind: "operator", symbol: "+" }, text("4")]),
+    });
+    expect(missingMapping.ok).toBe(false);
+    expect(missingMapping.blockers[0]).toContain("sound/letter mapping");
+  });
+
+  it("requires a real spatial layout and relationship explanation", () => {
+    const passing = evaluateSemanticAlignment({
+      answer: "mind over matter",
+      techniqueId: "positional_phrase",
+      explanation: "MIND is placed over MATTER, which reads as the familiar phrase.",
+      visual: visual([text("MIND"), text("MATTER")], "stack"),
+    });
+    expect(passing.ok).toBe(true);
+
+    const flattened = evaluateSemanticAlignment({
+      answer: "mind over matter",
+      techniqueId: "positional_phrase",
+      explanation: "MIND is next to MATTER and gives the phrase.",
+      visual: visual([text("MIND"), text("MATTER")], "row"),
+    });
+    expect(flattened.ok).toBe(false);
+    expect(flattened.blockers[0]).toContain("non-row layout");
+  });
+
+  it("requires typography techniques to visibly style an answer token", () => {
+    const passing = evaluateSemanticAlignment({
+      answer: "big deal",
+      techniqueId: "size_or_case_semantics",
+      visual: visual([text("DEAL", "large")]),
+    });
+    expect(passing.ok).toBe(true);
+
+    const plain = evaluateSemanticAlignment({
+      answer: "big deal",
+      techniqueId: "size_or_case_semantics",
+      visual: visual([text("DEAL")]),
+    });
+    expect(plain.ok).toBe(false);
+    expect(plain.blockers[0]).toContain("styled text layer");
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/benchmark/static-audit.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/static-audit.ts
@@ -4,6 +4,7 @@ import {
   type ReservePuzzle,
   validateReservePuzzleCorpus,
 } from "../reserve-puzzles";
+import { evaluateSemanticAlignment } from "../semantic-alignment";
 import { type PuzzleVisual, PuzzleVisualSchema } from "../visual/composition";
 import { evaluatePictogramPixelIntegrity } from "../visual/pictogram-pixel-integrity";
 import { PUZZLE_BOARD_RECOGNITION_PROFILES } from "../visual/presentation";
@@ -11,13 +12,14 @@ import { renderPuzzleVisualProfiles } from "../visual/render-board";
 import { buildPuzzleSolveBenchmarkCorpus } from "./puzzle-corpus";
 import { PUZZLE_GENERATOR_BENCHMARK_VERSION } from "./types";
 
-export const STATIC_PUZZLE_AUDIT_VERSION = "static-puzzle-audit-v1";
+export const STATIC_PUZZLE_AUDIT_VERSION = "static-puzzle-audit-v2";
 
 export type StaticAuditPuzzle = {
   id: string;
   answer: string;
   rebusPuzzle: string;
   techniqueId: string;
+  explanation?: string;
   visual: PuzzleVisual;
   source: "solve-corpus" | "reserve";
 };
@@ -71,6 +73,7 @@ function defaultCorpus(): StaticAuditPuzzle[] {
     answer: entry.answer,
     rebusPuzzle: entry.rebusPuzzle,
     techniqueId: entry.techniqueId,
+    explanation: entry.explanation,
     visual: entry.visual,
     source: "reserve" as const,
   }));
@@ -107,6 +110,19 @@ async function auditPuzzle(puzzle: StaticAuditPuzzle): Promise<StaticPuzzleAudit
   }
   if (!isKnownTechniqueId(puzzle.techniqueId)) {
     failures.push(`Unknown technique: ${puzzle.techniqueId}`);
+  }
+
+  const semanticAlignment = evaluateSemanticAlignment({
+    answer: puzzle.answer,
+    techniqueId: puzzle.techniqueId,
+    explanation: puzzle.explanation,
+    visual: puzzle.visual,
+    requireExplanation: false,
+  });
+  if (!semanticAlignment.ok) {
+    failures.push(
+      `Semantic alignment failed (${semanticAlignment.rule}): ${semanticAlignment.blockers.join("; ")}`
+    );
   }
 
   let profilesRendered = 0;

--- a/apps/web/src/ai/puzzle-agent/quality.ts
+++ b/apps/web/src/ai/puzzle-agent/quality.ts
@@ -8,7 +8,9 @@ import {
   getDifficultyLevelForScore,
   isDifficultyInBand,
 } from "./difficulty-levels";
+import { evaluateSemanticAlignment } from "./semantic-alignment";
 import { TECHNIQUE_LIBRARY, type TechniqueId } from "./technique-library";
+import type { PuzzleVisual } from "./visual/composition";
 import { isAuthenticCuratedPictogram } from "./visual/curated-pictograms";
 import { scorePictogramClarity } from "./visual/pictogram-clarity";
 
@@ -377,6 +379,19 @@ export function evaluatePublishGates(input: PublishGateInput): PublishGateResult
   const visualCheck = evaluateVisualForPublish(input.visual);
   if (!visualCheck.ok) {
     return { ok: false, reason: visualCheck.reason ?? "Visual failed publish check" };
+  }
+
+  const semanticAlignment = evaluateSemanticAlignment({
+    answer,
+    techniqueId: input.techniqueId,
+    explanation: input.explanation,
+    visual: input.visual as unknown as PuzzleVisual,
+  });
+  if (!semanticAlignment.ok) {
+    return {
+      ok: false,
+      reason: `Semantic alignment failed (${semanticAlignment.rule}): ${semanticAlignment.blockers.join("; ")}`,
+    };
   }
 
   if (input.qualityOverall < input.qualityThreshold) {

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -34,6 +34,7 @@ import {
   PuzzleAgentDraftSchema,
   type PuzzleAgentResult,
 } from "./schemas";
+import { evaluateSemanticAlignment } from "./semantic-alignment";
 import {
   calibratePuzzleDifficulty,
   checkUniqueness,
@@ -327,6 +328,32 @@ export async function runPuzzleAgentGeneration(
               attempt,
               stage: "asset-approval",
               reason: priorFailure,
+            });
+          }
+          continue;
+        }
+
+        // Semantic alignment is deterministic and intentionally runs before
+        // novelty, calibration, and all model-backed recognition. It catches
+        // a board whose visible parts cannot plausibly produce its answer.
+        const semanticAlignment = evaluateSemanticAlignment({
+          answer: puzzle.answer,
+          techniqueId: puzzle.techniqueId,
+          explanation: puzzle.explanation,
+          visual: puzzle.visual,
+        });
+        if (!semanticAlignment.ok) {
+          priorFailure = `Semantic alignment failed (${semanticAlignment.rule}): ${semanticAlignment.blockers.join("; ")}`;
+          lastCandidateError = new PuzzleCandidateRejectedError(priorFailure, puzzle);
+          lastError = lastCandidateError;
+          if (process.env.REBUZZLE_GENERATOR_TRACE === "1") {
+            console.warn("[Puzzle Agent] candidate rejected", {
+              modelId,
+              attempt,
+              stage: "semantic-alignment",
+              reason: priorFailure,
+              score: semanticAlignment.score,
+              warnings: semanticAlignment.warnings,
             });
           }
           continue;

--- a/apps/web/src/ai/puzzle-agent/semantic-alignment.ts
+++ b/apps/web/src/ai/puzzle-agent/semantic-alignment.ts
@@ -1,0 +1,388 @@
+import type { PuzzleVisual, VisualLayer } from "./visual/composition";
+import { getCuratedPictogramAliases } from "./visual/curated-pictograms";
+import { lookupIconFeatures } from "./visual/icon-features";
+
+/**
+ * Cheap, deterministic semantic checks for a composed board.
+ *
+ * These checks do not try to solve a rebus. They catch a more basic failure:
+ * the declared mechanism and the player-visible cues cannot plausibly produce
+ * the declared answer. Keeping this gate deterministic means a bad board is
+ * rejected before novelty, calibration, or model judges spend budget on it.
+ */
+export const SEMANTIC_ALIGNMENT_VERSION = "semantic-alignment-v1";
+
+export type SemanticAlignmentInput = {
+  answer: string;
+  techniqueId?: string;
+  explanation?: string;
+  visual?: PuzzleVisual;
+  /** Static corpus fixtures may omit explanations; generation may not. */
+  requireExplanation?: boolean;
+};
+
+export type SemanticCueEvidence = {
+  kind: "pictogram" | "image" | "text";
+  label: string;
+  variants: string[];
+  matchedVariant?: string;
+};
+
+export type SemanticAlignmentResult = {
+  version: typeof SEMANTIC_ALIGNMENT_VERSION;
+  ok: boolean;
+  score: number;
+  rule: string;
+  blockers: string[];
+  warnings: string[];
+  cues: SemanticCueEvidence[];
+};
+
+/** Rebus readings that are useful for composition but are not icon identities. */
+const REBUS_CUE_ALIASES: Record<string, string[]> = {
+  anchor: ["hold"],
+  baby: ["child"],
+  boat: ["ship"],
+  camera: ["shot"],
+  clock: ["time"],
+  diamond: ["gem"],
+  envelope: ["letter", "mail"],
+  fire: ["hot"],
+  footprints: ["feet", "walk"],
+  heart: ["love"],
+  lightbulb: ["light"],
+  lightning: ["flash"],
+  music: ["song"],
+  puzzle: ["piece"],
+  rain: ["shower"],
+  skull: ["dead", "death"],
+  snowflake: ["cold", "snow"],
+  sun: ["day"],
+  trash: ["junk"],
+  tree: ["forest"],
+  watch: ["time"],
+  wheat: ["grain"],
+  wrench: ["tool"],
+};
+
+const NUMBER_WORDS: Record<string, string> = {
+  "0": "zero",
+  "1": "one",
+  "2": "two",
+  "3": "three",
+  "4": "four",
+  "5": "five",
+  "6": "six",
+  "7": "seven",
+  "8": "eight",
+  "9": "nine",
+};
+
+const LITERAL_COMPOUND_TECHNIQUE = "simple_compound";
+const POSITIONAL_TECHNIQUES = new Set([
+  "basic_positional",
+  "positional_phrase",
+  "spatial_preposition_play",
+]);
+const PHONETIC_TECHNIQUES = new Set([
+  "single_homophone",
+  "nested_homophone",
+  "multi_layer_phonetic",
+]);
+
+function normalize(value: string): string {
+  return value
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function compact(value: string): string {
+  return normalize(value).replace(/\s+/g, "");
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.map(normalize).filter(Boolean))];
+}
+
+function containsTokenSequence(haystack: string, needle: string): boolean {
+  const haystackTokens = normalize(haystack).split(/\s+/).filter(Boolean);
+  const needleTokens = normalize(needle).split(/\s+/).filter(Boolean);
+  if (!haystackTokens.length || !needleTokens.length) return false;
+  if (needleTokens.length > haystackTokens.length) return false;
+  return Array.from({ length: haystackTokens.length - needleTokens.length + 1 }).some((_, start) =>
+    needleTokens.every((token, index) => haystackTokens[start + index] === token)
+  );
+}
+
+function answerContainsVariant(answer: string, variant: string): boolean {
+  const answerKey = compact(answer);
+  const variantKey = compact(variant);
+  if (!answerKey || !variantKey) return false;
+  if (answerKey === variantKey || answerKey.includes(variantKey)) return true;
+  return containsTokenSequence(answer, variant);
+}
+
+function cueBaseVariants(layer: VisualLayer): string[] {
+  if (layer.kind === "text") {
+    const numberWord = NUMBER_WORDS[layer.content.trim()];
+    return [layer.content, ...(numberWord ? [numberWord] : [])];
+  }
+
+  if (layer.kind === "image") return layer.concept ? [layer.concept] : [];
+
+  if (layer.kind !== "pictogram") return [];
+
+  const concept = layer.concept.trim();
+  const canonical = compact(concept);
+  const featureEntry = lookupIconFeatures(concept);
+  return [
+    concept,
+    ...getCuratedPictogramAliases(concept),
+    ...(featureEntry?.aliases ?? []),
+    ...(REBUS_CUE_ALIASES[canonical] ?? []),
+  ];
+}
+
+function cueEvidence(layer: VisualLayer): SemanticCueEvidence | null {
+  if (layer.kind === "operator") return null;
+  const label = layer.kind === "text" ? layer.content : (layer.concept ?? "");
+  const variants = unique(cueBaseVariants(layer));
+  if (!label.trim() || !variants.length) return null;
+  return { kind: layer.kind, label: label.trim(), variants };
+}
+
+function collectCues(visual: PuzzleVisual | undefined): SemanticCueEvidence[] {
+  return (visual?.layers ?? [])
+    .map(cueEvidence)
+    .filter((cue): cue is SemanticCueEvidence => Boolean(cue));
+}
+
+/**
+ * Match ordered visual cues against the compact answer for literal compounds.
+ * A cue may use a curated synonym (e.g. clock → time) but cannot skip answer
+ * characters; this prevents a single coincidental substring from passing.
+ */
+function matchOrderedCompound(answer: string, cues: SemanticCueEvidence[]): string[] | null {
+  const answerKey = compact(answer);
+  if (!answerKey || !cues.length) return null;
+
+  const memo = new Map<string, string[] | null>();
+  function visit(cueIndex: number, offset: number): string[] | null {
+    const key = `${cueIndex}:${offset}`;
+    if (memo.has(key)) return memo.get(key)!;
+    if (cueIndex === cues.length) {
+      const result = offset === answerKey.length ? [] : null;
+      memo.set(key, result);
+      return result;
+    }
+
+    const cue = cues[cueIndex]!;
+    const sortedVariants = [...cue.variants].sort((left, right) => right.length - left.length);
+    for (const variant of sortedVariants) {
+      const variantKey = compact(variant);
+      if (variantKey.length < 2 || !answerKey.startsWith(variantKey, offset)) continue;
+      const remainder = visit(cueIndex + 1, offset + variantKey.length);
+      if (remainder) {
+        const result = [variant, ...remainder];
+        memo.set(key, result);
+        return result;
+      }
+    }
+
+    memo.set(key, null);
+    return null;
+  }
+
+  return visit(0, 0);
+}
+
+function hasMechanismLanguage(explanation: string | undefined, pattern: RegExp): boolean {
+  return Boolean(explanation && pattern.test(explanation));
+}
+
+function hasCueMention(explanation: string | undefined, cues: SemanticCueEvidence[]): boolean {
+  if (!explanation) return false;
+  return cues.some((cue) =>
+    cue.variants.some((variant) => answerContainsVariant(explanation, variant))
+  );
+}
+
+function isSpatialLayout(visual: PuzzleVisual | undefined): boolean {
+  if (!visual) return false;
+  if (visual.layout !== "row") return true;
+  return visual.layers.some(
+    (layer) => layer.kind === "operator" && /[↑↓←→↔↕/\\]/.test(layer.symbol)
+  );
+}
+
+function hasOrderedSpatialLanguage(explanation: string | undefined): boolean {
+  return Boolean(
+    explanation &&
+      /\b(after|before|left of|right of|first|last|next to|beside)\b/i.test(explanation)
+  );
+}
+
+function evaluateLiteralCompound(
+  answer: string,
+  cues: SemanticCueEvidence[],
+  blockers: string[]
+): string[] {
+  if (cues.length < 2) {
+    blockers.push("Simple compound needs at least two visible semantic parts");
+    return [];
+  }
+  const matched = matchOrderedCompound(answer, cues);
+  if (!matched) {
+    blockers.push(
+      `Visible parts do not form the answer in order: ${cues.map((cue) => cue.label).join(" + ")} → ${answer}`
+    );
+  }
+  return matched ?? [];
+}
+
+/**
+ * Evaluate semantic alignment before any expensive model-backed judge.
+ * `ok` means the board passes deterministic plausibility checks; it is not a
+ * substitute for blind recognition or human playtesting.
+ */
+export function evaluateSemanticAlignment(input: SemanticAlignmentInput): SemanticAlignmentResult {
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  const cues = collectCues(input.visual);
+  const technique = input.techniqueId ?? "unknown";
+  const explanationRequired = input.requireExplanation !== false;
+  let rule = "generic";
+  let matchedVariants: string[] = [];
+
+  if (!input.answer.trim()) blockers.push("Semantic alignment requires a non-empty answer");
+  if (!cues.length) blockers.push("Board has no visible semantic cues");
+
+  for (const cue of cues) {
+    if (!cue.variants.length) blockers.push(`Cue has no readable label: ${cue.label}`);
+  }
+
+  if (technique === LITERAL_COMPOUND_TECHNIQUE) {
+    rule = "ordered-literal-compound";
+    matchedVariants = evaluateLiteralCompound(input.answer, cues, blockers);
+  } else if (technique === "size_or_case_semantics") {
+    rule = "typographic-semantic-cue";
+    const styled = (input.visual?.layers ?? []).filter(
+      (layer): layer is Extract<VisualLayer, { kind: "text" }> =>
+        layer.kind === "text" && layer.emphasis !== "normal"
+    );
+    const spacingCue = Boolean(
+      input.visual?.unicodeFallback && /\s{3,}/.test(input.visual.unicodeFallback)
+    );
+    if (!styled.length && !spacingCue) {
+      blockers.push("Size/case technique needs a visibly styled text layer or spacing cue");
+    }
+    if (
+      styled.length &&
+      !styled.some((layer) => answerContainsVariant(input.answer, layer.content))
+    ) {
+      blockers.push("Styled text does not contribute a visible token from the answer");
+    }
+  } else if (POSITIONAL_TECHNIQUES.has(technique)) {
+    rule = "spatial-layout-and-explanation";
+    if (
+      !isSpatialLayout(input.visual) &&
+      !(technique === "spatial_preposition_play" && hasOrderedSpatialLanguage(input.explanation))
+    ) {
+      blockers.push(`${technique} requires a non-row layout or explicit spatial operator`);
+    }
+    if (cues.length < 2) blockers.push(`${technique} needs at least two positioned semantic cues`);
+    if (
+      !hasMechanismLanguage(
+        input.explanation,
+        /\b(above|below|under|over|between|after|before|around|inside|across|cross|intersect|overlap|position|placement|stack|line|road)\b/i
+      )
+    ) {
+      const message = "Explanation does not name the spatial relationship";
+      if (explanationRequired) blockers.push(message);
+      else warnings.push(message);
+    }
+  } else if (technique === "math_symbol_wordplay") {
+    rule = "operator-wordplay";
+    const hasOperator = (input.visual?.layers ?? []).some(
+      (layer) => layer.kind === "operator" && /[+\-×÷/=✓✔]/.test(layer.symbol)
+    );
+    if (!hasOperator) blockers.push("Math wordplay needs a visible operator or check symbol");
+  } else if (PHONETIC_TECHNIQUES.has(technique)) {
+    rule = "phonetic-explanation";
+    const literalMatch = matchOrderedCompound(input.answer, cues);
+    if (literalMatch) {
+      matchedVariants = literalMatch;
+      warnings.push("Phonetic technique currently reads as a literal compound");
+    } else if (
+      !hasMechanismLanguage(
+        input.explanation,
+        /\b(sound(?:s)? like|sound-alike|homophone|phonetic|pronounc|say it aloud|read(?:s)? as|letter|number|repeat|copies|times)\b/i
+      )
+    ) {
+      const message =
+        "Phonetic technique lacks an explicit sound/letter mapping in the explanation";
+      if (explanationRequired) blockers.push(message);
+      else warnings.push(message);
+    } else if (!hasCueMention(input.explanation, cues)) {
+      blockers.push("Phonetic explanation does not mention any visible cue");
+    }
+  } else if (technique === "obvious_emoji_sum" || technique === "multi_emoji_compound") {
+    rule = "ordered-cue-composition";
+    if (cues.length < 2) blockers.push(`${technique} needs at least two visible semantic cues`);
+    if (
+      !hasMechanismLanguage(input.explanation, /\b(combine|join|add|plus|sum|part|form|read)\b/i)
+    ) {
+      warnings.push("Explanation does not explicitly describe how the cues combine");
+    }
+  } else if (technique === "idiom_as_picture" || technique === "rare_but_fair_idiom") {
+    rule = "idiom-mapping";
+    if (
+      !hasMechanismLanguage(
+        input.explanation,
+        /\b(idiom|phrase|means|literal|picture|stands for|maps|represents|gives|forms|makes|plus|combine|join)\b/i
+      )
+    ) {
+      const message = "Idiom technique lacks a clear literal-to-phrase explanation";
+      if (explanationRequired) blockers.push(message);
+      else warnings.push(message);
+    }
+  } else if (technique === "false_lead_visual" || technique === "triple_layer_composition") {
+    rule = "multi-layer-composition";
+    if (cues.length < 2) blockers.push(`${technique} needs multiple visible semantic cues`);
+    if (!input.explanation || input.explanation.trim().length < 40) {
+      const message = `${technique} needs a complete explanation for every visual layer`;
+      if (explanationRequired) blockers.push(message);
+      else warnings.push(message);
+    }
+  }
+
+  if (cues.length >= 2 && !matchedVariants.length) {
+    const answerMentioned = cues.filter((cue) =>
+      cue.variants.some((variant) => answerContainsVariant(input.answer, variant))
+    ).length;
+    if (answerMentioned === 0 && !PHONETIC_TECHNIQUES.has(technique)) {
+      warnings.push(
+        "No visible cue label appears verbatim in the answer; rely on explicit explanation"
+      );
+    }
+  }
+
+  const score = blockers.length
+    ? Math.max(0, 40 - blockers.length * 15)
+    : Math.max(0, 100 - warnings.length * 8);
+
+  return {
+    version: SEMANTIC_ALIGNMENT_VERSION,
+    ok: blockers.length === 0,
+    score,
+    rule,
+    blockers,
+    warnings,
+    cues: cues.map((cue, index) => ({
+      ...cue,
+      matchedVariant: matchedVariants[index],
+    })),
+  };
+}

--- a/apps/web/src/ai/puzzle-agent/tool-impl.ts
+++ b/apps/web/src/ai/puzzle-agent/tool-impl.ts
@@ -31,7 +31,9 @@ import {
   normalizeAnswerKey,
 } from "./quality";
 import type { CandidatePuzzle } from "./schemas";
+import { evaluateSemanticAlignment } from "./semantic-alignment";
 import { getTechniques, listAllTechniques, type TechniqueId } from "./technique-library";
+import type { PuzzleVisual } from "./visual/composition";
 
 function resolvePrompt(
   value: string | ((params: Record<string, unknown>) => string) | undefined,
@@ -733,6 +735,20 @@ export function scorePuzzleQuality(
         ? `Generative Ink Pictograms (${visualCheck.pictogramSvgCount})`
         : "Styled generative text layers"
     );
+
+    const semanticAlignment = evaluateSemanticAlignment({
+      answer,
+      techniqueId: input.techniqueId,
+      explanation: input.explanation,
+      visual: input.visual as unknown as PuzzleVisual,
+    });
+    if (!semanticAlignment.ok) {
+      issues.push(
+        `Semantic alignment failed (${semanticAlignment.rule}): ${semanticAlignment.blockers.join("; ")}`
+      );
+    } else {
+      strengths.push(`Semantic alignment ${semanticAlignment.score}/100`);
+    }
   }
 
   const styledText = Boolean(


### PR DESCRIPTION
## What changed

Adds a deterministic semantic-alignment gate to the puzzle generation pipeline and all publish-quality paths.

- Validates visible cues against the declared answer and technique before novelty, calibration, or model-backed judges spend budget.
- Rejects malformed literal compounds, flattened positional rebuses, missing phonetic mappings, invalid typography cues, and under-specified multi-layer boards.
- Reuses curated pictogram aliases, icon features, number words, and rebus readings such as clock -> time.
- Adds quality/tool telemetry and static-corpus auditing.
- Adds regression coverage and documents the gate and its limits.

## Why

A board can pass asset and structural checks while still being semantically unrecognizable to a player. This catches that failure earlier and reduces wasted AI spend without pretending deterministic rules replace blind recognition or human playtesting.

## Validation

- Full workspace Jest/Turbo suite: 86 suites, 488 tests passed.
- Production web build: passed; 132 pages generated.
- Web-package Biome check for all touched TypeScript files: passed.
- Static no-spend preflight: promotion=true, puzzles=93/93, profiles=279/279, assets=47/47.
- Targeted semantic/quality/asset-gate tests: 5 suites, 32 tests passed.

The remaining deployment evidence depends on the external Vercel plan/deployment quota; local build and tests are green.