### PR TITLE
feat(ai): ground Apex generation answer-first

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -10,6 +10,8 @@ The Apex/Eve pipeline began with strong conceptual machinery—multiple candidat
 
 That original blind spot is now guarded by deterministic player-pixel checks, blind multi-model icon naming, responsive board perception, screenshot-only solving, answer-aware rejection, and human calibration workflows. The remaining market-readiness gap is empirical: the implemented gates still need sufficient qualified-player evidence and credentialed frozen-benchmark results. A green automated pipeline remains screening evidence, not proof that every intended “car” looks like a car to players.
 
+The Apex invent path now adds an answer-first contract before model composition. Each tournament slot selects a fresh, non-overused phrase-bank answer compatible with its technique focus, asks the model to backform one catalog-grounded visual mechanism, and rejects any returned answer that drifts from the selected seed before asset, novelty, or model-judge work begins. This turns the highest-risk failure mode—an attractive explanation for the wrong board—into a cheap deterministic retry while preserving technique and answer diversity across slots. If no fresh seed is available, the pipeline remains explicit about falling back to the existing free-invention path rather than fabricating evidence.
+
 ## Non-negotiable publish contract
 
 A candidate may publish only when all of these are true:
@@ -34,6 +36,7 @@ The implementation owns these internal stages:
 
 ```text
 curriculum brief
+  -> fresh answer-first seed per tournament slot
   -> concept candidates
   -> grounded visual plan
   -> authoritative composition

--- a/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
@@ -46,6 +46,7 @@ jest.mock("../difficulty-levels", () => ({
 }));
 jest.mock("../quality", () => ({
   evaluatePublishGates,
+  normalizeAnswerKey: (answer: string) => answer.toLowerCase().replace(/[^a-z0-9]/g, ""),
 }));
 jest.mock("../schemas", () => ({
   normalizePuzzleAgentDraft: jest.fn((output) => output),
@@ -140,6 +141,21 @@ describe("runPuzzleAgentGeneration asset gate", () => {
     expect(calibratePuzzleDifficulty).not.toHaveBeenCalled();
     expect(stressTestSolvability).not.toHaveBeenCalled();
     expect(scorePuzzleQuality).not.toHaveBeenCalled();
+    expect(evaluatePublishGates).not.toHaveBeenCalled();
+  });
+
+  it("rejects an answer that violates the Apex answer-first contract before asset checks", async () => {
+    await expect(
+      runPuzzleAgentGeneration({
+        targetDifficulty: 5,
+        maxAttempts: 1,
+        modelChainLimit: 1,
+        answerSeed: "car",
+      })
+    ).rejects.toBeInstanceOf(PuzzleCandidateRejectedError);
+
+    expect(verifyPublicationAssets).not.toHaveBeenCalled();
+    expect(checkUniqueness).not.toHaveBeenCalled();
     expect(evaluatePublishGates).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/answer-first.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/answer-first.test.ts
@@ -1,0 +1,67 @@
+import { answerFirstSeedKey, selectAnswerFirstSeed } from "../answer-first";
+import type { PhraseBankEntry } from "../types";
+
+const entries: PhraseBankEntry[] = [
+  {
+    answer: "sunflower",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound"],
+    overused: true,
+  },
+  {
+    answer: "moonlight",
+    category: "compound",
+    difficultyHint: 5,
+    techniqueAffinity: ["simple_compound"],
+  },
+  {
+    answer: "under the weather",
+    category: "positional",
+    difficultyHint: 6,
+    techniqueAffinity: ["spatial_preposition_play"],
+  },
+];
+
+describe("answer-first seed selection", () => {
+  it("prefers a fresh seed compatible with the slot technique", () => {
+    expect(
+      selectAnswerFirstSeed({
+        entries,
+        techniqueId: "spatial_preposition_play",
+      })?.answer
+    ).toBe("under the weather");
+  });
+
+  it("skips overused and already-consumed answers", () => {
+    expect(
+      selectAnswerFirstSeed({
+        entries,
+        techniqueId: "simple_compound",
+        usedAnswerKeys: ["moonlight"],
+      })?.answer
+    ).toBe("under the weather");
+  });
+
+  it("falls back to a fresh answer when no technique-specific seed exists", () => {
+    expect(
+      selectAnswerFirstSeed({
+        entries,
+        techniqueId: "idiom_as_picture",
+      })?.answer
+    ).toBe("moonlight");
+  });
+
+  it("returns no seed when the inventory is exhausted", () => {
+    expect(
+      selectAnswerFirstSeed({
+        entries,
+        usedAnswerKeys: ["moonlight", "under-the-weather"],
+      })
+    ).toBeUndefined();
+  });
+
+  it("normalizes the answer for collision tracking", () => {
+    expect(answerFirstSeedKey(entries[2])).toBe("undertheweather");
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/answer-first.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/answer-first.ts
@@ -1,0 +1,39 @@
+import { normalizeAnswerKey } from "../quality";
+import type { PhraseBankEntry } from "./types";
+
+/**
+ * Choose a fresh answer seed before the model invents a board.
+ *
+ * The generator still owns the creative composition, but the answer is no
+ * longer allowed to drift independently from the curated phrase inventory.
+ * This makes the visual a constrained backform problem instead of a free-form
+ * answer followed by an optimistic explanation.
+ */
+export function selectAnswerFirstSeed(input: {
+  entries: readonly PhraseBankEntry[];
+  techniqueId?: string;
+  usedAnswerKeys?: Iterable<string>;
+}): PhraseBankEntry | undefined {
+  const used = new Set(
+    Array.from(input.usedAnswerKeys ?? [], (answer) => normalizeAnswerKey(answer)).filter(Boolean)
+  );
+  const fresh = input.entries.filter(
+    (entry) => !entry.overused && !used.has(normalizeAnswerKey(entry.answer))
+  );
+  if (!fresh.length) return undefined;
+
+  if (input.techniqueId) {
+    const compatible = fresh.filter((entry) =>
+      entry.techniqueAffinity.some((technique) => technique === input.techniqueId)
+    );
+    if (compatible.length) return compatible[0];
+  }
+
+  return fresh[0];
+}
+
+export function answerFirstSeedKey(seed: PhraseBankEntry | undefined): string | undefined {
+  if (!seed) return undefined;
+  const key = normalizeAnswerKey(seed.answer);
+  return key || undefined;
+}

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -15,6 +15,7 @@ import { type PuzzleGenerationParams, runPuzzleAgentGeneration } from "../run-ge
 import type { PuzzleAgentResult } from "../schemas";
 import type { TechniqueId } from "../technique-library";
 import { stableId } from "../tool-impl";
+import { answerFirstSeedKey, selectAnswerFirstSeed } from "./answer-first";
 import { toPlayabilityEvidence } from "./blind-solve-consensus";
 import { critiqueCandidate } from "./critique";
 import { buildGenerationBrief } from "./curriculum";
@@ -82,6 +83,7 @@ function toCandidate(
     solvable: true,
     qualityOverall: result.metadata.qualityScore,
     funScore: result.metadata.funScore ?? 0,
+    answerSeed: result.metadata.answerSeed,
     boardRecognitionConfidence: result.metadata.boardRecognitionConfidence,
     boardRecognitionModels: result.metadata.boardRecognitionModels,
     boardConceptVotes: result.metadata.boardConceptVotes,
@@ -191,6 +193,7 @@ export async function runApexGeneration(
   const generateStarted = Date.now();
   const candidates: ApexCandidate[] = [];
   const failures: string[] = [];
+  const usedAnswerSeeds = new Set<string>();
 
   // Sequential slots — safer for gateway quota; each slot gets a distinct brief nudge
   for (let slot = 1; slot <= brief.candidateCount; slot++) {
@@ -198,7 +201,17 @@ export async function runApexGeneration(
       // Rotate preferred technique focus per slot
       const focusTechnique =
         brief.preferredTechniques[(slot - 1) % Math.max(1, brief.preferredTechniques.length)];
-      const phraseSlice = brief.phraseSuggestions
+      const answerSeedEntry = selectAnswerFirstSeed({
+        entries: brief.phraseSuggestions,
+        techniqueId: focusTechnique,
+        usedAnswerKeys: usedAnswerSeeds,
+      });
+      const answerSeed = answerFirstSeedKey(answerSeedEntry);
+      if (answerSeed) usedAnswerSeeds.add(answerSeed);
+      const antiCopySuggestions = brief.phraseSuggestions.filter(
+        (entry) => answerFirstSeedKey(entry) !== answerSeed
+      );
+      const phraseSlice = antiCopySuggestions
         .filter((_, i) => i % brief.candidateCount === (slot - 1) % brief.candidateCount)
         .map((p) => p.answer);
 
@@ -215,7 +228,8 @@ export async function runApexGeneration(
         avoidTechniques: brief.avoidTechniques,
         phraseSeeds: phraseSlice.length
           ? phraseSlice
-          : brief.phraseSuggestions.slice(0, 3).map((p) => p.answer),
+          : antiCopySuggestions.slice(0, 3).map((p) => p.answer),
+        answerSeed: answerSeedEntry?.answer,
         bannedAnswerKeys: brief.diversity.bannedAnswerKeys,
         candidateIndex: slot,
         candidateCount: brief.candidateCount,
@@ -433,6 +447,7 @@ async function finalizeWinner(
       generationAttempts: ranked.length,
       thinkingSummary,
       visualStyleId: chosen.visual.styleId,
+      answerSeed: chosen.answerSeed,
       estimatedSolveRate: chosen.playerSim?.estimatedSolveRate,
       playabilityEvidence: chosen.playerSim ? toPlayabilityEvidence(chosen.playerSim) : undefined,
       boardRecognitionConfidence: chosen.boardRecognitionConfidence,

--- a/apps/web/src/ai/puzzle-agent/apex/types.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/types.ts
@@ -163,6 +163,7 @@ export type ApexCandidate = {
   solvable: boolean;
   qualityOverall: number;
   funScore: number;
+  answerSeed?: string;
   boardRecognitionConfidence?: number;
   boardRecognitionModels?: string[];
   boardConceptVotes?: Record<string, number>;

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -28,7 +28,7 @@ import {
   type CapturedPuzzleComposition,
 } from "./authoritative-draft";
 import { getDifficultyLevelForScore } from "./difficulty-levels";
-import { evaluatePublishGates } from "./quality";
+import { evaluatePublishGates, normalizeAnswerKey } from "./quality";
 import {
   normalizePuzzleAgentDraft,
   PuzzleAgentDraftSchema,
@@ -76,6 +76,8 @@ export interface PuzzleGenerationParams {
   avoidTechniques?: string[];
   /** Phrase-bank inspirations (not mandatory answers) */
   phraseSeeds?: string[];
+  /** Apex answer-first contract; when present the model must preserve this answer. */
+  answerSeed?: string;
   /** Banned normalized answer keys */
   bannedAnswerKeys?: string[];
   /** Tournament candidate slot (1-based) — encourages diversity across slots */
@@ -164,6 +166,13 @@ function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string)
       : null,
     params.category ? `Preferred category: ${params.category}.` : null,
     params.theme ? `Theme: ${params.theme}.` : null,
+    params.answerSeed
+      ? [
+          `ANSWER-FIRST CONTRACT: the intended answer is exactly "${params.answerSeed}".`,
+          "Backform one clean, fair visual mechanism from that answer using catalog-backed cues.",
+          "Do not substitute a different answer; if the seed cannot be composed fairly, let the host reject this attempt.",
+        ].join("\n")
+      : null,
     params.phraseSeeds?.length
       ? `Phrase-bank tropes/seeds to avoid copying (invent a different mechanism/answer; cousins of bee/before/sunflower/piece-of-cake are discouraged): ${params.phraseSeeds.join("; ")}.`
       : null,
@@ -313,6 +322,16 @@ export async function runPuzzleAgentGeneration(
           throw new Error("compose_puzzle_visual did not return a valid authoritative board");
         }
         const puzzle = applyAuthoritativeComposition(output.puzzle, capturedComposition);
+
+        if (
+          params.answerSeed &&
+          normalizeAnswerKey(puzzle.answer) !== normalizeAnswerKey(params.answerSeed)
+        ) {
+          priorFailure = `Answer-first seed mismatch: expected "${params.answerSeed}" but received "${puzzle.answer}"`;
+          lastCandidateError = new PuzzleCandidateRejectedError(priorFailure, puzzle);
+          lastError = lastCandidateError;
+          continue;
+        }
 
         // Asset provenance is a cheap, fail-closed gate. Run it before novelty
         // and difficulty evaluation so an unapproved/generated pictogram cannot
@@ -473,6 +492,7 @@ export async function runPuzzleAgentGeneration(
               qualityVerdict: quality.verdict,
               funScore: quality.funScore,
               visualStyleId: puzzle.visual?.styleId,
+              answerSeed: params.answerSeed,
               generationAttempts: attempt,
               thinkingSummary:
                 output.thinkingSummary ??
@@ -546,6 +566,7 @@ export async function runPuzzleAgentGeneration(
             qualityVerdict: quality.verdict,
             funScore: quality.funScore,
             visualStyleId: puzzle.visual?.styleId,
+            answerSeed: params.answerSeed,
             boardRecognitionConfidence: boardRecognition.perceptions.length
               ? Math.min(
                   ...boardRecognition.perceptions.map((perception) =>

--- a/apps/web/src/ai/puzzle-agent/schemas.ts
+++ b/apps/web/src/ai/puzzle-agent/schemas.ts
@@ -139,6 +139,8 @@ export const PuzzleAgentResultSchema = z.object({
     funScore: z.number().optional(),
     generationAttempts: z.number().optional(),
     thinkingSummary: z.string().optional(),
+    /** Answer selected by the Apex answer-first contract, when applicable. */
+    answerSeed: z.string().optional(),
     visualStyleId: z.string().optional(),
     /** Calibrated player-sim solve rate (0–1) */
     estimatedSolveRate: z.number().min(0).max(1).optional(),


### PR DESCRIPTION
## What changed

- Select a fresh, non-overused phrase-bank answer compatible with each Apex technique slot before model composition.
- Pass the selected answer as an explicit answer-first contract and reject normalized answer drift before asset, novelty, or model-judge work.
- Preserve the seed in generation metadata and add selector/gate regression coverage.
- Document the new pipeline stage and its fallback boundary.

## Validation

- Full tests: 87 suites, 497 tests passed
- Static puzzle audit: 93/93 puzzles, 279/279 profiles, 47/47 assets
- TypeScript and focused Biome checks passed
- Next production build passed and generated 132 pages

The build still reports the existing local MongoDB Atlas DNS/prerender warnings, but exits successfully. No paid live AI generation was invoked; a credentialed canary still requires a controlled Gateway budget.