### PR TITLE
Market-leading generator: player-size honesty + human calibration breaker

### DIFF
--- a/apps/web/artifacts/puzzle-generator/static-audit.json
+++ b/apps/web/artifacts/puzzle-generator/static-audit.json
@@ -1,0 +1,912 @@
+{
+  "generatedAt": "2026-08-03T01:59:52.341Z",
+  "report": {
+    "version": "static-puzzle-audit-v2",
+    "benchmarkVersion": "2026-08-03.1",
+    "puzzleCount": 93,
+    "puzzlePassCount": 93,
+    "renderedProfileCount": 279,
+    "expectedRenderedProfileCount": 279,
+    "assetCount": 47,
+    "assetPassCount": 47,
+    "sourceCounts": {
+      "solve-corpus": 24,
+      "reserve": 69
+    },
+    "puzzleItems": [
+      {
+        "id": "literal:sunflower",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:moonlight",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:bookmark",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:keyboard",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:starfish",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:houseboat",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:raindrop",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:firework",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:heartbreak",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:eye-contact",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "literal:time-bomb",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "phonetic:ice-cream",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "phonetic:season",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "phonetic:before",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "phonetic:belief",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "position:mind-over-matter",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "position:head-over-heels",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "position:reading-between-lines",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "position:man-overboard",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "typography:big-deal",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "typography:small-talk",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "typography:broken-promise",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "position:crossroads",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "typography:long-time-no-see",
+        "source": "solve-corpus",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:firetruck",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:birdhouse",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:doghouse",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:catfish",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:mailbox",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:doorbell",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:handbag",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:bedtime",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:moonwalk",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:hotdog",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:watchdog",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:lighthouse",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:starlight",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:cookbook",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:rainforest",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:campfire",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:airmail",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:phonebook",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:songbird",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:toolbox",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:birdbrain",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:brainchild",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:sweetheart",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:heartburn",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:pizza-box",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:eggplant",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:treehouse",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:snowball",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:eyeball",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:fireball",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:clockwork",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:blackmail",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:bluebird",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:newsflash",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:dead-end",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:deadline",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:cold-feet",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:baby-shower",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:brain-drain",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:love-letter",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:junk-mail",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:rain-check",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:hot-shot",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:piece-of-cake",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:handbook",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:bookend",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:housework",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:daydream",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:keychain",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:keyring",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:gemstone",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:doorway",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:rainfall",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:moonbeam",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:notebook",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:textbook",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:storybook",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:dreamboat",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:backdoor",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:blue-moon",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:black-cat",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:red-eye",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:big-fish",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:small-world",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:little-things",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:tricycle",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:i-understand",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:life-after-death",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      },
+      {
+        "id": "reserve:world-under-water",
+        "source": "reserve",
+        "profilesRendered": 3,
+        "passed": true,
+        "failures": []
+      }
+    ],
+    "assetItems": [
+      {
+        "concept": "baby",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "bed",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "bell",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "bird",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "boat",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "book",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "brain",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "camera",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "candy",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "cat",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "clock",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "diamond",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "dog",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "door",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "egg",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "envelope",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "eye",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "fire",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "fish",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "flower",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "footprints",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "globe",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "hand",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "heart",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "house",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "key",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "leaf",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "lightbulb",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "lightning",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "moon",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "music",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "newspaper",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "phone",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "pizza",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "plane",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "puzzle",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "rain",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "skull",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "snowflake",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "sprout",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "star",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "sun",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "trash",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "tree",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "truck",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "watch",
+        "passed": true,
+        "failures": []
+      },
+      {
+        "concept": "wrench",
+        "passed": true,
+        "failures": []
+      }
+    ],
+    "failures": [],
+    "promotion": {
+      "passed": true,
+      "failures": []
+    }
+  }
+}

--- a/apps/web/docs/HUMAN_ICON_RECOGNITION.md
+++ b/apps/web/docs/HUMAN_ICON_RECOGNITION.md
@@ -8,7 +8,7 @@ communicates its intended message without explanatory text. A clean SVG or a
 model confidence score is therefore not enough to qualify a puzzle asset.
 
 The admin panel at `/admin/icon-recognition` presents one unlabeled pictogram at
-the exact 36px or 72px player size. It never returns the intended concept,
+the exact compact (44px) or large (72px) player tile size. It never returns the intended concept,
 aliases, correctness, or aggregate results until that reviewer finishes the
 selected cohort. Answers use the catalog's exact synonym ontology; fuzzy or
 generic matches receive no credit.

--- a/apps/web/docs/PUZZLE_GENERATOR_V2.md
+++ b/apps/web/docs/PUZZLE_GENERATOR_V2.md
@@ -159,10 +159,10 @@ The first implementation slice now includes:
 
 - a 98-concept publication catalog selected from 118 local Lucide-backed candidates, with 20 benchmark-failing assets quarantined behind exact provenance checks until replacements pass;
 - catalog-first resolution before long-tail SVG generation;
-- 36px and 72px rasterization so evaluators see compact and large player-level detail;
-- a deterministic 36px/72px pixel-integrity gate for contrast, visible-ink occupancy, subject bounds, canvas-edge contact, and rasterization failures, enforced before model calls and on approved-cache reuse;
-- two independent blind vision judges at every icon size;
-- one shared presentation specification used by the React player and server renderer;
+- player-tile rasterization derived from the shared board presentation spec (compact 44px + large 72px) so evaluators see the same sizes as the React player;
+- a deterministic player-tile pixel-integrity gate for contrast, visible-ink occupancy, subject bounds, canvas-edge contact, and rasterization failures, enforced before model calls and on approved-cache reuse;
+- two independent blind vision judges at every player tile size, including curated catalog icons on the publication path (catalog provenance alone is not sufficient);
+- one shared presentation specification used by the React player, server renderer, icon panels, and publish evidence;
 - independent board perception at compact 320px, mobile 375px, and desktop 768px;
 - two-judge visibility consensus for every pictogram, text cue, and operator at its declared multiplicity in every responsive profile;
 - screenshot-only solve tournaments across every production profile, separated from answer-aware hint review;
@@ -175,7 +175,8 @@ The first implementation slice now includes:
 - a frozen 196-specimen publication icon evaluator corpus producing 392 required decisions, plus an opt-in diagnostic lane for quarantined candidates;
 - an admin-only blind human naming panel for all 196 publication catalog/size specimens, with opaque fixture IDs and browser payloads that contain no concept, alias, asset ID, or correctness signal;
 - immutable one-response-per-reviewer/specimen storage, reviewer-specific randomized order, private no-store transport, and results withheld until that reviewer completes the full panel;
-- separate human release (90%) and market-leading (97%) top-1 gates at both 36px and 72px, requiring at least three independent reviewers for every specimen;
+- separate human release (90%) and market-leading (97%) top-1 gates at both player tile sizes, requiring at least three independent reviewers for every specimen;
+- a human-calibration circuit breaker (`human-calibration-gate-v1`) that moves daily publication to reserve only when fully covered icon-panel or playtest release cohorts fail — collecting samples stay watch/insufficient and do not halt AI;
 - a per-specimen two-of-three hard floor so a single unusable icon cannot hide behind a strong catalog average, plus weakest-concept and semantic-confusion reports for replacement decisions;
 - a versioned generated-pictogram registry for long-tail concepts that are not covered by the curated catalog;
 - one pending generated candidate per normalized concept, immutable blind reviews, and unanimous three-reviewer approval at both 36px and 72px before an asset can be reused;

--- a/apps/web/src/ai/learning/__tests__/human-calibration-gate.test.ts
+++ b/apps/web/src/ai/learning/__tests__/human-calibration-gate.test.ts
@@ -1,0 +1,73 @@
+import { assessHumanCalibrationGate } from "../human-calibration-gate";
+
+describe("human calibration gate", () => {
+  it("does not halt when human evidence is still collecting", () => {
+    const gate = assessHumanCalibrationGate({
+      icon: {
+        contractVersion: "human-icon-recognition-v3",
+        releaseReady: false,
+        coverageRate: 0.4,
+        weakFixtureCount: 0,
+      },
+      playtest: {
+        contractVersion: "puzzle-playtest-v3",
+        completedCandidates: 8,
+        releaseReady: false,
+        visualFailureRate: 0.02,
+        ambiguityRate: 0.05,
+      },
+    });
+    expect(gate.shouldUseReserve).toBe(false);
+    expect(gate.status).toBe("watch");
+  });
+
+  it("halts when a fully covered icon panel fails release", () => {
+    const gate = assessHumanCalibrationGate({
+      icon: {
+        contractVersion: "human-icon-recognition-v3",
+        releaseReady: false,
+        coverageRate: 1,
+        weakFixtureCount: 4,
+      },
+    });
+    expect(gate.shouldUseReserve).toBe(true);
+    expect(gate.status).toBe("halt");
+    expect(gate.reasons.join(" ")).toMatch(/weak specimens/i);
+  });
+
+  it("halts when playtest release sample fails quality gates", () => {
+    const gate = assessHumanCalibrationGate({
+      playtest: {
+        contractVersion: "puzzle-playtest-v3",
+        completedCandidates: 30,
+        releaseReady: false,
+        releaseFailures: ["Visual failure rate too high"],
+        visualFailureRate: 0.12,
+        ambiguityRate: 0.08,
+      },
+    });
+    expect(gate.shouldUseReserve).toBe(true);
+    expect(gate.status).toBe("halt");
+    expect(gate.reasons[0]).toMatch(/Visual failure/i);
+  });
+
+  it("is healthy when complete human cohorts pass release", () => {
+    const gate = assessHumanCalibrationGate({
+      icon: {
+        contractVersion: "human-icon-recognition-v3",
+        releaseReady: true,
+        coverageRate: 1,
+        weakFixtureCount: 0,
+      },
+      playtest: {
+        contractVersion: "puzzle-playtest-v3",
+        completedCandidates: 30,
+        releaseReady: true,
+        visualFailureRate: 0.01,
+        ambiguityRate: 0.04,
+      },
+    });
+    expect(gate.shouldUseReserve).toBe(false);
+    expect(gate.status).toBe("healthy");
+  });
+});

--- a/apps/web/src/ai/learning/human-calibration-gate.ts
+++ b/apps/web/src/ai/learning/human-calibration-gate.ts
@@ -1,0 +1,191 @@
+/**
+ * Merge human icon-naming + playtest readiness into the daily reserve breaker.
+ *
+ * Insufficient human samples remain "watch" / "insufficient" (do not halt AI).
+ * Only complete, failing human cohorts force reserve publication.
+ */
+
+export type HumanCalibrationStatus = "insufficient" | "watch" | "healthy" | "halt";
+
+export type HumanCalibrationGate = {
+  version: "human-calibration-gate-v1";
+  status: HumanCalibrationStatus;
+  shouldUseReserve: boolean;
+  reasons: string[];
+  icon?: {
+    contractVersion: string;
+    releaseReady: boolean;
+    coverageRate: number;
+    weakFixtureCount: number;
+  };
+  playtest?: {
+    contractVersion: string;
+    completedCandidates: number;
+    releaseReady: boolean;
+    visualFailureRate: number | null;
+    ambiguityRate: number | null;
+  };
+  generatedAt: string;
+};
+
+/** Playtest release sample floor from HUMAN_PUZZLE_PLAYTESTING.md */
+const PLAYTEST_RELEASE_COMPLETED_FLOOR = 30;
+
+export function assessHumanCalibrationGate(input: {
+  icon?: {
+    contractVersion: string;
+    releaseReady: boolean;
+    coverageRate: number;
+    weakFixtureCount: number;
+    status?: string;
+  } | null;
+  playtest?: {
+    contractVersion: string;
+    completedCandidates: number;
+    releaseReady: boolean;
+    releaseFailures?: string[];
+    visualFailureRate: number | null;
+    ambiguityRate: number | null;
+  } | null;
+  now?: Date;
+}): HumanCalibrationGate {
+  const reasons: string[] = [];
+  let status: HumanCalibrationStatus = "insufficient";
+
+  const icon = input.icon;
+  const playtest = input.playtest;
+
+  if (icon) {
+    if (icon.coverageRate >= 1) {
+      if (!icon.releaseReady) {
+        status = "halt";
+        reasons.push(
+          icon.weakFixtureCount > 0
+            ? `Human icon panel failed release (${icon.weakFixtureCount} weak specimens)`
+            : "Human icon recognition release gate failed"
+        );
+      } else if (status !== "halt") {
+        status = "healthy";
+      }
+    } else if (icon.coverageRate > 0) {
+      if (status !== "halt") status = "watch";
+      reasons.push(
+        `Human icon panel collecting (${Math.round(icon.coverageRate * 100)}% specimen coverage)`
+      );
+    }
+  }
+
+  if (playtest) {
+    if (playtest.completedCandidates >= PLAYTEST_RELEASE_COMPLETED_FLOOR) {
+      if (!playtest.releaseReady) {
+        status = "halt";
+        reasons.push(
+          ...(playtest.releaseFailures?.length
+            ? playtest.releaseFailures.slice(0, 3)
+            : ["Human playtest release gate failed"])
+        );
+      } else if (status !== "halt") {
+        status = "healthy";
+      }
+    } else if (playtest.completedCandidates > 0) {
+      if (status !== "halt") status = "watch";
+      reasons.push(
+        `Human playtest collecting (${playtest.completedCandidates}/${PLAYTEST_RELEASE_COMPLETED_FLOOR} completed puzzles)`
+      );
+    }
+  }
+
+  if (!icon && !playtest) {
+    reasons.push("No human calibration reports available");
+  } else if (status === "insufficient" && reasons.length === 0) {
+    reasons.push("Human calibration evidence below release sample floors");
+  }
+
+  return {
+    version: "human-calibration-gate-v1",
+    status,
+    shouldUseReserve: status === "halt",
+    reasons,
+    icon: icon
+      ? {
+          contractVersion: icon.contractVersion,
+          releaseReady: icon.releaseReady,
+          coverageRate: icon.coverageRate,
+          weakFixtureCount: icon.weakFixtureCount,
+        }
+      : undefined,
+    playtest: playtest
+      ? {
+          contractVersion: playtest.contractVersion,
+          completedCandidates: playtest.completedCandidates,
+          releaseReady: playtest.releaseReady,
+          visualFailureRate: playtest.visualFailureRate,
+          ambiguityRate: playtest.ambiguityRate,
+        }
+      : undefined,
+    generatedAt: (input.now ?? new Date()).toISOString(),
+  };
+}
+
+/**
+ * Load live human reports when Mongo/services are available.
+ * Failures are non-fatal — caller treats missing reports as insufficient.
+ */
+export async function loadHumanCalibrationGate(): Promise<HumanCalibrationGate> {
+  let icon: Parameters<typeof assessHumanCalibrationGate>[0]["icon"] = null;
+  let playtest: Parameters<typeof assessHumanCalibrationGate>[0]["playtest"] = null;
+
+  try {
+    const {
+      HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
+      buildIconRecognitionFixtures,
+      scoreIconRecognitionCalibration,
+    } = await import("@/ai/puzzle-agent/review/icon-recognition-service");
+    const { CURATED_PICTOGRAM_CATALOG_VERSION } = await import(
+      "@/ai/puzzle-agent/visual/curated-pictograms"
+    );
+    const { createMongoIconRecognitionRepository } = await import(
+      "@/ai/puzzle-agent/review/mongo-icon-recognition-repository"
+    );
+    const fixtures = buildIconRecognitionFixtures("publication");
+    const reviews = await createMongoIconRecognitionRepository().listCalibrationDecisions({
+      contractVersion: HUMAN_ICON_RECOGNITION_CONTRACT_VERSION,
+      catalogVersion: CURATED_PICTOGRAM_CATALOG_VERSION,
+    });
+    const report = scoreIconRecognitionCalibration({
+      fixtures,
+      reviews,
+      panelId: "publication",
+    });
+    icon = {
+      contractVersion: report.contractVersion,
+      releaseReady: report.releaseReady,
+      coverageRate: report.coverageRate,
+      weakFixtureCount: report.weakFixtures.length,
+      status: report.status,
+    };
+  } catch {
+    icon = null;
+  }
+
+  try {
+    const { puzzlePlaytestService } = await import(
+      "@/ai/puzzle-agent/review/puzzle-playtest-server"
+    );
+    const report = await puzzlePlaytestService.getReport("operational-audit", new Date(), {
+      readOnly: true,
+    });
+    playtest = {
+      contractVersion: report.contractVersion,
+      completedCandidates: report.completedCandidates,
+      releaseReady: report.releaseReady,
+      releaseFailures: report.releaseFailures,
+      visualFailureRate: report.visualFailureRate,
+      ambiguityRate: report.ambiguityRate,
+    };
+  } catch {
+    playtest = null;
+  }
+
+  return assessHumanCalibrationGate({ icon, playtest });
+}

--- a/apps/web/src/ai/learning/index.ts
+++ b/apps/web/src/ai/learning/index.ts
@@ -62,6 +62,12 @@ export {
 } from "./quality-drift";
 export { loadQualityDriftReport } from "./quality-drift-store";
 export {
+  assessHumanCalibrationGate,
+  loadHumanCalibrationGate,
+  type HumanCalibrationGate,
+  type HumanCalibrationStatus,
+} from "./human-calibration-gate";
+export {
   applySimCalibration,
   computeSimCalibrationFromPairs,
   loadSimCalibration,

--- a/apps/web/src/ai/puzzle-agent/__tests__/quality.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/quality.test.ts
@@ -71,7 +71,29 @@ describe("evaluateVisualForPublish", () => {
     ).toBe(false);
   });
 
-  it("accepts composed pictogram SVG boards with trusted catalog provenance", () => {
+  it("accepts composed pictogram SVG boards with trusted catalog provenance and player-size recognition", () => {
+    expect(
+      evaluateVisualForPublish({
+        mode: "composed",
+        layers: [
+          {
+            kind: "pictogram",
+            concept: "eye",
+            svg: catalogEye.svg,
+            source: "catalog",
+            assetId: catalogEye.assetId,
+            recognitionProfiles: [
+              { tileSize: 44, seenAs: "eye", confidence: 0.94 },
+              { tileSize: 72, seenAs: "eye", confidence: 0.96 },
+            ],
+          },
+        ],
+        unicodeFallback: "👁️",
+      }).ok
+    ).toBe(true);
+  });
+
+  it("rejects authentic catalog icons that lack player-size recognition evidence on AI publish", () => {
     expect(
       evaluateVisualForPublish({
         mode: "composed",
@@ -86,6 +108,27 @@ describe("evaluateVisualForPublish", () => {
         ],
         unicodeFallback: "👁️",
       }).ok
+    ).toBe(false);
+  });
+
+  it("allows authentic catalog icons without recognition evidence for offline reserve audits", () => {
+    expect(
+      evaluateVisualForPublish(
+        {
+          mode: "composed",
+          layers: [
+            {
+              kind: "pictogram",
+              concept: "eye",
+              svg: catalogEye.svg,
+              source: "catalog",
+              assetId: catalogEye.assetId,
+            },
+          ],
+          unicodeFallback: "👁️",
+        },
+        { requireCatalogRecognitionEvidence: false }
+      ).ok
     ).toBe(true);
   });
 
@@ -141,7 +184,7 @@ describe("evaluateVisualForPublish", () => {
     ).toBe(true);
   });
 
-  it("accepts an authentic simple catalog silhouette", () => {
+  it("accepts an authentic simple catalog silhouette with recognition evidence", () => {
     const heart = resolveCuratedPictogram("heart")!;
     expect(
       evaluateVisualForPublish({
@@ -153,6 +196,10 @@ describe("evaluateVisualForPublish", () => {
             svg: heart.svg,
             source: "catalog",
             assetId: heart.assetId,
+            recognitionProfiles: [
+              { tileSize: 44, seenAs: "heart", confidence: 0.93 },
+              { tileSize: 72, seenAs: "heart", confidence: 0.95 },
+            ],
           },
         ],
         unicodeFallback: "❤️",

--- a/apps/web/src/ai/puzzle-agent/benchmark/__tests__/benchmark.test.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/__tests__/benchmark.test.ts
@@ -43,7 +43,7 @@ describe("puzzle generator benchmark", () => {
 
   it("fails closed when one required size is absent", () => {
     const corpus = buildIconBenchmarkCorpus();
-    const observations = perfectObservations().filter((observation) => observation.tileSize !== 36);
+    const observations = perfectObservations().filter((observation) => observation.tileSize !== 44);
     const report = scoreIconBenchmark({ cases: corpus, observations });
 
     expect(report.coverage).toBe(0.5);
@@ -59,14 +59,14 @@ describe("puzzle generator benchmark", () => {
       (entry) => entry.critical && entry.expected === "accept" && entry.intendedConcept === "car"
     )!;
     const failed = observations.map((observation) =>
-      observation.caseId === critical.id && observation.tileSize === 36
+      observation.caseId === critical.id && observation.tileSize === 44
         ? { ...observation, accepted: false }
         : observation
     );
     const report = scoreIconBenchmark({ cases: corpus, observations: failed });
 
     expect(report.promotion.passed).toBe(false);
-    expect(report.criticalFailures).toContain(`${critical.id}@36`);
+    expect(report.criticalFailures).toContain(`${critical.id}@44`);
   });
 
   it("blocks promotion when a judge disappears even if decisions look correct", () => {

--- a/apps/web/src/ai/puzzle-agent/benchmark/score.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/score.ts
@@ -61,13 +61,15 @@ export function scoreIconBenchmark(input: {
       return observation.expected === "accept" ? !observation.accepted : observation.accepted;
     })
     .map((observation) => `${observation.caseId}@${observation.tileSize}`);
+  const [compactTile = 44, largeTile = 72] = ICON_BENCHMARK_TILE_SIZES;
   const compactPositive = scoreSlice(
     validObservations,
-    (observation) => observation.expected === "accept" && observation.tileSize === 36
+    (observation) =>
+      observation.expected === "accept" && observation.tileSize === compactTile
   );
   const largePositive = scoreSlice(
     validObservations,
-    (observation) => observation.expected === "accept" && observation.tileSize === 72
+    (observation) => observation.expected === "accept" && observation.tileSize === largeTile
   );
   const independentJudgeCoverage = safeRate(
     validObservations.filter((observation) => observation.judgeCount >= 2).length,
@@ -120,8 +122,14 @@ export function scoreIconBenchmark(input: {
         validObservations,
         (observation) => observation.expected === "reject"
       ),
-      "compact-36": scoreSlice(validObservations, (observation) => observation.tileSize === 36),
-      "large-72": scoreSlice(validObservations, (observation) => observation.tileSize === 72),
+      [`compact-${compactTile}`]: scoreSlice(
+        validObservations,
+        (observation) => observation.tileSize === compactTile
+      ),
+      [`large-${largeTile}`]: scoreSlice(
+        validObservations,
+        (observation) => observation.tileSize === largeTile
+      ),
     },
     promotion: {
       passed: promotionFailures.length === 0,

--- a/apps/web/src/ai/puzzle-agent/benchmark/static-audit.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/static-audit.ts
@@ -100,7 +100,11 @@ async function auditPuzzle(puzzle: StaticAuditPuzzle): Promise<StaticPuzzleAudit
     return { id: puzzle.id, source: puzzle.source, profilesRendered: 0, passed: false, failures };
   }
 
-  const visualCheck = evaluateVisualForPublish(puzzle.visual);
+  const visualCheck = evaluateVisualForPublish(puzzle.visual, {
+    // Static audit is no-spend: catalog authenticity + pixel integrity cover
+    // offline inventory. Live blind naming is enforced on AI publish.
+    requireCatalogRecognitionEvidence: false,
+  });
   if (!visualCheck.ok) failures.push(visualCheck.reason ?? "Visual failed publish preflight");
   if (puzzle.rebusPuzzle !== puzzle.visual.unicodeFallback) {
     failures.push("rebusPuzzle does not equal visual.unicodeFallback");

--- a/apps/web/src/ai/puzzle-agent/benchmark/types.ts
+++ b/apps/web/src/ai/puzzle-agent/benchmark/types.ts
@@ -1,7 +1,8 @@
 import type { EditorialFailureKind } from "../visual/editorial-consensus";
+import { PLAYER_ICON_GATE_SIZES } from "../visual/presentation";
 
-export const PUZZLE_GENERATOR_BENCHMARK_VERSION = "2026-08-02.11";
-export const ICON_BENCHMARK_TILE_SIZES = [36, 72] as const;
+export const PUZZLE_GENERATOR_BENCHMARK_VERSION = "2026-08-03.1";
+export const ICON_BENCHMARK_TILE_SIZES = PLAYER_ICON_GATE_SIZES;
 
 export type IconBenchmarkExpectation = "accept" | "reject";
 

--- a/apps/web/src/ai/puzzle-agent/quality.ts
+++ b/apps/web/src/ai/puzzle-agent/quality.ts
@@ -13,6 +13,7 @@ import { TECHNIQUE_LIBRARY, type TechniqueId } from "./technique-library";
 import type { PuzzleVisual } from "./visual/composition";
 import { isAuthenticCuratedPictogram } from "./visual/curated-pictograms";
 import { scorePictogramClarity } from "./visual/pictogram-clarity";
+import { PLAYER_ICON_GATE_SIZES } from "./visual/presentation";
 
 export const TECHNIQUE_IDS = Object.keys(TECHNIQUE_LIBRARY) as TechniqueId[];
 
@@ -118,21 +119,32 @@ export type VisualPublishCheck = {
   textLayerCount: number;
 };
 
-export function evaluateVisualForPublish(visual?: {
-  mode?: string;
-  unicodeFallback?: string;
-  layers?: Array<{
-    kind: string;
-    svg?: string;
-    concept?: string;
-    assetId?: string;
-    source?: "catalog" | "generated" | "approved-cache";
-    recognitionProfiles?: Array<{ tileSize: number; seenAs: string; confidence: number }>;
-    src?: string;
-    content?: string;
-    emphasis?: string;
-  }>;
-}): VisualPublishCheck {
+export function evaluateVisualForPublish(
+  visual?: {
+    mode?: string;
+    unicodeFallback?: string;
+    layers?: Array<{
+      kind: string;
+      svg?: string;
+      concept?: string;
+      assetId?: string;
+      source?: "catalog" | "generated" | "approved-cache";
+      recognitionProfiles?: Array<{ tileSize: number; seenAs: string; confidence: number }>;
+      src?: string;
+      content?: string;
+      emphasis?: string;
+    }>;
+  },
+  options?: {
+    /**
+     * AI publication requires blind naming evidence on catalog icons.
+     * Offline reserve/static audits may disable this because they cannot
+     * spend vision judges; they still require authentic catalog provenance.
+     */
+    requireCatalogRecognitionEvidence?: boolean;
+  }
+): VisualPublishCheck {
+  const requireCatalogRecognitionEvidence = options?.requireCatalogRecognitionEvidence !== false;
   if (!visual) {
     return {
       ok: false,
@@ -176,16 +188,15 @@ export function evaluateVisualForPublish(visual?: {
   }
 
   for (const layer of pictogramLayers) {
-    if (
+    const authenticCatalog =
       layer.source === "catalog" &&
       isAuthenticCuratedPictogram({
         concept: layer.concept ?? "",
         assetId: layer.assetId,
         svg: layer.svg,
-      })
-    ) {
-      continue;
-    }
+      });
+    const approvedCache = layer.source === "approved-cache" && Boolean(layer.assetId);
+
     if (layer.source === "generated" || !layer.source) {
       return {
         ok: false,
@@ -198,21 +209,39 @@ export function evaluateVisualForPublish(visual?: {
         textLayerCount,
       };
     }
-    if (
-      layer.source === "approved-cache" &&
-      (!layer.assetId ||
-        ![36, 72].every((size) =>
-          layer.recognitionProfiles?.some((profile) => profile.tileSize === size)
-        ))
-    ) {
+
+    if (!authenticCatalog && !approvedCache) {
       return {
         ok: false,
-        reason: `Approved pictogram "${layer.concept ?? "unknown"}" is missing current player-size evidence`,
+        reason: `Pictogram "${layer.concept ?? "unknown"}" failed catalog authenticity checks`,
         mode: visual.mode,
         pictogramSvgCount,
         textLayerCount,
       };
     }
+
+    // Approved-cache always needs live evidence. Catalog needs it for AI publish.
+    const needsRecognitionEvidence =
+      approvedCache || (authenticCatalog && requireCatalogRecognitionEvidence);
+    if (
+      needsRecognitionEvidence &&
+      !PLAYER_ICON_GATE_SIZES.every((size) =>
+        layer.recognitionProfiles?.some((profile) => profile.tileSize === size)
+      )
+    ) {
+      return {
+        ok: false,
+        reason: `Pictogram "${layer.concept ?? "unknown"}" is missing current player-size recognition evidence`,
+        mode: visual.mode,
+        pictogramSvgCount,
+        textLayerCount,
+      };
+    }
+
+    // Authentic catalog assets are already publication-vetted; clarity re-check
+    // is for approved-cache / regenerated SVGs that may regress.
+    if (authenticCatalog) continue;
+
     const clarity = scorePictogramClarity(layer.svg);
     if (!clarity.ok) {
       return {

--- a/apps/web/src/ai/puzzle-agent/review/__tests__/generated-pictogram-registry.test.ts
+++ b/apps/web/src/ai/puzzle-agent/review/__tests__/generated-pictogram-registry.test.ts
@@ -112,7 +112,7 @@ function automatedInput(concept = "lighthouse") {
     seenAs: concept,
     recognitionConfidence: 0.95,
     recognitionProfiles: [
-      { tileSize: 36, seenAs: concept, confidence: 0.94 },
+      { tileSize: 44, seenAs: concept, confidence: 0.94 },
       { tileSize: 72, seenAs: concept, confidence: 0.97 },
     ],
     now: new Date("2026-08-01T12:00:00.000Z"),
@@ -151,7 +151,7 @@ describe("human-governed generated pictogram registry", () => {
 
     await expect(
       registry.submitCandidate({ ...automatedInput(), recognitionProfiles: [] })
-    ).rejects.toThrow("both player-size");
+    ).rejects.toThrow("player-size recognition profiles");
     expect(store.candidates).toHaveLength(0);
   });
 
@@ -201,6 +201,8 @@ describe("human-governed generated pictogram registry", () => {
       requiredReviewersPerSize: 3,
       size36: { decisions: 3, correct: 3 },
       size72: { decisions: 3, correct: 3 },
+      compactTilePx: 44,
+      largeTilePx: 72,
     });
     await expect(registry.findApproved("lighthouse")).resolves.toMatchObject({
       id: candidate?.id,

--- a/apps/web/src/ai/puzzle-agent/review/__tests__/icon-recognition-service.test.ts
+++ b/apps/web/src/ai/puzzle-agent/review/__tests__/icon-recognition-service.test.ts
@@ -84,7 +84,7 @@ describe("blind human icon-recognition calibration", () => {
 
     expect(fixtures).toHaveLength(196);
     expect(new Set(fixtures.map((fixture) => fixture.fixtureId)).size).toBe(196);
-    expect(new Set(fixtures.map((fixture) => fixture.sizePx))).toEqual(new Set([36, 72]));
+    expect(new Set(fixtures.map((fixture) => fixture.sizePx))).toEqual(new Set([44, 72]));
     for (const fixture of fixtures) {
       expect(fixture.fixtureId).toMatch(/^[a-f0-9]{32}$/);
       expect(fixture.fixtureId).not.toContain(fixture.conceptId);
@@ -268,7 +268,7 @@ describe("blind human icon-recognition calibration", () => {
   it("fails candidate promotion when qualified reviewers miss the hidden controls", () => {
     const fixtures = buildIconRecognitionFixtures("candidates");
     const missedControl = fixtures.find(
-      (fixture) => fixture.role === "control" && fixture.sizePx === 36
+      (fixture) => fixture.role === "control" && fixture.sizePx === 44
     )!;
     const reviews = ["reviewer-1", "reviewer-2", "reviewer-3", "reviewer-4", "reviewer-5"].flatMap(
       (reviewerId) =>
@@ -296,7 +296,7 @@ describe("blind human icon-recognition calibration", () => {
   it("blocks one weak candidate even when the cohort average exceeds 97%", () => {
     const fixtures = buildIconRecognitionFixtures("candidates");
     const weakCandidate = fixtures.find(
-      (fixture) => fixture.conceptId === "soda" && fixture.sizePx === 36
+      (fixture) => fixture.conceptId === "soda" && fixture.sizePx === 44
     )!;
     const reviews = ["reviewer-1", "reviewer-2", "reviewer-3", "reviewer-4", "reviewer-5"].flatMap(
       (reviewerId, reviewerIndex) =>
@@ -312,9 +312,9 @@ describe("blind human icon-recognition calibration", () => {
       panelId: "candidates",
     });
 
-    expect(report.sizeScores.find((score) => score.sizePx === 36)?.accuracy).toBeGreaterThan(0.97);
+    expect(report.sizeScores.find((score) => score.sizePx === 44)?.accuracy).toBeGreaterThan(0.97);
     expect(report.weakFixtures).toEqual([
-      expect.objectContaining({ conceptId: "soda", sizePx: 36, accuracy: 0.6 }),
+      expect.objectContaining({ conceptId: "soda", sizePx: 44, accuracy: 0.6 }),
     ]);
     expect(report.marketLeadingReady).toBe(false);
     expect(report.promotionEligibleConceptIds).not.toContain("soda");
@@ -324,7 +324,7 @@ describe("blind human icon-recognition calibration", () => {
   it("blocks promotion when a single unusable icon is hidden by a 97%+ catalog average", () => {
     const fixtures = buildIconRecognitionFixtures();
     const badFixture = fixtures.find(
-      (fixture) => fixture.conceptId === "car" && fixture.sizePx === 36
+      (fixture) => fixture.conceptId === "car" && fixture.sizePx === 44
     )!;
     const reviews = ["reviewer-1", "reviewer-2", "reviewer-3"].flatMap((reviewerId) =>
       fixtures.map((fixture) =>
@@ -335,9 +335,9 @@ describe("blind human icon-recognition calibration", () => {
     );
     const report = scoreIconRecognitionCalibration({ fixtures, reviews });
 
-    expect(report.sizeScores.find((score) => score.sizePx === 36)?.accuracy).toBeGreaterThan(0.97);
+    expect(report.sizeScores.find((score) => score.sizePx === 44)?.accuracy).toBeGreaterThan(0.97);
     expect(report.weakFixtures).toEqual([
-      expect.objectContaining({ conceptId: "car", sizePx: 36, accuracy: 0 }),
+      expect.objectContaining({ conceptId: "car", sizePx: 44, accuracy: 0 }),
     ]);
     expect(report.releaseReady).toBe(false);
     expect(report.marketLeadingReady).toBe(false);
@@ -346,9 +346,9 @@ describe("blind human icon-recognition calibration", () => {
 
   it("reports semantic confusion pairs and ignores duplicate reviewer rows", () => {
     const fixtures = buildIconRecognitionFixtures();
-    const car36 = fixtures.find((fixture) => fixture.conceptId === "car" && fixture.sizePx === 36)!;
+    const carCompact = fixtures.find((fixture) => fixture.conceptId === "car" && fixture.sizePx === 44)!;
     const wrong = review({
-      fixture: car36,
+      fixture: carCompact,
       reviewerId: "reviewer-1",
       correct: false,
       matchedConceptId: "bus",

--- a/apps/web/src/ai/puzzle-agent/review/generated-pictogram-registry.ts
+++ b/apps/web/src/ai/puzzle-agent/review/generated-pictogram-registry.ts
@@ -7,14 +7,15 @@ import type {
 } from "@/db/models";
 import { scorePictogramClarity } from "../visual/pictogram-clarity";
 import { evaluatePictogramPixelIntegrity } from "../visual/pictogram-pixel-integrity";
+import { PLAYER_ICON_GATE_SIZES } from "../visual/presentation";
 import { sanitizePictogramSvg } from "../visual/sanitize-svg";
 import { INK_PICTOGRAM_STYLE_ID } from "../visual/style";
 import { normalizeIconNamingGuess, resolveIconNamingGuess } from "./icon-recognition-service";
 
-export const GENERATED_PICTOGRAM_REGISTRY_VERSION = "generated-pictogram-registry-v1";
+export const GENERATED_PICTOGRAM_REGISTRY_VERSION = "generated-pictogram-registry-v2";
 export const GENERATED_PICTOGRAM_REQUIRED_REVIEWERS_PER_SIZE = 3;
 export const GENERATED_PICTOGRAM_MAX_PENDING_PER_CONCEPT = 1;
-export const GENERATED_PICTOGRAM_REVIEW_SIZES = [36, 72] as const;
+export const GENERATED_PICTOGRAM_REVIEW_SIZES = PLAYER_ICON_GATE_SIZES;
 
 export type GeneratedPictogramReviewSize = (typeof GENERATED_PICTOGRAM_REVIEW_SIZES)[number];
 
@@ -199,12 +200,17 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
         candidateId: candidate.id,
       })
     );
-    const size36 = sizeEvidence(reviews, 36);
-    const size72 = sizeEvidence(reviews, 72);
+    const [compactPx, largePx] = GENERATED_PICTOGRAM_REVIEW_SIZES;
+    const size36 = sizeEvidence(reviews, compactPx!);
+    const size72 = sizeEvidence(reviews, largePx!);
     const humanEvidence = {
       requiredReviewersPerSize: GENERATED_PICTOGRAM_REQUIRED_REVIEWERS_PER_SIZE,
+      // Legacy field names keep admin/report consumers working; values are
+      // compact/large player-tile evidence for the current gate sizes.
       size36,
       size72,
+      compactTilePx: compactPx!,
+      largeTilePx: largePx!,
     };
     const failed = [size36, size72].some(
       (size) =>
@@ -230,7 +236,7 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
           action: approved ? "approved" : "rejected",
           actor: "human-panel",
           reason: approved
-            ? "Three independent exact-name decisions passed at both 36px and 72px"
+            ? `Three independent exact-name decisions passed at both ${compactPx}px and ${largePx}px`
             : "A player-size specimen failed unanimous blind naming",
           now,
         }),
@@ -263,9 +269,9 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
         );
       }
       const profileSizes = new Set((input.recognitionProfiles ?? []).map((row) => row.tileSize));
-      if (!profileSizes.has(36) || !profileSizes.has(72)) {
+      if (!GENERATED_PICTOGRAM_REVIEW_SIZES.every((size) => profileSizes.has(size))) {
         throw new Error(
-          "Generated pictogram candidate lacks both player-size recognition profiles"
+          `Generated pictogram candidate lacks player-size recognition profiles (${GENERATED_PICTOGRAM_REVIEW_SIZES.join("px, ")}px)`
         );
       }
       const assetSha256 = sha256(svg);
@@ -450,11 +456,12 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
                 .filter((review) => review.candidateId === candidate.id)
                 .map((review) => review.sizePx)
             );
-            return sizes.has(36) && sizes.has(72);
+            return GENERATED_PICTOGRAM_REVIEW_SIZES.every((size) => sizes.has(size));
           })
           .map((candidate) => candidate.id)
       );
       const visible = candidates.filter((candidate) => completedCandidateIds.has(candidate.id));
+      const [compactPx, largePx] = GENERATED_PICTOGRAM_REVIEW_SIZES;
       const reports = await Promise.all(
         visible.map(async (candidate): Promise<GeneratedPictogramCandidateReport> => {
           const reviews = uniqueReviews(
@@ -467,8 +474,8 @@ export function createGeneratedPictogramRegistry(repository: GeneratedPictogramR
             id: candidate.id,
             conceptLabel: candidate.conceptLabel,
             status: candidate.status,
-            size36: sizeEvidence(reviews, 36),
-            size72: sizeEvidence(reviews, 72),
+            size36: sizeEvidence(reviews, compactPx!),
+            size72: sizeEvidence(reviews, largePx!),
             automatedConfidence: candidate.automatedEvidence.recognitionConfidence,
             createdAt: candidate.createdAt.toISOString(),
             updatedAt: candidate.updatedAt.toISOString(),

--- a/apps/web/src/ai/puzzle-agent/review/icon-recognition-service.ts
+++ b/apps/web/src/ai/puzzle-agent/review/icon-recognition-service.ts
@@ -10,9 +10,11 @@ import {
   listMaterialSymbolCandidateIds,
   MATERIAL_SYMBOL_CANDIDATE_SOURCE,
 } from "../visual/material-symbol-candidates";
+import { PLAYER_ICON_GATE_SIZES } from "../visual/presentation";
 
-export const HUMAN_ICON_RECOGNITION_CONTRACT_VERSION = "human-icon-recognition-v2";
-export const ICON_RECOGNITION_SIZES = [36, 72] as const;
+/** v3 aligns blind naming specimens to live player tile sizes (44px + 72px). */
+export const HUMAN_ICON_RECOGNITION_CONTRACT_VERSION = "human-icon-recognition-v3";
+export const ICON_RECOGNITION_SIZES = PLAYER_ICON_GATE_SIZES;
 export const ICON_RECOGNITION_MIN_REVIEWERS = 3;
 export const ICON_RECOGNITION_CANDIDATE_MIN_REVIEWERS = 5;
 export const ICON_RECOGNITION_RELEASE_ACCURACY = 0.9;

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/critique-board.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/critique-board.test.ts
@@ -44,7 +44,7 @@ function profile(
     ...result,
     profileId,
     viewportWidth: profileId === "compact-320" ? 320 : 768,
-    tileSize: profileId === "compact-320" ? 36 : 72,
+    tileSize: profileId === "compact-320" ? 44 : 72,
     width: profileId === "compact-320" ? 320 : 768,
     height: 120,
     wrappedRows: 1,

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/critique-pictogram.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/critique-pictogram.test.ts
@@ -75,7 +75,7 @@ describe("rendered pictogram recognition consensus", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("rejects an icon that works at 72px but fails at compact 36px", () => {
+  it("rejects an icon that works at 72px but fails at compact 44px", () => {
     const large = evaluateRecognitionConsensus({
       concept: "car",
       judgments: [judgment("vision-a", "car", 0.94), judgment("vision-b", "car", 0.9)],
@@ -90,14 +90,14 @@ describe("rendered pictogram recognition consensus", () => {
     });
     const result = evaluateRecognitionProfiles({
       profileResults: [
-        { ...compact, tileSize: 36 },
+        { ...compact, tileSize: 44 },
         { ...large, tileSize: 72 },
       ],
-      expectedTileSizes: [36, 72],
+      expectedTileSizes: [44, 72],
     });
 
     expect(result.ok).toBe(false);
-    expect(result.redrawAdvice).toContain("36px");
+    expect(result.redrawAdvice).toContain("44px");
   });
 
   it("fails closed when a required player size was not tested", () => {
@@ -109,11 +109,11 @@ describe("rendered pictogram recognition consensus", () => {
     });
     const result = evaluateRecognitionProfiles({
       profileResults: [{ ...large, tileSize: 72 }],
-      expectedTileSizes: [36, 72],
+      expectedTileSizes: [44, 72],
     });
 
     expect(result.ok).toBe(false);
-    expect(result.redrawAdvice).toContain("Missing tests at 36px");
+    expect(result.redrawAdvice).toContain("Missing tests at 44px");
   });
 
   it("preserves per-model failures across player sizes for diagnosis", () => {
@@ -127,14 +127,14 @@ describe("rendered pictogram recognition consensus", () => {
       profileResults: [
         {
           ...failed,
-          tileSize: 36,
+          tileSize: 44,
           judgeErrors: [{ model: "vision-a", error: "model access denied" }],
         },
       ],
-      expectedTileSizes: [36, 72],
+      expectedTileSizes: [44, 72],
     });
 
     expect(result.ok).toBe(false);
-    expect(result.judgeErrors).toEqual([{ model: "vision-a@36px", error: "model access denied" }]);
+    expect(result.judgeErrors).toEqual([{ model: "vision-a@44px", error: "model access denied" }]);
   });
 });

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/generate-pictogram-registry.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/generate-pictogram-registry.test.ts
@@ -27,7 +27,7 @@ function recognition(ok = true, seenLabel = "lighthouse") {
     judges: [],
     profileResults: [
       {
-        tileSize: 36,
+        tileSize: 44,
         ok,
         seenLabel,
         confidence: ok ? 0.94 : 0.2,

--- a/apps/web/src/ai/puzzle-agent/visual/__tests__/pictogram-pixel-integrity.test.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/__tests__/pictogram-pixel-integrity.test.ts
@@ -2,7 +2,7 @@ import { listCuratedPictogramIds, resolveCuratedPictogram } from "../curated-pic
 import { evaluatePictogramPixelIntegrity } from "../pictogram-pixel-integrity";
 
 describe("player-sized pictogram pixel integrity", () => {
-  it("accepts every publication catalog asset at 36px and 72px", async () => {
+  it("accepts every publication catalog asset at live player tile sizes", async () => {
     const failures: Array<{ id: string; reasons: string[] }> = [];
     for (const id of listCuratedPictogramIds()) {
       const result = await evaluatePictogramPixelIntegrity(resolveCuratedPictogram(id)!.svg);

--- a/apps/web/src/ai/puzzle-agent/visual/critique-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/critique-pictogram.ts
@@ -3,6 +3,7 @@
 import { z } from "zod";
 import { generateAIObjectFromImage } from "@/ai/client";
 import { AI_CONFIG } from "@/ai/config";
+import { PLAYER_ICON_GATE_SIZES } from "./presentation";
 import { rasterizePictogramForRecognition } from "./rasterize-pictogram";
 import {
   evaluateRecognitionConsensus,
@@ -11,7 +12,7 @@ import {
   type IconRecognitionResult,
 } from "./recognition-consensus";
 
-const ICON_PLAYER_SIZES = [36, 72] as const;
+const ICON_PLAYER_SIZES = PLAYER_ICON_GATE_SIZES;
 
 const IconRecognitionSchema = z.object({
   seenLabel: z.string().min(1).max(48).describe("Concrete object name you see, or 'unclear'"),
@@ -82,8 +83,8 @@ Do not infer the creator's intent and do not invent missing details.`,
 }
 
 /**
- * Require independent recognition at both compact (36px) and large (72px)
- * player sizes. An unavailable size or judge is a publication failure.
+ * Require independent recognition at every production player tile size
+ * (compact + large). An unavailable size or judge is a publication failure.
  */
 export async function recognizePictogramIcon(input: {
   svg: string;

--- a/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/generate-pictogram.ts
@@ -336,7 +336,9 @@ export async function generatePictogram(
     const clarity = scorePictogramClarity(curated.svg);
     const pixelIntegrity = await evaluatePictogramPixelIntegrity(curated.svg);
     lastPixelIntegrity = pixelIntegrity;
-    if (clarity.ok && pixelIntegrity.ok && (input.skipRecognition || usage === "publication")) {
+    // Publication must still prove blind recognition at player sizes.
+    // Only explicit skipRecognition (tests / offline tools) bypasses judges.
+    if (clarity.ok && pixelIntegrity.ok && input.skipRecognition) {
       return {
         styleId: INK_PICTOGRAM_STYLE_ID,
         concept,

--- a/apps/web/src/ai/puzzle-agent/visual/pictogram-pixel-integrity.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/pictogram-pixel-integrity.ts
@@ -1,8 +1,9 @@
 import sharp from "sharp";
+import { PLAYER_ICON_GATE_SIZES } from "./presentation";
 import { PICTOGRAM_CANVAS, rasterizePictogramAtPlayerSize } from "./rasterize-pictogram";
 
-export const PICTOGRAM_PIXEL_INTEGRITY_VERSION = "pictogram-pixels-v1";
-export const PICTOGRAM_PIXEL_INTEGRITY_SIZES = [36, 72] as const;
+export const PICTOGRAM_PIXEL_INTEGRITY_VERSION = "pictogram-pixels-v2";
+export const PICTOGRAM_PIXEL_INTEGRITY_SIZES = PLAYER_ICON_GATE_SIZES;
 
 const REQUIRED_CONTRAST = 3;
 const MIN_FOREGROUND_RATIO = 0.06;

--- a/apps/web/src/ai/puzzle-agent/visual/presentation.ts
+++ b/apps/web/src/ai/puzzle-agent/visual/presentation.ts
@@ -13,6 +13,18 @@ export const PUZZLE_BOARD_SIZE_SPECS: Record<PuzzleBoardSize, PuzzleBoardSizeSpe
   large: { tile: 72, fontSize: 44, gap: 12 },
 };
 
+/**
+ * Exact player tile sizes used for icon pixel integrity, blind naming,
+ * human panels, and publish evidence. Always derived from the board specs
+ * so compact/desktop gates match the React player.
+ */
+export const PLAYER_ICON_GATE_SIZES = [
+  PUZZLE_BOARD_SIZE_SPECS.small.tile,
+  PUZZLE_BOARD_SIZE_SPECS.large.tile,
+] as const;
+
+export type PlayerIconGateSize = (typeof PLAYER_ICON_GATE_SIZES)[number];
+
 export const PUZZLE_BOARD_RECOGNITION_PROFILES = [
   {
     id: "compact-320",

--- a/apps/web/src/app/actions/puzzleGenerationActions.ts
+++ b/apps/web/src/app/actions/puzzleGenerationActions.ts
@@ -9,6 +9,7 @@ import {
   recordGenerationAudit,
   resolveAdaptiveDifficultyForDate,
 } from "@/ai/learning";
+import { loadHumanCalibrationGate } from "@/ai/learning/human-calibration-gate";
 import { selectMongoReservePuzzle } from "@/ai/puzzle-agent/mongo-reserve-puzzles";
 import { db } from "@/db";
 import { getCachedDailyPuzzleFromDb } from "@/lib/cache/daily-puzzle";
@@ -182,19 +183,46 @@ async function getOrGenerateDailyPuzzle(
     });
   }
 
-  if (qualityDrift?.shouldUseReserve) {
+  let humanCalibration: Awaited<ReturnType<typeof loadHumanCalibrationGate>> | null = null;
+  try {
+    humanCalibration = await loadHumanCalibrationGate();
+  } catch (error) {
+    logger.warn("Human calibration telemetry unavailable; retaining automated fail-closed gates", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const reserveReason = qualityDrift?.shouldUseReserve
+    ? ("Quality SLO circuit breaker" as const)
+    : humanCalibration?.shouldUseReserve
+      ? ("Human calibration circuit breaker" as const)
+      : null;
+
+  if (reserveReason) {
     const puzzleDate = new Date(`${dateString}T00:00:00Z`);
     difficultyPlan = await calculateDailyDifficulty(puzzleDate);
-    logger.warn("Quality SLO circuit breaker halted AI puzzle generation", {
+    logger.warn("Publication circuit breaker halted AI puzzle generation", {
       dateString,
-      contractVersion: qualityDrift.version,
-      status: qualityDrift.status,
-      criticalMetrics: qualityDrift.metrics
-        .filter((metric) => metric.status === "critical")
-        .map((metric) => metric.id),
+      reason: reserveReason,
+      qualityDrift: qualityDrift
+        ? {
+            contractVersion: qualityDrift.version,
+            status: qualityDrift.status,
+            criticalMetrics: qualityDrift.metrics
+              .filter((metric) => metric.status === "critical")
+              .map((metric) => metric.id),
+          }
+        : null,
+      humanCalibration: humanCalibration
+        ? {
+            contractVersion: humanCalibration.version,
+            status: humanCalibration.status,
+            reasons: humanCalibration.reasons.slice(0, 5),
+          }
+        : null,
     });
 
-    const reserve = await persistReservePuzzle(dateString, "Quality SLO circuit breaker");
+    const reserve = await persistReservePuzzle(dateString, reserveReason);
     void recordGenerationAudit({
       dateString,
       puzzleId: reserve.id,
@@ -207,7 +235,10 @@ async function getOrGenerateDailyPuzzle(
       learningReason: difficultyPlan.reason,
       answerKey: normalizeAnswerKey(reserve.answer),
       durationMs: Date.now() - genStarted,
-      error: qualityDrift.recommendation,
+      error:
+        reserveReason === "Quality SLO circuit breaker"
+          ? qualityDrift!.recommendation
+          : humanCalibration!.reasons.join(" · "),
     });
     return reserve;
   }

--- a/apps/web/src/db/models.ts
+++ b/apps/web/src/db/models.ts
@@ -1036,7 +1036,7 @@ export interface IconRecognitionReview {
   fixtureId: string;
   assetId: string;
   conceptId: string;
-  sizePx: 36 | 72;
+  sizePx: number;
   reviewerId: string;
   rawGuess: string;
   normalizedGuess: string;
@@ -1076,8 +1076,12 @@ export interface GeneratedPictogramCandidate {
   };
   humanEvidence?: {
     requiredReviewersPerSize: number;
+    /** Compact player-tile evidence (legacy key; tile may be 44px). */
     size36: { decisions: number; correct: number };
+    /** Large player-tile evidence. */
     size72: { decisions: number; correct: number };
+    compactTilePx?: number;
+    largeTilePx?: number;
   };
   auditHistory: GeneratedPictogramAuditEvent[];
   createdAt: Date;
@@ -1091,7 +1095,7 @@ export interface GeneratedPictogramReview {
   registryVersion: string;
   candidateId: string;
   fixtureId: string;
-  sizePx: 36 | 72;
+  sizePx: number;
   reviewerId: string;
   rawGuess: string;
   normalizedGuess: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Audited the live Apex/Eve publish stack against `PUZZLE_GENERATOR_V2.md`, then closed the highest-leverage remaining gaps for recognizable, fair, diverse, playable generation.

### Research / architecture
Existing V2 contract already encodes SOTA direction (ISO 9186 symbol testing, REBUS/VLM limits, Wilson/pigeonhole human evidence, catalog-first assets, screenshot-only blind solve). The gap was enforcement honesty, not a greenfield rewrite.

### Implemented now
1. **Player-size honesty** — `PLAYER_ICON_GATE_SIZES` derived from board presentation (compact **44px** + large **72px**) for pixel integrity, blind naming, human panels, generated-asset registry, and publish evidence.
2. **Catalog recognition on AI publish** — curated icons no longer skip blind naming; AI publish requires recognition profiles. Offline reserve/static audits keep catalog authenticity without spending vision judges.
3. **Human calibration breaker** — `human-calibration-gate-v1` forces daily reserve when fully covered icon-panel or playtest release cohorts fail. Collecting samples stay watch/insufficient.

### Validation
- Jest: **87 passed** across quality, recognition, registry, human-calibration, benchmarks
- `pnpm --filter @rebuzzle/web benchmark:puzzles:static` → **promotion=true** (93/93 puzzles, 279/279 profiles, 47/47 assets)

### Still outstanding (Stage 4)
- Technique-family difficulty from human solve rates (demote hint-aware text self-test)
- Progressive-hint vision pass after blind solve
- Larger editorial corpora toward 150+/100- failure market target

### Docs
- `PUZZLE_GENERATOR_V2.md` and `HUMAN_ICON_RECOGNITION.md` updated for the 44/72 contract and human breaker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

