### PR TITLE
fix(web): show header nav links on the home/play page

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -62,20 +62,18 @@ export default function Header({ nextPlayTime, puzzleType, gameState }: HeaderPr
               Rebuzzle
             </Link>
 
-            {/* Keep marketing nav off the play surface — app-like focus */}
-            {!isPlaying && (
-              <nav className="hidden items-center gap-1 md:flex">
-                {NAV_LINKS.map((link) => (
-                  <Link
-                    className="rounded-md px-2.5 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground"
-                    href={link.href}
-                    key={link.href}
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-              </nav>
-            )}
+            {/* Always show site nav — home starts a game which used to hide these */}
+            <nav className="hidden items-center gap-1 md:flex">
+              {NAV_LINKS.map((link) => (
+                <Link
+                  className="rounded-md px-2.5 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground"
+                  href={link.href}
+                  key={link.href}
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
           </div>
 
           <div className="flex items-center gap-1.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On `/`, Leaderboard / Achievements / How it works / Blog disappeared from the header once the daily puzzle started. Those same links showed on logged-in account pages.

## Cause

`Header` gated the marketing nav on `!isPlaying`. The home page mounts `GameBoard`, which calls `startGame()` and sets `isPlaying: true`. Account routes never start a game, so the nav stayed visible there.

## Fix

Always render the site nav links in the header. The difficulty / attempts status rail remains play-gated.

## Test plan

- [ ] Open `/` (desktop width ≥ md): nav links visible next to Rebuzzle while the puzzle is active
- [ ] Open an account page: nav links still present
- [ ] Confirm difficulty badge / attempts still appear in the status rail during play
- [ ] Narrow viewport: nav remains `hidden` below `md` (unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

