### PR TITLE
fix(ai): tighten blind solve publication evidence

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -119,6 +119,8 @@ The solver should receive only a screenshot first. Run independent attempts that
 
 Only after that first pass should hints be introduced one at a time. Do not reveal declared pictogram concepts, answer, explanation, or technique ID to the solver. A candidate fails when judges can “solve” only after seeing generator metadata.
 
+Blind solve credit uses exact normalized phrase matching rather than the game's typo-tolerant answer matcher. Case, Unicode normalization, punctuation, and whitespace variants are harmless; a different word, plural, article, synonym, or near-spelling remains a wrong parse. The tournament also fails closed unless the exact compact, mobile, and desktop production profiles are all represented.
+
 VLM solve rate is a screening signal, not ground truth. Published research shows that current models still struggle sharply on difficult rebuses, so final difficulty and fairness must be calibrated against player telemetry and periodic human panels.
 
 ## Human benchmark and metrics

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/blind-solve-consensus.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/blind-solve-consensus.test.ts
@@ -1,6 +1,31 @@
-import { summarizeBlindSolveAttempts } from "../blind-solve-consensus";
+import { blindAnswerMatch, summarizeBlindSolveAttempts } from "../blind-solve-consensus";
 
 describe("blind screenshot solve consensus", () => {
+  it("uses exact normalized phrases instead of typo-tolerant solve credit", () => {
+    expect(blindAnswerMatch("car-key", "car key")).toBe(true);
+    expect(blindAnswerMatch("cars", "car")).toBe(false);
+    expect(blindAnswerMatch("the car", "car")).toBe(false);
+  });
+
+  it("does not count a near-match as a successful visual solve", () => {
+    const summary = summarizeBlindSolveAttempts({
+      answer: "car",
+      attempts: [
+        {
+          model: "vision-a",
+          profileId: "compact-320",
+          visibleElements: ["car"],
+          relationships: ["single object"],
+          hypotheses: [{ answer: "cars", confidence: 0.9, rationale: "looks like a car" }],
+          confidence: 0.9,
+        },
+      ],
+    });
+
+    expect(summary.targetFoundBy).toBe(0);
+    expect(summary.wrongParses).toEqual(["cars"]);
+  });
+
   it("derives solve rate only from answer hypotheses", () => {
     const summary = summarizeBlindSolveAttempts({
       answer: "car key",

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/player-sim-gate.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/player-sim-gate.test.ts
@@ -97,4 +97,16 @@ describe("blind solve publication gate", () => {
     });
     expect(blockers.join(" ")).toContain("missing per-profile consensus evidence");
   });
+
+  it("fails closed when the profile count is correct but an expected profile is absent", () => {
+    const blockers = blindSolvePublishBlockers({
+      ...passingSim(),
+      blindProfileResults: passingSim().blindProfileResults!.map((profile, index) =>
+        index === 0 ? { ...profile, profileId: "unknown-profile" } : profile
+      ),
+    });
+
+    expect(blockers.join(" ")).toContain("missing: compact-320");
+    expect(blockers.join(" ")).toContain("unexpected: unknown-profile");
+  });
 });

--- a/apps/web/src/ai/puzzle-agent/apex/blind-solve-consensus.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/blind-solve-consensus.ts
@@ -1,9 +1,9 @@
-import { fuzzyMatch } from "@rebuzzle/game-logic/fuzzy-match";
 import {
   BLIND_SOLVE_DOMINANCE_MARGIN,
   BLIND_SOLVE_REQUIRED_VOTES,
   distinctJudgeResults,
 } from "../quality-contract";
+import { PUZZLE_BOARD_RECOGNITION_PROFILES } from "../visual/presentation";
 import type { PlayerSimResult } from "./types";
 
 export type BlindSolveHypothesis = {
@@ -53,6 +53,25 @@ export type BlindSolveProfileResult = {
   strongestWrongConfidence: number;
 };
 
+/**
+ * Blind recognition evidence is intentionally stricter than player answer
+ * validation. A typo-tolerant match can make a visually wrong answer look
+ * like a successful solve and hide an ambiguous board from publication.
+ * Punctuation and whitespace variants are harmless; different words are not.
+ */
+export function blindAnswerMatch(input: string, target: string): boolean {
+  const normalize = (value: string) =>
+    value
+      .normalize("NFKC")
+      .toLocaleLowerCase("en-US")
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .trim()
+      .replace(/\s+/g, " ");
+  const normalizedInput = normalize(input);
+  const normalizedTarget = normalize(target);
+  return Boolean(normalizedInput && normalizedInput === normalizedTarget);
+}
+
 type RankedAttempt = {
   attempt: BlindSolveAttempt;
   ranked: BlindSolveHypothesis[];
@@ -70,22 +89,35 @@ type RankedAttempt = {
  */
 export function blindSolvePublishBlockers(
   sim: PlayerSimResult,
-  expectedProfileCount = 3,
+  expectedProfileIds: readonly string[] = PUZZLE_BOARD_RECOGNITION_PROFILES.map(
+    (profile) => profile.id
+  ),
   requiredVotes = BLIND_SOLVE_REQUIRED_VOTES
 ): string[] {
   const blockers: string[] = [];
+  const expectedProfileCount = expectedProfileIds.length;
   if (sim.confidence < 0.45) {
     blockers.push("Blind screenshot solve simulation was unavailable or low-confidence");
   }
   const profileResults = sim.blindProfileResults ?? [];
-  const uniqueProfileCount = new Set(profileResults.map((profile) => profile.profileId)).size;
+  const observedProfileIds = new Set(profileResults.map((profile) => profile.profileId));
+  const missingProfileIds = expectedProfileIds.filter((id) => !observedProfileIds.has(id));
+  const unexpectedProfileIds = Array.from(observedProfileIds).filter(
+    (id) => !expectedProfileIds.includes(id)
+  );
   if (
     profileResults.length !== expectedProfileCount ||
-    uniqueProfileCount !== expectedProfileCount ||
-    (sim.blindProfileCount ?? 0) !== expectedProfileCount
+    observedProfileIds.size !== expectedProfileCount ||
+    (sim.blindProfileCount ?? 0) !== expectedProfileCount ||
+    missingProfileIds.length > 0 ||
+    unexpectedProfileIds.length > 0
   ) {
+    const coverageDetails = [
+      missingProfileIds.length > 0 ? `; missing: ${missingProfileIds.join(", ")}` : "",
+      unexpectedProfileIds.length > 0 ? `; unexpected: ${unexpectedProfileIds.join(", ")}` : "",
+    ].join("");
     blockers.push(
-      "Blind solve tournament did not cover each production board profile exactly once"
+      `Blind solve tournament did not cover the exact production board profiles${coverageDetails}`
     );
   }
   if (profileResults.length === 0) {
@@ -191,11 +223,11 @@ export function toPlayabilityEvidence(sim: PlayerSimResult): {
 
 function rankAttempt(answer: string, attempt: BlindSolveAttempt): RankedAttempt {
   const ranked = [...attempt.hypotheses].sort((a, b) => b.confidence - a.confidence);
-  const targetIndex = ranked.findIndex((hypothesis) => fuzzyMatch(hypothesis.answer, answer, 82));
+  const targetIndex = ranked.findIndex((hypothesis) => blindAnswerMatch(hypothesis.answer, answer));
   const target = targetIndex >= 0 ? ranked[targetIndex] : undefined;
   const strongestWrongConfidence = ranked.reduce(
     (strongest, hypothesis) =>
-      fuzzyMatch(hypothesis.answer, answer, 82)
+      blindAnswerMatch(hypothesis.answer, answer)
         ? strongest
         : Math.max(strongest, hypothesis.confidence),
     0
@@ -244,7 +276,7 @@ export function summarizeBlindSolveAttempts(input: {
     new Map(
       rankedAttempts
         .flatMap((result) => result.ranked)
-        .filter((hypothesis) => !fuzzyMatch(hypothesis.answer, input.answer, 82))
+        .filter((hypothesis) => !blindAnswerMatch(hypothesis.answer, input.answer))
         .sort((a, b) => b.confidence - a.confidence)
         .map((hypothesis) => [hypothesis.answer.toLowerCase(), hypothesis.answer])
     ).values()


### PR DESCRIPTION
## What changed\n\n- require exact normalized blind-solve phrase matching so near misses and synonyms cannot receive solve credit\n- require the exact production responsive profile IDs in the blind publication gate\n- add regression coverage and document the stricter evidence contract\n\n## Validation\n\n- pnpm.cmd exec turbo test -- --runInBand\n- pnpm.cmd --filter @rebuzzle/web exec tsc --noEmit\n- pnpm.cmd --filter @rebuzzle/web exec biome check ...\n- pnpm.cmd --filter @rebuzzle/web build\n- pnpm.cmd --filter @rebuzzle/web benchmark:puzzles:static\n\nAll local checks passed. No live Gateway generation was run.