### PR TITLE
Enforce technique-grounded answer seeds

### DIFF
--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -10,7 +10,7 @@ The Apex/Eve pipeline began with strong conceptual machinery—multiple candidat
 
 That original blind spot is now guarded by deterministic player-pixel checks, blind multi-model icon naming, responsive board perception, screenshot-only solving, answer-aware rejection, and human calibration workflows. The remaining market-readiness gap is empirical: the implemented gates still need sufficient qualified-player evidence and credentialed frozen-benchmark results. A green automated pipeline remains screening evidence, not proof that every intended “car” looks like a car to players.
 
-The Apex invent path now adds an answer-first contract before model composition. Before any model call, every tournament slot reserves a distinct fresh, non-overused phrase-bank answer compatible with its technique focus, asks the model to backform one catalog-grounded visual mechanism, and rejects any returned answer that drifts from the selected seed before asset, novelty, or model-judge work begins. Critique repairs preserve the finalist answer instead of inventing a replacement. This turns the highest-risk failure mode—an attractive explanation for the wrong board—into a cheap deterministic retry while preserving technique and answer diversity across slots. If the inventory cannot cover the tournament, Apex fails closed before spending and the orchestrator uses the validated catalog-grounded reserve path.
+The Apex invent path now adds an answer-first contract before model composition. Before any model call, curriculum removes tier techniques that have no fresh curated seed, the prompt slice guarantees a representative seed for each remaining technique, and every tournament slot reserves a distinct fresh, non-overused phrase-bank answer with strict technique affinity. Apex asks the model to backform one catalog-grounded visual mechanism and rejects any returned answer that drifts from the selected seed before asset, novelty, or model-judge work begins. Critique repairs preserve the finalist answer instead of inventing a replacement. This turns the highest-risk failure mode—an attractive explanation for the wrong board—into a cheap deterministic retry while preserving technique and answer diversity across slots. If the inventory cannot cover the tournament, Apex fails closed before spending and the orchestrator uses the validated catalog-grounded reserve path.
 
 ## Non-negotiable publish contract
 
@@ -36,7 +36,8 @@ The implementation owns these internal stages:
 
 ```text
 curriculum brief
-  -> reserve distinct answer-first seeds for every tournament slot
+  -> filter to techniques with fresh seed coverage
+  -> reserve distinct, strictly technique-compatible answer-first seeds
   -> concept candidates
   -> grounded visual plan
   -> authoritative composition

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/answer-first.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/answer-first.test.ts
@@ -42,25 +42,26 @@ describe("answer-first seed selection", () => {
     expect(
       selectAnswerFirstSeed({
         entries,
-        techniqueId: "simple_compound",
+        techniqueId: "spatial_preposition_play",
         usedAnswerKeys: ["moonlight"],
       })?.answer
     ).toBe("under the weather");
   });
 
-  it("falls back to a fresh answer when no technique-specific seed exists", () => {
+  it("fails closed when no technique-specific seed exists", () => {
     expect(
       selectAnswerFirstSeed({
         entries,
         techniqueId: "idiom_as_picture",
       })?.answer
-    ).toBe("moonlight");
+    ).toBeUndefined();
   });
 
   it("returns no seed when the inventory is exhausted", () => {
     expect(
       selectAnswerFirstSeed({
         entries,
+        techniqueId: "simple_compound",
         usedAnswerKeys: ["moonlight", "under-the-weather"],
       })
     ).toBeUndefined();
@@ -87,5 +88,25 @@ describe("answer-first seed selection", () => {
       requestedCount: 2,
       selectedCount: 1,
     });
+  });
+
+  it("stops reservation when a slot has no compatible seed", () => {
+    expect(
+      selectAnswerFirstSeeds({
+        entries,
+        techniqueIds: ["idiom_as_picture", "simple_compound"],
+        count: 2,
+      })
+    ).toEqual([]);
+  });
+
+  it("fails closed when no technique schedule is provided", () => {
+    expect(
+      selectAnswerFirstSeeds({
+        entries,
+        techniqueIds: [],
+        count: 1,
+      })
+    ).toEqual([]);
   });
 });

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/apex.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/apex.test.ts
@@ -1,8 +1,8 @@
+import { INK_PICTOGRAM_EXAMPLE_EYE, INK_PICTOGRAM_EXAMPLE_KEY } from "../../visual/style";
 import { phraseBankSize, samplePhraseBank } from "../phrase-bank";
 import { scoreRubric, tournamentScore } from "../rubric";
 import { pickWinner, rankCandidates } from "../tournament";
 import type { ApexCandidate } from "../types";
-import { INK_PICTOGRAM_EXAMPLE_EYE, INK_PICTOGRAM_EXAMPLE_KEY } from "../../visual/style";
 
 function fakeCandidate(overrides: Partial<ApexCandidate> = {}): ApexCandidate {
   return {
@@ -90,9 +90,26 @@ describe("phrase bank", () => {
       limit: 6,
     });
     expect(samples.length).toBeGreaterThan(0);
-    expect(samples.every((s) => !banned.has(s.answer.replace(/[^a-z0-9]/gi, "").toLowerCase()))).toBe(
+    expect(
+      samples.every((s) => !banned.has(s.answer.replace(/[^a-z0-9]/gi, "").toLowerCase()))
+    ).toBe(true);
+  });
+
+  it("keeps fresh coverage for every requested technique in the prompt slice", () => {
+    const samples = samplePhraseBank({
+      targetDifficulty: 5,
+      preferredTechniques: ["simple_compound", "obvious_emoji_sum"],
+      bannedAnswerKeys: new Set(),
+      excludeOverused: true,
+      limit: 6,
+    });
+    expect(samples.some((sample) => sample.techniqueAffinity.includes("simple_compound"))).toBe(
       true
     );
+    expect(samples.some((sample) => sample.techniqueAffinity.includes("obvious_emoji_sum"))).toBe(
+      true
+    );
+    expect(samples.every((sample) => !sample.overused)).toBe(true);
   });
 });
 

--- a/apps/web/src/ai/puzzle-agent/apex/answer-first.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/answer-first.ts
@@ -19,7 +19,7 @@ export class AnswerFirstSeedUnavailableError extends Error {
 }
 
 /**
- * Choose a fresh answer seed before the model invents a board.
+ * Choose a fresh, technique-compatible answer seed before the model invents a board.
  *
  * The generator still owns the creative composition, but the answer is no
  * longer allowed to drift independently from the curated phrase inventory.
@@ -28,7 +28,7 @@ export class AnswerFirstSeedUnavailableError extends Error {
  */
 export function selectAnswerFirstSeed(input: {
   entries: readonly PhraseBankEntry[];
-  techniqueId?: string;
+  techniqueId: string;
   usedAnswerKeys?: Iterable<string>;
 }): PhraseBankEntry | undefined {
   const used = new Set(
@@ -40,14 +40,10 @@ export function selectAnswerFirstSeed(input: {
   });
   if (!fresh.length) return undefined;
 
-  if (input.techniqueId) {
-    const compatible = fresh.filter((entry) =>
-      entry.techniqueAffinity.some((technique) => technique === input.techniqueId)
-    );
-    if (compatible.length) return compatible[0];
-  }
-
-  return fresh[0];
+  const compatible = fresh.filter((entry) =>
+    entry.techniqueAffinity.some((technique) => technique === input.techniqueId)
+  );
+  return compatible[0];
 }
 
 /**
@@ -68,6 +64,7 @@ export function selectAnswerFirstSeeds(input: {
 
   for (let index = 0; index < input.count; index++) {
     const techniqueId = input.techniqueIds[index % Math.max(1, input.techniqueIds.length)];
+    if (!techniqueId) break;
     const seed = selectAnswerFirstSeed({
       entries: input.entries,
       techniqueId,

--- a/apps/web/src/ai/puzzle-agent/apex/curriculum.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/curriculum.ts
@@ -5,10 +5,11 @@
 import { AI_CONFIG } from "../../config";
 import { loadAllAnswerKeys } from "../../learning/answer-registry";
 import { getDifficultyLevelForScore } from "../difficulty-levels";
+import { normalizeAnswerKey } from "../quality";
 import type { TechniqueId } from "../technique-library";
 import { loadDiversitySnapshot } from "./diversity-memory";
 import { loadLearningDigest } from "./learning-context";
-import { samplePhraseBank } from "./phrase-bank";
+import { PHRASE_BANK, samplePhraseBank } from "./phrase-bank";
 import type { GenerationBrief } from "./types";
 
 export type CurriculumInput = {
@@ -54,6 +55,19 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
   const banned = new Set([...diversity.bannedAnswerKeys, ...archiveKeys]);
   const overused = new Set(diversity.overusedTechniques);
 
+  // Do not advertise a tier technique that has no fresh, curated answer
+  // seed. The engine reserves seeds strictly by technique; filtering here
+  // preserves diversity without silently pairing a positional slot with an
+  // unrelated compound answer.
+  const freshSeedTechniques = new Set(
+    PHRASE_BANK.filter(
+      (entry) => !entry.overused && !banned.has(normalizeAnswerKey(entry.answer))
+    ).flatMap((entry) => entry.techniqueAffinity)
+  );
+  const supportedTierTechniques = level.techniques.filter((technique) =>
+    freshSeedTechniques.has(technique as TechniqueId)
+  ) as TechniqueId[];
+
   // Prefer underused techniques from this tier; avoid overused ones.
   // When players are finishing too quickly, bias toward harder techniques in-band.
   const harderBias = learning.tooEasy
@@ -68,18 +82,22 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
 
   const preferredTechniques = (
     [
-      ...harderBias.filter((t) => level.techniques.includes(t)),
-      ...diversity.underusedTechniques.filter((t) => level.techniques.includes(t)),
-      ...level.techniques.filter((t) => !overused.has(t)),
-      ...level.techniques,
+      ...harderBias.filter((t) => supportedTierTechniques.includes(t)),
+      ...diversity.underusedTechniques.filter((t) =>
+        supportedTierTechniques.includes(t as TechniqueId)
+      ),
+      ...supportedTierTechniques.filter((t) => !overused.has(t)),
+      ...supportedTierTechniques,
     ] as TechniqueId[]
   ).filter((t, i, arr) => arr.indexOf(t) === i) as TechniqueId[];
 
   const avoidTechniques = [
-    ...diversity.overusedTechniques.filter((t) => level.techniques.includes(t)),
+    ...diversity.overusedTechniques.filter((t) =>
+      supportedTierTechniques.includes(t as TechniqueId)
+    ),
     ...(learning.tooEasy
       ? (["simple_compound", "obvious_emoji_sum"] as string[]).filter((t) =>
-          level.techniques.includes(t)
+          supportedTierTechniques.includes(t as TechniqueId)
         )
       : []),
   ];
@@ -91,6 +109,7 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
     theme: input.theme,
     category: input.category,
     limit: Math.max(8, candidateCount * 3),
+    excludeOverused: true,
   });
 
   const briefSummary = [
@@ -99,6 +118,7 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
     avoidTechniques.length
       ? `Avoid overused/too-easy techniques: ${avoidTechniques.slice(0, 4).join(", ")}.`
       : "Technique diversity looks healthy.",
+    `Fresh answer seeds cover ${supportedTierTechniques.length}/${level.techniques.length} techniques in this tier.`,
     `Ban ${banned.size} archived+recent answers (never reuse).`,
     phraseSuggestions.length
       ? `Answer-first candidates available for grounded composition: ${phraseSuggestions

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -201,6 +201,7 @@ export async function runApexGeneration(
     entries: brief.phraseSuggestions,
     techniqueIds: brief.preferredTechniques,
     count: brief.candidateCount,
+    usedAnswerKeys: brief.diversity.bannedAnswerKeys,
   });
   if (answerSeedEntries.length !== brief.candidateCount) {
     throw new AnswerFirstSeedUnavailableError({

--- a/apps/web/src/ai/puzzle-agent/apex/phrase-bank.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/phrase-bank.ts
@@ -69,6 +69,83 @@ export const PHRASE_BANK: readonly PhraseBankEntry[] = [
     difficultyHint: 5,
     techniqueAffinity: ["simple_compound", "basic_positional"],
   },
+  {
+    answer: "flowerpot",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "flower + pot",
+  },
+  {
+    answer: "houseboat",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "house + boat",
+  },
+  {
+    answer: "starfish",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "star + fish",
+  },
+  {
+    answer: "seashell",
+    category: "compound",
+    difficultyHint: 5,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "sea + shell",
+  },
+  {
+    answer: "cupcake",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "cup + cake",
+  },
+  {
+    answer: "dogfish",
+    category: "compound",
+    difficultyHint: 5,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "dog + fish",
+  },
+  {
+    answer: "musicbox",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "music + box",
+  },
+  {
+    answer: "firehouse",
+    category: "compound",
+    difficultyHint: 5,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "fire + house",
+  },
+  {
+    answer: "coffeehouse",
+    category: "compound",
+    difficultyHint: 4,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "coffee + house",
+  },
+  {
+    answer: "flowerbox",
+    category: "compound",
+    difficultyHint: 5,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "flower + box",
+  },
+  {
+    answer: "fishcake",
+    category: "compound",
+    difficultyHint: 5,
+    techniqueAffinity: ["simple_compound", "obvious_emoji_sum"],
+    notes: "fish + cake",
+  },
 
   // Phonetic
   {
@@ -113,6 +190,27 @@ export const PHRASE_BANK: readonly PhraseBankEntry[] = [
     difficultyHint: 7,
     techniqueAffinity: ["nested_homophone", "multi_layer_phonetic"],
     notes: "four + give / for + give",
+  },
+  {
+    answer: "knight",
+    category: "phonetic",
+    difficultyHint: 5,
+    techniqueAffinity: ["single_homophone"],
+    notes: "night / knight",
+  },
+  {
+    answer: "flower",
+    category: "phonetic",
+    difficultyHint: 5,
+    techniqueAffinity: ["single_homophone"],
+    notes: "flour / flower",
+  },
+  {
+    answer: "pair",
+    category: "phonetic",
+    difficultyHint: 5,
+    techniqueAffinity: ["single_homophone"],
+    notes: "pear / pair",
   },
 
   // Positional / spatial
@@ -410,6 +508,8 @@ export function samplePhraseBank(input: {
   theme?: string;
   category?: string;
   limit?: number;
+  /** Keep answer-first prompts free of classic tropes. */
+  excludeOverused?: boolean;
 }): PhraseBankEntry[] {
   const limit = input.limit ?? 8;
   const bandMin = Math.max(3, input.targetDifficulty - 2);
@@ -420,6 +520,9 @@ export function samplePhraseBank(input: {
 
   const scored = PHRASE_BANK.map((entry) => {
     if (input.bannedAnswerKeys.has(normalize(entry.answer))) {
+      return { entry, score: -Infinity };
+    }
+    if (input.excludeOverused && entry.overused) {
       return { entry, score: -Infinity };
     }
     let score = 0;
@@ -442,7 +545,34 @@ export function samplePhraseBank(input: {
     .filter((s) => s.score > -Infinity)
     .sort((a, b) => b.score - a.score);
 
-  return scored.slice(0, limit).map((s) => s.entry);
+  // Keep the prompt useful for strict answer-first reservation: each
+  // technique gets a representative seed before we spend the remaining
+  // prompt budget on the highest-scoring nearby answers.
+  const selected: PhraseBankEntry[] = [];
+  const selectedKeys = new Set<string>();
+  for (const technique of input.preferredTechniques) {
+    const match = scored.find(
+      (candidate) =>
+        candidate.entry.techniqueAffinity.includes(technique as TechniqueId) &&
+        !selectedKeys.has(normalize(candidate.entry.answer))
+    );
+    if (!match) continue;
+    selected.push(match.entry);
+    selectedKeys.add(normalize(match.entry.answer));
+    if (selected.length >= limit) break;
+  }
+
+  if (selected.length < limit) {
+    for (const candidate of scored) {
+      const key = normalize(candidate.entry.answer);
+      if (selectedKeys.has(key)) continue;
+      selected.push(candidate.entry);
+      selectedKeys.add(key);
+      if (selected.length >= limit) break;
+    }
+  }
+
+  return selected;
 }
 
 export function phraseBankSize(): number {


### PR DESCRIPTION
## What changed\n- expand the curated answer-first bank with clear catalog-backed compound and homophone seeds\n- exclude overused answers and guarantee technique coverage in the curriculum prompt slice\n- make answer reservation strictly technique-compatible and fail closed when the schedule cannot be covered\n- add regression coverage and update the generator contract\n\n## Validation\n- pnpm.cmd --filter @rebuzzle/web test -- --runInBand\n- pnpm.cmd --filter @rebuzzle/web exec tsc --noEmit\n- pnpm.cmd --filter @rebuzzle/web benchmark:puzzles:static\n- pnpm.cmd --filter @rebuzzle/web build\n\nAll local checks pass. Live paid AI generation remains intentionally unrun while the Gateway budget is exhausted; no human playtest results are fabricated.