### PR TITLE
fix(web): smoother completion beat with confetti, Eve close, and streak hooks

### DIFF
--- a/apps/web/src/app/api/puzzles/guess/route.ts
+++ b/apps/web/src/app/api/puzzles/guess/route.ts
@@ -53,6 +53,8 @@ export async function POST(request: Request) {
         guess?: string;
         timeSpentSeconds?: number;
         hintsUsed?: number;
+        /** Prior consecutive cold misses this session (for sharper Eve lines). */
+        consecutiveCold?: number;
       }>,
     ]);
 
@@ -227,9 +229,58 @@ export async function POST(request: Request) {
       );
     }
 
+    // Award wins before responding so the client can whisper the unlock in-thread.
+    let unlockedAchievement: { name: string } | undefined;
+    let unlockedForEmail: Awaited<
+      ReturnType<(typeof import("@/lib/achievements/service"))["checkAndAwardAchievements"]>
+    >["newlyUnlocked"] = [];
+
+    if (isFinal && isCorrect) {
+      try {
+        await updateUserStats(user.userId, {
+          won: true,
+          attempts: attemptNumber,
+          timeSpent: timeSpentSeconds,
+          difficulty: difficultyLevel,
+          maxAttempts,
+          hintsUsed,
+          pointsMultiplier,
+          affectsStreak: !isArchive,
+        });
+
+        const stats = await db.userStatsOps.findByUserId(user.userId);
+        const score = Math.floor(
+          calculateGamePoints(
+            attemptNumber,
+            timeSpentSeconds,
+            stats?.streak ?? 1,
+            difficultyLevel
+          ) * pointsMultiplier
+        );
+        const { checkAndAwardAchievements } = await import("@/lib/achievements/service");
+        const { newlyUnlocked } = await checkAndAwardAchievements(user.userId, {
+          puzzleId: puzzle.id,
+          attempts: attemptNumber,
+          maxAttempts,
+          timeTaken: timeSpentSeconds,
+          hintsUsed,
+          difficulty: getAchievementDifficultyCategory(difficultyLevel),
+          isCorrect: true,
+          score,
+        });
+        unlockedForEmail = newlyUnlocked;
+        if (newlyUnlocked[0]?.name) {
+          unlockedAchievement = { name: newlyUnlocked[0].name };
+        }
+      } catch (error) {
+        console.error("[guess] sync win update failed:", error);
+      }
+    }
+
     if (isFinal) {
       const uid = user.userId;
       const pid = puzzle.id;
+      const emailUnlocks = unlockedForEmail;
       after(async () => {
         try {
           // Self-learning pulse — fast solves raise tomorrow's difficulty
@@ -244,60 +295,40 @@ export async function POST(request: Request) {
             isArchive,
           });
 
-          await updateUserStats(uid, {
-            won: isCorrect,
-            attempts: attemptNumber,
-            timeSpent: timeSpentSeconds,
-            difficulty: difficultyLevel,
-            maxAttempts,
-            hintsUsed,
-            pointsMultiplier,
-            affectsStreak: !isArchive,
-          });
-
-          if (isCorrect) {
-            const stats = await db.userStatsOps.findByUserId(uid);
-            const score = Math.floor(
-              calculateGamePoints(
-                attemptNumber,
-                timeSpentSeconds,
-                stats?.streak ?? 1,
-                difficultyLevel
-              ) * pointsMultiplier
-            );
-            const { checkAndAwardAchievements } = await import("@/lib/achievements/service");
-            const { newlyUnlocked } = await checkAndAwardAchievements(uid, {
-              puzzleId: pid,
+          // Wins already updated stats above; losses still need the streak reset.
+          if (!isCorrect) {
+            await updateUserStats(uid, {
+              won: false,
               attempts: attemptNumber,
+              timeSpent: timeSpentSeconds,
+              difficulty: difficultyLevel,
               maxAttempts,
-              timeTaken: timeSpentSeconds,
               hintsUsed,
-              difficulty: getAchievementDifficultyCategory(difficultyLevel),
-              isCorrect: true,
-              score,
+              pointsMultiplier,
+              affectsStreak: !isArchive,
             });
+          }
 
-            // Email non-guest users about freshly unlocked badges (Resend)
-            if (newlyUnlocked.length > 0) {
-              const dbUser = await db.userOps.findById(uid);
-              if (dbUser && !dbUser.isGuest && dbUser.email) {
-                const { getUserAchievementProgress } = await import("@/lib/achievements/service");
-                const { sendAchievementUnlockedEmail } = await import(
-                  "@/lib/notifications/email-service"
-                );
-                const progress = await getUserAchievementProgress(uid);
-                for (const achievement of newlyUnlocked.slice(0, 3)) {
-                  await sendAchievementUnlockedEmail(dbUser.email, {
-                    username: dbUser.username,
-                    achievementName: achievement.name,
-                    achievementDescription: achievement.description,
-                    achievementRarity: achievement.rarity,
-                    achievementPoints: achievement.points,
-                    achievementIcon: achievement.icon,
-                    totalUnlocked: progress.unlocked,
-                    totalAchievements: progress.total,
-                  });
-                }
+          // Email non-guest users about freshly unlocked badges (Resend)
+          if (isCorrect && emailUnlocks.length > 0) {
+            const dbUser = await db.userOps.findById(uid);
+            if (dbUser && !dbUser.isGuest && dbUser.email) {
+              const { getUserAchievementProgress } = await import("@/lib/achievements/service");
+              const { sendAchievementUnlockedEmail } = await import(
+                "@/lib/notifications/email-service"
+              );
+              const progress = await getUserAchievementProgress(uid);
+              for (const achievement of emailUnlocks.slice(0, 3)) {
+                await sendAchievementUnlockedEmail(dbUser.email, {
+                  username: dbUser.username,
+                  achievementName: achievement.name,
+                  achievementDescription: achievement.description,
+                  achievementRarity: achievement.rarity,
+                  achievementPoints: achievement.points,
+                  achievementIcon: achievement.icon,
+                  totalUnlocked: progress.unlocked,
+                  totalAchievements: progress.total,
+                });
               }
             }
           }
@@ -308,6 +339,10 @@ export async function POST(request: Request) {
     }
 
     const similarity = Math.round((validation.confidence ?? 0) * 100);
+    const consecutiveCold =
+      typeof body.consecutiveCold === "number" && body.consecutiveCold > 0
+        ? Math.min(Math.floor(body.consecutiveCold), 10)
+        : 0;
 
     return NextResponse.json({
       success: true,
@@ -320,6 +355,7 @@ export async function POST(request: Request) {
         similarity,
         attemptsLeft,
         guess,
+        consecutiveCold,
       }),
       method: validation.method,
       attemptNumber,
@@ -336,6 +372,7 @@ export async function POST(request: Request) {
             explanation: puzzle.explanation || "",
             pointsEarned,
             wasSuccessful: isCorrect,
+            ...(unlockedAchievement ? { unlockedAchievement } : {}),
           }
         : {}),
     });

--- a/apps/web/src/app/api/puzzles/quip/route.ts
+++ b/apps/web/src/app/api/puzzles/quip/route.ts
@@ -21,18 +21,28 @@ import { getAuthenticatedUser } from "@/lib/auth-middleware";
 import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
 import { getUserKey, rateLimit } from "@/lib/middleware/rate-limit";
 
-/** Mid-game tiers only — win/loss use the deterministic reaction line (no AI). */
+/** Mid-game tiers only while the day is still open. */
 const MID_GAME_TIERS = ["close", "warm", "cold"] as const;
-type MidGameTier = (typeof MID_GAME_TIERS)[number];
+/** Final tiers allowed even after today's attempt is written. */
+const FINAL_TIERS = ["correct", "out"] as const;
+const ALL_TIERS = [...MID_GAME_TIERS, ...FINAL_TIERS] as const;
 
-const TIER_BRIEF: Record<MidGameTier, string> = {
+type QuipTier = (typeof ALL_TIERS)[number];
+
+const TIER_BRIEF: Record<QuipTier, string> = {
   close: "They are one small step away. Say so without hinting at what to change.",
   warm: "Part of their thinking is on track. Acknowledge it, don't guide it.",
   cold: "They are nowhere near. Be funny about the distance, never about them.",
+  correct: "They solved it. Celebrate briefly — never restate or hint at the answer.",
+  out: "They are out of guesses. Empathize briefly — never reveal or hint at the answer.",
 };
 
-function isMidGameTier(value: unknown): value is MidGameTier {
-  return typeof value === "string" && (MID_GAME_TIERS as readonly string[]).includes(value);
+function isQuipTier(value: unknown): value is QuipTier {
+  return typeof value === "string" && (ALL_TIERS as readonly string[]).includes(value);
+}
+
+function isFinalTier(tier: QuipTier): boolean {
+  return (FINAL_TIERS as readonly string[]).includes(tier);
 }
 
 const SYSTEM = `You are Eve, the author of Rebuzzle's daily puzzle, reacting to a player's guess.
@@ -86,18 +96,18 @@ export async function POST(request: Request) {
 
     const puzzleId = typeof body.puzzleId === "string" ? body.puzzleId.trim() : "";
     const guess = typeof body.guess === "string" ? body.guess.trim().slice(0, 200) : "";
-    const tier = isMidGameTier(body.tier) ? body.tier : null;
+    const tier = isQuipTier(body.tier) ? body.tier : null;
 
     if (!(puzzleId && guess && tier)) {
       return NextResponse.json(
-        { success: false, error: "puzzleId, guess and a mid-game tier are required" },
+        { success: false, error: "puzzleId, guess and a valid reaction tier are required" },
         { status: 400 }
       );
     }
 
-    // Day already locked — refuse further AI spend.
+    // Day already locked — only the closing win/loss riff may still spend credits.
     const lock = await db.puzzleAttemptOps.hasTodayAttempt(user.userId, getUtcPuzzleDate());
-    if (lock.hasAttempt) {
+    if (lock.hasAttempt && !isFinalTier(tier)) {
       return NextResponse.json(
         { success: false, error: "Puzzle already finished for today" },
         { status: 409 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1027,6 +1027,32 @@
   animation: lock-seat 280ms var(--ease) both;
 }
 
+/* Near-level flicker — only when within ~15% of the next level. */
+.level-rim {
+  position: relative;
+  overflow: hidden;
+}
+
+.level-rim::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--level-progress, 85%);
+  background: hsl(var(--warning) / 0.75);
+  animation: level-flicker 1.4s var(--ease) infinite;
+}
+
+@keyframes level-flicker {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
 @keyframes lock-seat {
   from {
     transform: scale(0.88);
@@ -1045,7 +1071,8 @@
   .reaction-heat-bubble,
   .heart-fragile,
   .streak-lock-in,
-  .chat-lock-icon {
+  .chat-lock-icon,
+  .level-rim::after {
     animation: none !important;
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -955,8 +955,97 @@
   animation: message-in 420ms var(--ease) both;
 }
 
+/* Near-miss "heat" — one pulse so almost-there is felt, not only read. */
+.reaction-heat [data-tone-dot] {
+  animation: heat-pulse 420ms var(--ease) 1;
+}
+
+.reaction-heat-bubble {
+  animation: heat-border 420ms var(--ease) 1;
+}
+
+@keyframes heat-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  40% {
+    transform: scale(1.55);
+    opacity: 1;
+  }
+}
+
+@keyframes heat-border {
+  0%,
+  100% {
+    border-color: hsl(var(--warning) / 0.3);
+  }
+
+  40% {
+    border-color: hsl(var(--warning) / 0.7);
+  }
+}
+
+/* Last heart scarcity — soft breathe, not urgent blink. */
+.heart-fragile {
+  animation: heart-breathe 1.7s var(--ease) infinite;
+}
+
+@keyframes heart-breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.55;
+  }
+}
+
+/* Streak digit lock-in after points settle. */
+.streak-lock-in {
+  animation: streak-pop 420ms var(--ease) 1;
+}
+
+@keyframes streak-pop {
+  0% {
+    transform: scale(1);
+  }
+
+  45% {
+    transform: scale(1.1);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+.chat-lock-icon {
+  animation: lock-seat 280ms var(--ease) both;
+}
+
+@keyframes lock-seat {
+  from {
+    transform: scale(0.88);
+    opacity: 0.5;
+  }
+
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .solve-result-card {
+  .solve-result-card,
+  .reaction-heat [data-tone-dot],
+  .reaction-heat-bubble,
+  .heart-fragile,
+  .streak-lock-in,
+  .chat-lock-icon {
     animation: none !important;
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -698,6 +698,29 @@
   );
 }
 
+/* Answer bar ↔ closing / locked dock: soft lift instead of a hard cut. */
+.play-dock-panel {
+  animation: dock-in 280ms var(--ease) both;
+}
+
+@keyframes dock-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .play-dock-panel {
+    animation: none !important;
+  }
+}
+
 /*
  * The answer bar. A single hairline field that lifts on focus — a crisp edge
  * plus a soft halo, matching the global focus treatment, so it reads as

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { connection } from "next/server";
 import { Suspense } from "react";
+import { AlreadyPlayedPanel } from "@/components/AlreadyPlayedPanel";
 import GameBoard from "@/components/GameBoard";
 import Layout from "@/components/Layout";
 import { HomePageSkeleton } from "@/components/page-skeletons";
@@ -145,25 +146,12 @@ function NoPuzzleDisplay() {
 }
 
 /**
- * Puzzle already attempted component - shows when user has completed or failed today's puzzle
+ * Puzzle already attempted — soft landing that echoes the in-thread result beat.
  */
 function PuzzleAlreadyAttemptedDisplay({ wasSuccessful }: { wasSuccessful: boolean }) {
   return (
     <Layout>
-      <StatusPanel
-        action={{
-          href: wasSuccessful ? "/game-over?success=true" : "/game-over?success=false",
-          label: "View results",
-        }}
-        eyebrow={wasSuccessful ? "Solved" : "Attempted"}
-        headingId="puzzle-attempted-title"
-        secondaryAction={{ href: "/leaderboard", label: "Check the leaderboard" }}
-        title={wasSuccessful ? "You solved today's puzzle." : "You've used today's attempt."}
-      >
-        {wasSuccessful
-          ? "Nicely done. A new puzzle lands at midnight."
-          : "One puzzle a day, one shot at it. A new puzzle lands at midnight."}
-      </StatusPanel>
+      <AlreadyPlayedPanel wasSuccessful={wasSuccessful} />
     </Layout>
   );
 }

--- a/apps/web/src/components/AlreadyPlayedPanel.tsx
+++ b/apps/web/src/components/AlreadyPlayedPanel.tsx
@@ -108,6 +108,12 @@ export function AlreadyPlayedPanel({ wasSuccessful }: AlreadyPlayedPanelProps) {
           </Link>
           <Link
             className="text-center text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href="/blog"
+          >
+            Yesterday’s aha →
+          </Link>
+          <Link
+            className="text-center text-muted-foreground text-sm transition-colors hover:text-foreground"
             href="/leaderboard"
           >
             Check the leaderboard

--- a/apps/web/src/components/AlreadyPlayedPanel.tsx
+++ b/apps/web/src/components/AlreadyPlayedPanel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Timer } from "@/components/Timer";
+import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getStreakTease } from "@/lib/game/streak-tease";
+import { cn } from "@/lib/utils";
+
+interface AlreadyPlayedPanelProps {
+  wasSuccessful: boolean;
+}
+
+interface StoredCompletion {
+  streak?: number;
+  score?: number;
+}
+
+interface StoredSolution {
+  answer?: string;
+}
+
+/**
+ * Soft revisit landing after today's attempt — echoes the in-thread result
+ * language instead of a hard-cut status page.
+ */
+export function AlreadyPlayedPanel({ wasSuccessful }: AlreadyPlayedPanelProps) {
+  const [streak, setStreak] = useState(0);
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [eveLine, setEveLine] = useState<string | null>(null);
+  const [nextPlayTime] = useState(() => getNextUtcMidnight());
+
+  useEffect(() => {
+    try {
+      const completionRaw = localStorage.getItem("lastGameCompletion");
+      if (completionRaw) {
+        const completion = JSON.parse(completionRaw) as StoredCompletion;
+        if (typeof completion.streak === "number") {
+          setStreak(completion.streak);
+        }
+      }
+      const solutionRaw = localStorage.getItem("lastGameSolution");
+      if (solutionRaw) {
+        const solution = JSON.parse(solutionRaw) as StoredSolution;
+        if (typeof solution.answer === "string" && solution.answer.trim()) {
+          setAnswer(solution.answer.trim());
+        }
+      }
+      const eveRaw = localStorage.getItem("lastEveClosingLine");
+      if (typeof eveRaw === "string" && eveRaw.trim()) {
+        setEveLine(eveRaw.trim());
+      }
+    } catch {
+      // Ignore corrupt local storage — panel still works without extras.
+    }
+  }, []);
+
+  const tease = getStreakTease(wasSuccessful ? streak : 0, wasSuccessful);
+  const resultsHref = wasSuccessful ? "/game-over?success=true" : "/game-over?success=false";
+
+  return (
+    <div className="mx-auto flex max-w-page items-center justify-center px-4 py-16 md:px-6 md:py-24">
+      <div
+        className={cn(
+          "w-full max-w-md rounded-2xl border p-6 text-left shadow-lg sm:p-8",
+          wasSuccessful ? "border-success/30 bg-success/[0.06]" : "border-border bg-card"
+        )}
+        role="status"
+      >
+        <p className="eyebrow">{wasSuccessful ? "Solved" : "Day locked"}</p>
+        <h1
+          className="mt-3 text-balance font-semibold text-2xl text-foreground tracking-[-0.04em]"
+          id="puzzle-attempted-title"
+        >
+          {wasSuccessful ? "You already solved today." : "You've used today's attempt."}
+        </h1>
+        <p className="mt-3 text-balance text-muted-foreground text-sm leading-6">{tease}</p>
+
+        {eveLine ? (
+          <p className="mt-4 rounded-xl border border-border/70 bg-background/60 px-3.5 py-3 text-muted-foreground text-sm leading-6">
+            <span className="font-medium text-foreground">Eve · </span>
+            {eveLine}
+          </p>
+        ) : null}
+
+        {!wasSuccessful && answer ? (
+          <div className="mt-4 rounded-xl border border-border/70 bg-background/70 px-3.5 py-3">
+            <p className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">Answer</p>
+            <p className="mt-1 font-semibold text-foreground text-lg tracking-tight">{answer}</p>
+          </div>
+        ) : null}
+
+        <div className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/40 px-3 py-2.5">
+          <p className="text-muted-foreground text-xs">Next puzzle</p>
+          <Timer
+            className="font-mono text-foreground text-xs tabular-nums"
+            compact
+            nextPlayTime={nextPlayTime}
+          />
+        </div>
+
+        <div className="mt-7 flex flex-col items-stretch gap-3">
+          <Link
+            className="inline-flex h-10 items-center justify-center rounded-md bg-foreground px-4 font-medium text-background text-sm transition-opacity hover:opacity-90"
+            href={resultsHref}
+          >
+            {wasSuccessful ? "View results" : "Full results"}
+          </Link>
+          <Link
+            className="text-center text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href="/leaderboard"
+          >
+            Check the leaderboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/AttemptsIndicator.tsx
+++ b/apps/web/src/components/AttemptsIndicator.tsx
@@ -33,12 +33,12 @@ export function AttemptsIndicator({
   const remainingAttempts = maxAttempts - currentAttempts;
   const isLastAttempt = remainingAttempts === 1;
 
-  // Animate heart break when attempts increase
+  // Animate heart break when attempts increase (haptics live on the guess path —
+  // keep this visual-only so we don't double-buzz).
   useEffect(() => {
     if (animateOnChange && currentAttempts > prevAttempts) {
       const brokenHeartIndex = maxAttempts - currentAttempts;
       setAnimatingIndex(brokenHeartIndex);
-      haptics.error();
 
       const timeout = setTimeout(() => {
         setAnimatingIndex(null);
@@ -50,7 +50,7 @@ export function AttemptsIndicator({
     setPrevAttempts(currentAttempts);
   }, [currentAttempts, prevAttempts, maxAttempts, animateOnChange]);
 
-  // Warning haptic on last attempt
+  // One soft warning when the last heart becomes fragile.
   useEffect(() => {
     if (isLastAttempt && currentAttempts > 0) {
       haptics.warning();
@@ -59,7 +59,7 @@ export function AttemptsIndicator({
 
   const getTooltipText = () => {
     if (remainingAttempts === 0) return "No attempts remaining";
-    if (isLastAttempt) return "Last attempt! Be careful";
+    if (isLastAttempt) return "Last attempt — make it count";
     return `${remainingAttempts} attempts remaining`;
   };
 
@@ -82,7 +82,7 @@ export function AttemptsIndicator({
                     aria-hidden="true"
                     className={cn(
                       "h-3.5 w-3.5 transition-all duration-300",
-                      isFilled && isLastAttempt && "fill-destructive text-destructive",
+                      isFilled && isLastAttempt && "heart-fragile fill-destructive text-destructive",
                       isFilled && !isLastAttempt && "fill-foreground text-foreground",
                       !isFilled && "fill-transparent text-border-strong/50",
                       isAnimating && "scale-125"

--- a/apps/web/src/components/ChatClosingDock.tsx
+++ b/apps/web/src/components/ChatClosingDock.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { MessageTyping } from "@/components/ui/message";
+import { cn } from "@/lib/utils";
+
+interface ChatClosingDockProps {
+  success: boolean;
+  className?: string;
+}
+
+/**
+ * Fills the post-solve limbo while Eve's closing riff streams —
+ * so the answer bar never sits empty and muted.
+ */
+export function ChatClosingDock({ success, className }: ChatClosingDockProps) {
+  return (
+    <div className={cn("play-dock-panel w-full", className)}>
+      <div className="flex items-center gap-3 rounded-2xl border border-border bg-muted/40 px-4 py-3.5">
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-foreground text-sm">Eve is finishing…</p>
+          <p className="truncate text-muted-foreground text-xs">
+            {success
+              ? "One last line — then the day locks."
+              : "One last line — then you'll see the answer."}
+          </p>
+        </div>
+        <MessageTyping className="shrink-0" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ChatLockedDock.tsx
+++ b/apps/web/src/components/ChatLockedDock.tsx
@@ -1,23 +1,22 @@
 "use client";
 
 import { Lock } from "lucide-react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { Timer } from "@/components/Timer";
 import { cn } from "@/lib/utils";
 
 interface ChatLockedDockProps {
   success: boolean;
-  resultsHref: string;
+  nextPlayTime?: Date | null;
   className?: string;
 }
 
 /**
- * Replaces the answer bar once the day is locked and Eve's closing
- * riff has landed (or timed out), so the conversation clearly ends.
+ * Status-only dock after Eve's closing riff. Results / answer live on the
+ * SolveResultCard so there's a single primary CTA in the completion beat.
  */
-export function ChatLockedDock({ success, resultsHref, className }: ChatLockedDockProps) {
+export function ChatLockedDock({ success, nextPlayTime = null, className }: ChatLockedDockProps) {
   return (
-    <div className={cn("w-full", className)}>
+    <div className={cn("play-dock-panel w-full", className)}>
       <div className="flex items-center gap-3 rounded-2xl border border-border bg-muted/40 px-4 py-3.5">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground">
           <Lock className="h-4 w-4" />
@@ -27,12 +26,14 @@ export function ChatLockedDock({ success, resultsHref, className }: ChatLockedDo
             {success ? "Chat locked · puzzle solved" : "Chat locked · day over"}
           </p>
           <p className="truncate text-muted-foreground text-xs">
-            Come back after UTC midnight for tomorrow’s puzzle.
+            Come back after UTC midnight for tomorrow's puzzle.
           </p>
         </div>
-        <Button asChild className="shrink-0" size="sm" variant="outline">
-          <Link href={resultsHref}>{success ? "Results" : "Answer"}</Link>
-        </Button>
+        <Timer
+          className="shrink-0 font-mono text-foreground text-xs tabular-nums"
+          compact
+          nextPlayTime={nextPlayTime}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/ChatLockedDock.tsx
+++ b/apps/web/src/components/ChatLockedDock.tsx
@@ -12,8 +12,8 @@ interface ChatLockedDockProps {
 }
 
 /**
- * Replaces the answer bar once the day is locked so it is obvious
- * the conversation is closed (and AI quips cannot be requested again).
+ * Replaces the answer bar once the day is locked and Eve's closing
+ * riff has landed (or timed out), so the conversation clearly ends.
  */
 export function ChatLockedDock({ success, resultsHref, className }: ChatLockedDockProps) {
   return (

--- a/apps/web/src/components/ChatLockedDock.tsx
+++ b/apps/web/src/components/ChatLockedDock.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { Lock } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Timer } from "@/components/Timer";
+import { useEmailNotifications } from "@/hooks/useEmailNotifications";
 import { cn } from "@/lib/utils";
 
 interface ChatLockedDockProps {
@@ -10,11 +13,41 @@ interface ChatLockedDockProps {
   className?: string;
 }
 
+const NUDGE_DISMISS_KEY = "rebuzzleEmailNudgeDismissed";
+
 /**
  * Status-only dock after Eve's closing riff. Results / answer live on the
  * SolveResultCard so there's a single primary CTA in the completion beat.
  */
 export function ChatLockedDock({ success, nextPlayTime = null, className }: ChatLockedDockProps) {
+  const { enabled: notificationsEnabled, isLoading } = useEmailNotifications();
+  const [showNudge, setShowNudge] = useState(false);
+
+  useEffect(() => {
+    if (isLoading || notificationsEnabled) {
+      setShowNudge(false);
+      return;
+    }
+    try {
+      if (localStorage.getItem(NUDGE_DISMISS_KEY) === "1") {
+        setShowNudge(false);
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    setShowNudge(true);
+  }, [isLoading, notificationsEnabled]);
+
+  const dismissNudge = () => {
+    try {
+      localStorage.setItem(NUDGE_DISMISS_KEY, "1");
+    } catch {
+      // ignore
+    }
+    setShowNudge(false);
+  };
+
   return (
     <div className={cn("play-dock-panel w-full", className)}>
       <div className="flex items-center gap-3 rounded-2xl border border-border bg-muted/40 px-4 py-3.5">
@@ -25,9 +58,29 @@ export function ChatLockedDock({ success, nextPlayTime = null, className }: Chat
           <p className="font-medium text-foreground text-sm">
             {success ? "Chat locked · puzzle solved" : "Chat locked · day over"}
           </p>
-          <p className="truncate text-muted-foreground text-xs">
-            Come back after UTC midnight for tomorrow's puzzle.
-          </p>
+          {showNudge ? (
+            <p className="truncate text-muted-foreground text-xs">
+              <Link
+                className="text-foreground underline-offset-2 hover:underline"
+                href="/settings"
+                onClick={dismissNudge}
+              >
+                Email me at midnight
+              </Link>
+              <span className="text-subtle"> · </span>
+              <button
+                className="text-subtle underline-offset-2 hover:underline"
+                onClick={dismissNudge}
+                type="button"
+              >
+                Not now
+              </button>
+            </p>
+          ) : (
+            <p className="truncate text-muted-foreground text-xs">
+              Come back after UTC midnight for tomorrow's puzzle.
+            </p>
+          )}
         </div>
         <Timer
           className="shrink-0 font-mono text-foreground text-xs tabular-nums"

--- a/apps/web/src/components/ChatLockedDock.tsx
+++ b/apps/web/src/components/ChatLockedDock.tsx
@@ -18,7 +18,7 @@ export function ChatLockedDock({ success, nextPlayTime = null, className }: Chat
   return (
     <div className={cn("play-dock-panel w-full", className)}>
       <div className="flex items-center gap-3 rounded-2xl border border-border bg-muted/40 px-4 py-3.5">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground">
+        <div className="chat-lock-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground">
           <Lock className="h-4 w-4" />
         </div>
         <div className="min-w-0 flex-1">

--- a/apps/web/src/components/EnhancedShareButton.tsx
+++ b/apps/web/src/components/EnhancedShareButton.tsx
@@ -11,7 +11,7 @@ import {
   Share2,
   Twitter,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,6 +22,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { haptics } from "@/lib/haptics";
 import { playInterfaceSound } from "@/lib/interface-sounds";
 import { cn } from "@/lib/utils";
 
@@ -33,7 +34,11 @@ interface EnhancedShareButtonProps {
   difficulty?: number;
   answer?: string;
   puzzleType?: string;
+  /** Player brushed a close miss before solving / on loss. */
+  nearMiss?: boolean;
   className?: string;
+  /** Smaller primary for inline result cards. */
+  size?: "default" | "sm" | "lg";
 }
 
 export function EnhancedShareButton({
@@ -41,23 +46,25 @@ export function EnhancedShareButton({
   attempts,
   maxAttempts,
   streak = 0,
-  difficulty,
-  answer,
-  puzzleType,
+  nearMiss = false,
   className,
+  size = "sm",
 }: EnhancedShareButtonProps) {
   const [copied, setCopied] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
+  const [hasNativeShare, setHasNativeShare] = useState(false);
   const { userId } = useAuth();
   const hasTrackedShare = useRef(false);
 
-  // Track share for achievement (only once per session)
+  useEffect(() => {
+    setHasNativeShare(typeof navigator !== "undefined" && typeof navigator.share === "function");
+  }, []);
+
   const trackShare = async () => {
     if (!userId || hasTrackedShare.current) return;
     hasTrackedShare.current = true;
 
     try {
-      // Award Social Butterfly (catalog id: share_first)
       await fetch("/api/user/achievements", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -66,7 +73,6 @@ export function EnhancedShareButton({
         }),
       });
 
-      // Also update the sharedResults counter in stats
       await fetch("/api/user/update-stats", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -93,34 +99,34 @@ export function EnhancedShareButton({
       day: "numeric",
     });
 
-    // Create visual representation
     const squares = success
       ? "🟩".repeat(attempts) + "⬜".repeat(maxAttempts - attempts)
-      : "🟥".repeat(attempts);
+      : "🟥".repeat(Math.max(1, attempts));
 
-    // SEO-friendly, engaging message that's not overdone
-    // Includes natural keywords: daily puzzle, rebus puzzle, word game, free puzzle
-    let message = `Rebuzzle ${today} - ${success ? attempts : "X"}/${maxAttempts}\n\n${squares}\n\n`;
+    let message = `Rebuzzle ${today} · ${success ? attempts : "X"}/${maxAttempts}\n\n${squares}\n\n`;
 
     if (success) {
-      message += `✅ Solved today's daily puzzle!`;
-      if (streak > 0) {
-        message += ` 🔥 ${streak} day streak`;
+      if (nearMiss) {
+        message += `Almost had it → got it.`;
+      } else {
+        message += `Solved today's puzzle.`;
       }
-      message += `\n\nTry the free daily rebus puzzle game at ${url}`;
+      if (streak > 0) {
+        message += ` 🔥 ${streak}-day streak`;
+      }
+      message += `\n\nPlay free at ${url}`;
+    } else if (nearMiss) {
+      message += `So close. Can you get it?\n\nPlay free at ${url}`;
     } else {
-      message += `Challenge yourself with today's puzzle!\n\nPlay free daily puzzles at ${url}`;
+      message += `Today's puzzle got me. Your turn?\n\nPlay free at ${url}`;
     }
 
     return message;
   };
 
-  const generateShareUrl = () => {
-    return getBaseUrl();
-  };
+  const generateShareUrl = () => getBaseUrl();
 
   const generateTwitterText = () => {
-    // Twitter has character limits (280), so make it more concise
     const url = getBaseUrl();
     const today = new Date().toLocaleDateString("en-US", {
       month: "short",
@@ -128,17 +134,16 @@ export function EnhancedShareButton({
     });
     const squares = success
       ? "🟩".repeat(attempts) + "⬜".repeat(maxAttempts - attempts)
-      : "🟥".repeat(attempts);
+      : "🟥".repeat(Math.max(1, attempts));
 
     let tweet = `Rebuzzle ${today} ${success ? attempts : "X"}/${maxAttempts}\n\n${squares}\n\n`;
     if (success) {
-      tweet += `✅ Solved! `;
-      if (streak > 0) {
-        tweet += `🔥 ${streak} day streak `;
-      }
+      tweet += nearMiss ? `Almost → got it. ` : `Solved. `;
+      if (streak > 0) tweet += `🔥 ${streak} `;
+    } else if (nearMiss) {
+      tweet += `So close. `;
     }
-    tweet += `Play free daily rebus puzzles: ${url}`;
-
+    tweet += `${url}`;
     return tweet;
   };
 
@@ -146,84 +151,77 @@ export function EnhancedShareButton({
     setIsSharing(true);
     const url = generateShareUrl();
     const encodedUrl = encodeURIComponent(url);
-
-    // Track share for achievement
-    trackShare();
+    void trackShare();
 
     try {
       switch (platform) {
         case "native": {
-          // Use Web Share API if available
           if (navigator.share) {
-            const shareData = {
+            await navigator.share({
               title: success
-                ? `Rebuzzle - Solved in ${attempts} attempts!`
-                : "Rebuzzle - Daily Puzzle Challenge",
+                ? `Rebuzzle — solved in ${attempts}`
+                : "Rebuzzle — daily puzzle",
               text: generateShareText(),
               url,
-            };
-            await navigator.share(shareData);
+            });
+            haptics.tap();
             void playInterfaceSound("notification");
           } else {
-            // Fallback to copy
             await handleCopy();
           }
           break;
         }
-
         case "twitter": {
-          const tweetText = generateTwitterText();
-          const encodedText = encodeURIComponent(tweetText);
-          const shareUrl = `https://x.com/intent/tweet?text=${encodedText}`;
-          window.open(shareUrl, "_blank", "noopener,noreferrer");
+          window.open(
+            `https://x.com/intent/tweet?text=${encodeURIComponent(generateTwitterText())}`,
+            "_blank",
+            "noopener,noreferrer"
+          );
           break;
         }
-
         case "facebook": {
-          const shareText = generateShareText();
-          const encodedText = encodeURIComponent(shareText);
-          const shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedText}`;
-          window.open(shareUrl, "_blank", "noopener,noreferrer");
+          window.open(
+            `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodeURIComponent(generateShareText())}`,
+            "_blank",
+            "noopener,noreferrer"
+          );
           break;
         }
-
         case "linkedin": {
-          const shareText = generateShareText();
-          const encodedText = encodeURIComponent(shareText);
-          const shareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}&summary=${encodedText}`;
-          window.open(shareUrl, "_blank", "noopener,noreferrer");
+          window.open(
+            `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+            "_blank",
+            "noopener,noreferrer"
+          );
           break;
         }
-
         case "reddit": {
-          const shareText = success
-            ? `Rebuzzle ${success ? attempts : "X"}/${maxAttempts} - Solved today's puzzle!`
-            : "Rebuzzle - Daily Puzzle Challenge";
-          const encodedTitle = encodeURIComponent(shareText);
-          const shareUrl = `https://reddit.com/submit?url=${encodedUrl}&title=${encodedTitle}`;
-          window.open(shareUrl, "_blank", "noopener,noreferrer");
+          const title = success
+            ? `Rebuzzle ${attempts}/${maxAttempts}`
+            : "Rebuzzle — daily puzzle";
+          window.open(
+            `https://reddit.com/submit?url=${encodedUrl}&title=${encodeURIComponent(title)}`,
+            "_blank",
+            "noopener,noreferrer"
+          );
           break;
         }
-
         case "email": {
           const subject = success
-            ? `I solved today's Rebuzzle in ${attempts} attempts!`
-            : "Try today's Rebuzzle puzzle challenge";
-          const body = generateShareText();
-          const mailtoUrl = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-          window.location.href = mailtoUrl;
+            ? `I solved today's Rebuzzle in ${attempts} attempts`
+            : "Try today's Rebuzzle";
+          window.location.href = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(generateShareText())}`;
           break;
         }
-
         case "copy": {
           await handleCopy();
           break;
         }
       }
     } catch (error) {
-      console.error("Error sharing:", error);
-      // Fallback to copy on error
-      if (platform !== "copy") {
+      // User cancel on native share is fine — don't force copy.
+      if (platform !== "native" && platform !== "copy") {
+        console.error("Error sharing:", error);
         await handleCopy();
       }
     } finally {
@@ -233,9 +231,9 @@ export function EnhancedShareButton({
 
   const handleCopy = async () => {
     try {
-      const text = generateShareText();
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(generateShareText());
       setCopied(true);
+      haptics.tap();
       void playInterfaceSound("notification");
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {
@@ -244,93 +242,85 @@ export function EnhancedShareButton({
     }
   };
 
-  // Check if Web Share API is available
-  const hasNativeShare = typeof navigator !== "undefined" && navigator.share;
+  const moreMenu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={cn(hasNativeShare || !success ? "flex-1" : "w-full", !hasNativeShare && "w-full")}
+          disabled={isSharing}
+          size={size}
+          variant={hasNativeShare ? "outline" : "default"}
+        >
+          <Share2 className="mr-2 h-4 w-4" />
+          {copied ? "Copied!" : hasNativeShare ? "More" : "Share"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" className="w-56">
+        <DropdownMenuItem className="cursor-pointer" onClick={() => void handleShare("twitter")}>
+          <Twitter className="mr-2 h-4 w-4" />
+          Share on X
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer" onClick={() => void handleShare("facebook")}>
+          <Facebook className="mr-2 h-4 w-4" />
+          Share on Facebook
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer" onClick={() => void handleShare("linkedin")}>
+          <Linkedin className="mr-2 h-4 w-4" />
+          Share on LinkedIn
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer" onClick={() => void handleShare("reddit")}>
+          <MessageCircle className="mr-2 h-4 w-4" />
+          Share on Reddit
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="cursor-pointer" onClick={() => void handleShare("email")}>
+          <Mail className="mr-2 h-4 w-4" />
+          Email
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer" onClick={() => void handleShare("copy")}>
+          {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+          {copied ? "Copied!" : "Copy text"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 
   return (
     <TooltipProvider delayDuration={300}>
-      <div className={cn("flex flex-col gap-2", className)}>
-        {/* Primary share button */}
-        <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button className="w-full" disabled={isSharing} size="lg">
-                  <Share2 className="mr-2 h-5 w-5" />
-                  {copied ? "Copied!" : "Share Results"}
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Share your results on social media</TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="center" className="w-56">
-            {hasNativeShare && (
-              <>
-                <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("native")}>
+      <div className={cn("flex w-full gap-2", className)}>
+        {hasNativeShare ? (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  className="flex-[1.4]"
+                  disabled={isSharing}
+                  onClick={() => void handleShare("native")}
+                  size={size}
+                >
                   <Share2 className="mr-2 h-4 w-4" />
-                  Share via...
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
-            <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("twitter")}>
-              <Twitter className="mr-2 h-4 w-4" />
-              Share on X (Twitter)
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("facebook")}>
-              <Facebook className="mr-2 h-4 w-4" />
-              Share on Facebook
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("linkedin")}>
-              <Linkedin className="mr-2 h-4 w-4" />
-              Share on LinkedIn
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("reddit")}>
-              <MessageCircle className="mr-2 h-4 w-4" />
-              Share on Reddit
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("email")}>
-              <Mail className="mr-2 h-4 w-4" />
-              Share via Email
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cursor-pointer" onClick={() => handleShare("copy")}>
-              {copied ? (
-                <>
-                  <Check className="mr-2 h-4 w-4" />
-                  Copied!
-                </>
-              ) : (
-                <>
-                  <Copy className="mr-2 h-4 w-4" />
-                  Copy Link
-                </>
-              )}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+                  {success ? "Share" : nearMiss ? "Share the near miss" : "Share"}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Share your result</TooltipContent>
+            </Tooltip>
+            {moreMenu}
+          </>
+        ) : (
+          moreMenu
+        )}
 
-        {/* Quick copy button as fallback */}
-        {!hasNativeShare && (
+        {!hasNativeShare ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button className="w-full border-2 py-3" onClick={handleCopy} variant="outline">
-                {copied ? (
-                  <>
-                    <Check className="mr-2 h-4 w-4" />
-                    Copied to Clipboard!
-                  </>
-                ) : (
-                  <>
-                    <Link2 className="mr-2 h-4 w-4" />
-                    Copy Share Text
-                  </>
-                )}
+              <Button className="flex-1" onClick={() => void handleCopy()} size={size} variant="outline">
+                {copied ? <Check className="mr-2 h-4 w-4" /> : <Link2 className="mr-2 h-4 w-4" />}
+                {copied ? "Copied" : "Copy"}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Copy results to clipboard</TooltipContent>
+            <TooltipContent>Copy results</TooltipContent>
           </Tooltip>
-        )}
+        ) : null}
       </div>
     </TooltipProvider>
   );

--- a/apps/web/src/components/EnhancedShareButton.tsx
+++ b/apps/web/src/components/EnhancedShareButton.tsx
@@ -106,7 +106,11 @@ export function EnhancedShareButton({
     let message = `Rebuzzle ${today} · ${success ? attempts : "X"}/${maxAttempts}\n\n${squares}\n\n`;
 
     if (success) {
-      if (nearMiss) {
+      if (attempts === 1) {
+        message += `First guess.`;
+      } else if (attempts >= maxAttempts) {
+        message += `Clutch — last heart.`;
+      } else if (nearMiss) {
         message += `Almost had it → got it.`;
       } else {
         message += `Solved today's puzzle.`;
@@ -138,7 +142,10 @@ export function EnhancedShareButton({
 
     let tweet = `Rebuzzle ${today} ${success ? attempts : "X"}/${maxAttempts}\n\n${squares}\n\n`;
     if (success) {
-      tweet += nearMiss ? `Almost → got it. ` : `Solved. `;
+      if (attempts === 1) tweet += `First guess. `;
+      else if (attempts >= maxAttempts) tweet += `Clutch. `;
+      else if (nearMiss) tweet += `Almost → got it. `;
+      else tweet += `Solved. `;
       if (streak > 0) tweet += `🔥 ${streak} `;
     } else if (nearMiss) {
       tweet += `So close. `;

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -13,6 +13,7 @@ import {
 import { fireConfetti } from "@/lib/confetti";
 import { getNextUtcMidnight } from "@/lib/game/daily-lock";
 import { buildGameOverHref, markJustSolvedInSession } from "@/lib/game/game-over-href";
+import { recordPlayDay, shouldPromptGuestSave } from "@/lib/game/play-days";
 import type { GuessReaction, ReactionTier } from "@/lib/game/reactions";
 import type { GameData } from "@/lib/gameSettings";
 import {
@@ -25,6 +26,7 @@ import {
 import { haptics } from "@/lib/haptics";
 import { useLazyGuest } from "@/lib/hooks/useLazyGuest";
 import { playInterfaceSound } from "@/lib/interface-sounds";
+import { isReturningUser } from "@/lib/session-tracker";
 import { cn } from "@/lib/utils";
 import { useAuth } from "./AuthProvider";
 import { ChatClosingDock } from "./ChatClosingDock";
@@ -43,6 +45,7 @@ import { SolveResultCard } from "./SolveResultCard";
 interface UserStats {
   points: number;
   streak: number;
+  maxStreak: number;
   totalGames: number;
   wins: number;
   achievements: string[];
@@ -170,6 +173,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
   const [userStats, setUserStats] = useState<UserStats>({
     points: 0,
     streak: 0,
+    maxStreak: 0,
     totalGames: 0,
     wins: 0,
     achievements: [],
@@ -195,9 +199,19 @@ export default function GameBoard({ gameData }: GameBoardProps) {
   const [hadNearMiss, setHadNearMiss] = useState(false);
   /** Variable-reward lucky solve (client roll when server points absent). */
   const [isLuckySolve, setIsLuckySolve] = useState(false);
+  const [closestSimilarity, setClosestSimilarity] = useState(0);
+  const [unlockedAchievementName, setUnlockedAchievementName] = useState<string | null>(null);
+  const [dayRank, setDayRank] = useState<number | null>(null);
+  const [showGuestSave, setShowGuestSave] = useState(false);
+  const consecutiveColdRef = useRef(0);
+  const [isReturner, setIsReturner] = useState(false);
   /** Celebrate when the locked dock + result card land — not at guess submit. */
   const pendingCelebrationRef = useRef(false);
   const wasChatLockedRef = useRef(false);
+
+  useEffect(() => {
+    setIsReturner(isReturningUser());
+  }, []);
 
   const patchTurn = useCallback((id: number, patch: Partial<ThreadTurn>) => {
     setTurns((prev) =>
@@ -295,6 +309,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
             setUserStats({
               points: data.stats.points || 0,
               streak: data.stats.streak || 0,
+              maxStreak: data.stats.maxStreak || 0,
               totalGames: data.stats.totalGames || 0,
               wins: data.stats.wins || 0,
               achievements: [],
@@ -508,6 +523,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
             guess: guessToCheck,
             timeSpentSeconds: timeTaken,
             hintsUsed: gameState.hintsUsed,
+            consecutiveCold: consecutiveColdRef.current,
           }),
         });
 
@@ -525,6 +541,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           explanation?: string;
           pointsEarned?: number;
           reaction?: GuessReaction;
+          unlockedAchievement?: { name?: string };
           error?: string;
         };
 
@@ -549,6 +566,10 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         const attemptNumber =
           result.attemptNumber ?? gameSettings.maxAttempts - previousAttemptsLeft + 1;
 
+        if (typeof result.similarity === "number") {
+          setClosestSimilarity((prev) => Math.max(prev, result.similarity ?? 0));
+        }
+
         // Post the turn the moment the server answers. The reaction is derived
         // from the similarity score server-side, so this is instant.
         const reaction = result.reaction;
@@ -556,6 +577,11 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         if (reaction) {
           if (reaction.tier === "close") {
             setHadNearMiss(true);
+          }
+          if (reaction.tier === "cold") {
+            consecutiveColdRef.current += 1;
+          } else {
+            consecutiveColdRef.current = 0;
           }
           setTurns((prev) => [
             ...prev,
@@ -565,6 +591,11 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               attemptNumber,
               tier: reaction.tier,
               line: reaction.line,
+              wordResults: wordResults.map((w) => ({
+                word: w.word,
+                correct: w.correct,
+                similarity: w.similarity ?? 0,
+              })),
             },
           ]);
         }
@@ -599,6 +630,11 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           if (typeof result.answer === "string" && result.answer.trim()) {
             setRevealedAnswer(result.answer.trim());
           }
+          if (result.unlockedAchievement?.name) {
+            setUnlockedAchievementName(result.unlockedAchievement.name);
+          }
+          recordPlayDay();
+          setShowGuestSave(shouldPromptGuestSave());
 
           // Start Eve's closing riff before lock UI so the dock waits on it.
           if (reaction) {
@@ -619,6 +655,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           newStats.totalGames += 1;
           newStats.wins += 1;
           newStats.streak += 1;
+          newStats.maxStreak = Math.max(newStats.maxStreak, newStats.streak);
           newStats.points += earnedPoints;
           newStats.level = Math.floor(newStats.points / 1000) + 1;
           newStats.lastPlayDate = new Date().toISOString();
@@ -691,6 +728,8 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           if (typeof result.answer === "string" && result.answer.trim()) {
             setRevealedAnswer(result.answer.trim());
           }
+          recordPlayDay();
+          setShowGuestSave(shouldPromptGuestSave());
 
           // Start Eve's closing riff before lock UI so the dock waits on it.
           if (reaction) {
@@ -853,6 +892,36 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     wasChatLockedRef.current = chatLocked;
   }, [chatLocked]);
 
+  // Quiet day-rank murmur after a win — social proof without leaving the thread.
+  useEffect(() => {
+    if (!(chatLocked && gameState.wasSuccessful)) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch("/api/user/stats?timeframe=today");
+        if (!response.ok) return;
+        const data = (await response.json()) as { rank?: number };
+        if (!cancelled && typeof data.rank === "number" && data.rank > 0) {
+          setDayRank(data.rank);
+        }
+      } catch {
+        // Non-blocking
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [chatLocked, gameState.wasSuccessful]);
+
+  const stageCaption = useMemo(() => {
+    const base = getPuzzleQuestion(puzzleType);
+    if (hasThread || gameState.gameOver) return base;
+    if (isReturner && userStats.streak > 0) {
+      return `Day ${userStats.streak} · one puzzle`;
+    }
+    return base;
+  }, [puzzleType, hasThread, gameState.gameOver, userStats.streak, isReturner]);
+
   const resultCard = chatLocked ? (
     <SolveResultCard
       success={gameState.wasSuccessful}
@@ -865,6 +934,14 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       nextPlayTime={gameState.nextPlayTime}
       nearMiss={hadNearMiss}
       isLucky={isLuckySolve}
+      unlockedAchievementName={unlockedAchievementName}
+      closestSimilarity={closestSimilarity > 0 ? closestSimilarity : null}
+      maxStreak={userStats.maxStreak}
+      dayRank={dayRank}
+      hintsUsed={gameState.hintsUsed}
+      puzzleId={gameData.id}
+      timeTakenSeconds={gameState.timeTakenSeconds}
+      showGuestSave={showGuestSave}
     />
   ) : null;
 
@@ -951,7 +1028,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                       <PuzzleStage
                         puzzle={puzzleDisplay}
                         puzzleType={puzzleType}
-                        question={getPuzzleQuestion(puzzleType)}
+                        question={stageCaption}
                         state={hasThread ? "docked" : "hero"}
                         visual={gameData.visual}
                       />

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -191,8 +191,13 @@ export default function GameBoard({ gameData }: GameBoardProps) {
   const hasThread = turns.length > 0;
   /** Answer revealed after a loss (and stored for revisit). */
   const [revealedAnswer, setRevealedAnswer] = useState<string | null>(null);
+  /** Brushed a close miss — fuels share copy + Zeigarnik. */
+  const [hadNearMiss, setHadNearMiss] = useState(false);
+  /** Variable-reward lucky solve (client roll when server points absent). */
+  const [isLuckySolve, setIsLuckySolve] = useState(false);
   /** Celebrate when the locked dock + result card land — not at guess submit. */
   const pendingCelebrationRef = useRef(false);
+  const wasChatLockedRef = useRef(false);
 
   const patchTurn = useCallback((id: number, patch: Partial<ThreadTurn>) => {
     setTurns((prev) =>
@@ -397,6 +402,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         const dailyBonus = getDailyBonusMultiplier();
         if (luckyResult.isLucky) {
           score = Math.round(score * luckyResult.multiplier);
+          setIsLuckySolve(true);
         } else if (dailyBonus.hasBonus) {
           score = Math.round(score * dailyBonus.multiplier);
         }
@@ -434,16 +440,29 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     ]
   );
 
-  const handleIncorrectGuess = useCallback((_attemptsLeft: number, similarity?: number) => {
-    const isNearMiss = similarity !== undefined && similarity >= engagementConfig.nearMissThreshold;
-    if (isNearMiss) {
-      haptics.warning();
-      void playInterfaceSound("near-miss");
-    } else {
-      haptics.error();
-      void playInterfaceSound("incorrect");
-    }
-  }, []);
+  const handleIncorrectGuess = useCallback(
+    (_attemptsLeft: number, similarity?: number, tier?: ReactionTier) => {
+      const resolvedTier =
+        tier ??
+        (similarity !== undefined && similarity >= engagementConfig.nearMissThreshold
+          ? "close"
+          : similarity !== undefined && similarity >= 40
+            ? "warm"
+            : "cold");
+
+      if (resolvedTier === "close") {
+        haptics.warning();
+        void playInterfaceSound("near-miss");
+      } else if (resolvedTier === "warm") {
+        haptics.warm();
+        void playInterfaceSound("incorrect");
+      } else {
+        haptics.error();
+        void playInterfaceSound("incorrect");
+      }
+    },
+    []
+  );
 
   const handleGuess = useCallback(
     async (guessValue?: string) => {
@@ -535,6 +554,9 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         const reaction = result.reaction;
         const turnId = ++turnSeq.current;
         if (reaction) {
+          if (reaction.tier === "close") {
+            setHadNearMiss(true);
+          }
           setTurns((prev) => [
             ...prev,
             {
@@ -749,7 +771,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                 )
               : 0;
 
-        handleIncorrectGuess(newAttemptsLeft, overallSimilarity);
+        handleIncorrectGuess(newAttemptsLeft, overallSimilarity, reaction?.tier);
 
         // Eve's riff arrives behind the instant line, in its own bubble.
         if (reaction) {
@@ -822,6 +844,15 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     });
   }, [chatLocked, gameState.wasSuccessful]);
 
+  // Soft lock click when the day closes — ritualizes "come back tomorrow".
+  useEffect(() => {
+    if (chatLocked && !wasChatLockedRef.current) {
+      haptics.lock();
+      void playInterfaceSound("notification");
+    }
+    wasChatLockedRef.current = chatLocked;
+  }, [chatLocked]);
+
   const resultCard = chatLocked ? (
     <SolveResultCard
       success={gameState.wasSuccessful}
@@ -832,6 +863,8 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       resultsHref={resultsHref}
       answer={revealedAnswer}
       nextPlayTime={gameState.nextPlayTime}
+      nearMiss={hadNearMiss}
+      isLucky={isLuckySolve}
     />
   ) : null;
 
@@ -865,7 +898,14 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                         <div className="font-mono text-[11px] text-subtle uppercase tracking-[0.08em]">
                           Last: {lastTurn.text}
                         </div>
-                        <p className="mt-1 line-clamp-2 text-muted-foreground text-xs leading-5">
+                        <p
+                          className={cn(
+                            "mt-1 line-clamp-2 text-xs leading-5",
+                            lastTurn.tier === "close" || lastTurn.tier === "warm"
+                              ? "text-warning"
+                              : "text-muted-foreground"
+                          )}
+                        >
                           Eve · {lastTurn.line}
                         </p>
                       </div>

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -199,19 +199,23 @@ export default function GameBoard({ gameData }: GameBoardProps) {
    * Never blocks feedback: the instant line is already on screen by the time
    * this is called, and if the stream fails the riff bubble simply never
    * appears. The route is not given the answer, so it can't leak one.
+   *
+   * Final win/loss tiers are allowed so Eve can still close the conversation
+   * before the chat dock locks. A short timeout keeps a slow model from
+   * holding the input open forever.
    */
   const streamQuip = useCallback(
     async (id: number, guess: string, tier: ReactionTier) => {
-      // Never spend credits after the day is locked, or on the winning turn.
-      if (tier === "correct" || tier === "out") return;
-
       patchTurn(id, { quipPending: true });
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), 4500);
       try {
         const response = await fetch("/api/puzzles/quip", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
           body: JSON.stringify({ puzzleId: gameData.id, guess, tier }),
+          signal: controller.signal,
         });
 
         if (!(response.ok && response.body)) {
@@ -238,6 +242,8 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       } catch (_error) {
         // A missing riff is not worth surfacing — the instant line stands.
         patchTurn(id, { quipPending: false });
+      } finally {
+        window.clearTimeout(timeoutId);
       }
     },
     [gameData.id, patchTurn]
@@ -278,15 +284,16 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     loadUserStats();
   }, [userId]);
 
-  // Sync game state with context for header display
+  // Sync game state with context for header display.
+  // Stop (and don't restart) once the day is locked in-thread.
   useEffect(() => {
-    if (!gameData.isCompleted) {
+    if (!(gameData.isCompleted || gameState.gameOver)) {
       startGame(typeof gameData.difficulty === "number" ? gameData.difficulty : 5);
     }
     return () => {
       endGame();
     };
-  }, [gameData.difficulty, gameData.isCompleted, startGame, endGame]);
+  }, [gameData.difficulty, gameData.isCompleted, gameState.gameOver, startGame, endGame]);
 
   // Sync attempts with context
   useEffect(() => {
@@ -337,10 +344,16 @@ export default function GameBoard({ gameData }: GameBoardProps) {
   }, []);
 
   const setCompletionState = useCallback(
-    (success: boolean, finalGuess: string, attempts: number, serverScore?: number) => {
+    (
+      success: boolean,
+      finalGuess: string,
+      attempts: number,
+      opts?: { serverScore?: number; celebrate?: boolean }
+    ) => {
       const tomorrow = getNextUtcMidnight();
       const timeTakenSeconds = Math.max(0, Math.floor((Date.now() - gameState.startTime) / 1000));
       const difficultyLevel = typeof gameData.difficulty === "number" ? gameData.difficulty : 5;
+      const serverScore = opts?.serverScore;
 
       // Prefer authoritative server points; fall back to local estimate for UX only
       let score =
@@ -378,17 +391,23 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         },
       });
 
+      // Clear header difficulty / attempts rail — stay-in-thread solve used to leave them up.
+      endGame();
       dismissKeyboard();
-      if (success) {
+      if (success && opts?.celebrate) {
         haptics.celebration();
         markJustSolvedInSession();
-        void fireConfetti();
-      } else {
+        // Wait a frame so the lock UI has painted before the canvas mounts.
+        window.requestAnimationFrame(() => {
+          void fireConfetti();
+        });
+      } else if (!success) {
         haptics.error();
       }
     },
     [
       dismissKeyboard,
+      endGame,
       gameState.startTime,
       gameState.hintsUsed,
       userStats.streak,
@@ -474,7 +493,9 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         // Already locked / replay blocked — stay in-thread, don't hard-cut away
         if (response.status === 409 || result.locked) {
           void playInterfaceSound("notification");
-          setCompletionState(Boolean(result.wasSuccessful), guessToCheck, gameSettings.maxAttempts);
+          setCompletionState(Boolean(result.wasSuccessful), guessToCheck, gameSettings.maxAttempts, {
+            celebrate: false,
+          });
           toast({
             title: result.wasSuccessful ? "Already solved today" : "Day already locked",
             description: "Chat is locked. Open full results anytime from the dock.",
@@ -534,7 +555,15 @@ export default function GameBoard({ gameData }: GameBoardProps) {
             },
           });
 
-          setCompletionState(true, guessToCheck, attempts, earnedPoints);
+          // Start Eve's closing riff before lock UI so the dock waits on it.
+          if (reaction) {
+            void streamQuip(turnId, guessToCheck, reaction.tier);
+          }
+
+          setCompletionState(true, guessToCheck, attempts, {
+            serverScore: earnedPoints,
+            celebrate: true,
+          });
 
           const newStats = { ...userStats };
           newStats.totalGames += 1;
@@ -608,6 +637,12 @@ export default function GameBoard({ gameData }: GameBoardProps) {
 
         if (result.gameOver || newAttemptsLeft <= 0) {
           void playInterfaceSound("failure");
+
+          // Start Eve's closing riff before lock UI so the dock waits on it.
+          if (reaction) {
+            void streamQuip(turnId, guessToCheck, reaction.tier);
+          }
+
           setCompletionState(false, guessToCheck, gameSettings.maxAttempts);
 
           const newStats = { ...userStats };
@@ -658,7 +693,6 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           };
           localStorage.setItem("lastGameCompletion", JSON.stringify(completionData));
 
-          // Stay in the thread — chat stays locked.
           return;
         }
 
@@ -681,7 +715,6 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         handleIncorrectGuess(newAttemptsLeft, overallSimilarity);
 
         // Eve's riff arrives behind the instant line, in its own bubble.
-        // Never request a quip after the day locks — that burns AI credits.
         if (reaction) {
           void streamQuip(turnId, guessToCheck, reaction.tier);
         }
@@ -735,7 +768,13 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     gameState.timeTakenSeconds,
   ]);
 
-  const resultCard = gameState.gameOver ? (
+  // Keep the answer bar open (disabled) until Eve's closing riff settles.
+  const awaitingClosingQuip = turns.some(
+    (turn) => (turn.tier === "correct" || turn.tier === "out") && Boolean(turn.quipPending)
+  );
+  const chatLocked = gameState.gameOver && !awaitingClosingQuip;
+
+  const resultCard = chatLocked ? (
     <SolveResultCard
       success={gameState.wasSuccessful}
       score={gameState.finalScore}
@@ -783,27 +822,29 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                       hasThread ? "justify-start" : "justify-center"
                     )}
                   >
-                    <div className="mb-[clamp(0.5rem,2vh,1rem)] flex w-full max-w-2xl items-start justify-between gap-3">
-                      <DifficultyBadge
-                        className="play-fade-in"
-                        difficulty={currentEventPuzzle?.difficulty}
-                        showDescription={!hasThread}
-                      />
-                      {gameData.hints && gameData.hints.length > 0 && !gameState.gameOver && (
-                        <HintBadge
-                          hints={gameData.hints}
-                          gameId={gameData.id}
-                          onHintReveal={(hintIndex) => {
-                            dispatch({ type: "REVEAL_HINT" });
-                            void playInterfaceSound("hint");
-                            trackEvent(analyticsEvents.HINT_USED, {
-                              puzzleId: gameData.id || "unknown",
-                              hintIndex,
-                            });
-                          }}
+                    {!gameState.gameOver ? (
+                      <div className="mb-[clamp(0.5rem,2vh,1rem)] flex w-full max-w-2xl items-start justify-between gap-3">
+                        <DifficultyBadge
+                          className="play-fade-in"
+                          difficulty={currentEventPuzzle?.difficulty}
+                          showDescription={!hasThread}
                         />
-                      )}
-                    </div>
+                        {gameData.hints && gameData.hints.length > 0 ? (
+                          <HintBadge
+                            hints={gameData.hints}
+                            gameId={gameData.id}
+                            onHintReveal={(hintIndex) => {
+                              dispatch({ type: "REVEAL_HINT" });
+                              void playInterfaceSound("hint");
+                              trackEvent(analyticsEvents.HINT_USED, {
+                                puzzleId: gameData.id || "unknown",
+                                hintIndex,
+                              });
+                            }}
+                          />
+                        ) : null}
+                      </div>
+                    ) : null}
 
                     <section aria-label="Puzzle" className="w-full max-w-2xl">
                       <PuzzleStage
@@ -854,15 +895,19 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               )}
 
               <section
-                aria-label={gameState.gameOver ? "Day locked" : "Answer input"}
+                aria-label={chatLocked ? "Day locked" : "Answer input"}
                 className="input-area input-area-keyboard-transition play-dock z-30 shrink-0 px-4 pt-5 pb-safe-lg md:px-6"
               >
                 <div className="mx-auto max-w-2xl">
-                  {gameState.gameOver ? (
+                  {chatLocked ? (
                     <ChatLockedDock success={gameState.wasSuccessful} resultsHref={resultsHref} />
                   ) : (
                     <SmartAnswerInput
-                      disabled={gameState.isSubmitting || (!userId && isCreatingGuest)}
+                      disabled={
+                        gameState.gameOver ||
+                        gameState.isSubmitting ||
+                        (!userId && isCreatingGuest)
+                      }
                       isSubmitting={gameState.isSubmitting || isCreatingGuest}
                       onSubmit={handleGuess}
                     />

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -13,11 +13,12 @@ import {
 import { fireConfetti } from "@/lib/confetti";
 import { getNextUtcMidnight } from "@/lib/game/daily-lock";
 import { buildGameOverHref, markJustSolvedInSession } from "@/lib/game/game-over-href";
-import { recordPlayDay, shouldPromptGuestSave } from "@/lib/game/play-days";
+import { isComebackVisit, recordPlayDay, shouldPromptGuestSave } from "@/lib/game/play-days";
 import type { GuessReaction, ReactionTier } from "@/lib/game/reactions";
 import type { GameData } from "@/lib/gameSettings";
 import {
   calculateGamePoints,
+  checkStreakGracePeriod,
   engagementConfig,
   gameSettings,
   getDailyBonusMultiplier,
@@ -52,6 +53,8 @@ interface UserStats {
   level: number;
   lastPlayDate: string | null;
   dailyChallengeStreak: number;
+  noHintStreak: number;
+  fastestSolveSeconds: number | null;
 }
 
 interface GameBoardProps {
@@ -180,6 +183,8 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     level: 1,
     lastPlayDate: null,
     dailyChallengeStreak: 0,
+    noHintStreak: 0,
+    fastestSolveSeconds: null,
   });
   const [error, setError] = useState<{
     message: string;
@@ -203,14 +208,19 @@ export default function GameBoard({ gameData }: GameBoardProps) {
   const [unlockedAchievementName, setUnlockedAchievementName] = useState<string | null>(null);
   const [dayRank, setDayRank] = useState<number | null>(null);
   const [showGuestSave, setShowGuestSave] = useState(false);
+  const [dayBonusMultiplier, setDayBonusMultiplier] = useState<number | null>(null);
+  const [paceLabel, setPaceLabel] = useState<string | null>(null);
+  const [previousBestSeconds, setPreviousBestSeconds] = useState<number | null>(null);
   const consecutiveColdRef = useRef(0);
   const [isReturner, setIsReturner] = useState(false);
+  const [isComeback, setIsComeback] = useState(false);
   /** Celebrate when the locked dock + result card land — not at guess submit. */
   const pendingCelebrationRef = useRef(false);
   const wasChatLockedRef = useRef(false);
 
   useEffect(() => {
     setIsReturner(isReturningUser());
+    setIsComeback(isComebackVisit());
   }, []);
 
   const patchTurn = useCallback((id: number, patch: Partial<ThreadTurn>) => {
@@ -316,6 +326,11 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               level: data.stats.level || 1,
               lastPlayDate: data.stats.lastPlayDate || null,
               dailyChallengeStreak: data.stats.dailyChallengeStreak || 0,
+              noHintStreak: data.stats.noHintStreak || 0,
+              fastestSolveSeconds:
+                typeof data.stats.fastestSolveSeconds === "number"
+                  ? data.stats.fastestSolveSeconds
+                  : null,
             });
           }
         }
@@ -412,14 +427,19 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               )
             : 0;
 
-      if (success && !(typeof serverScore === "number" && serverScore > 0)) {
-        const luckyResult = rollLuckySolve();
+      if (success) {
         const dailyBonus = getDailyBonusMultiplier();
-        if (luckyResult.isLucky) {
-          score = Math.round(score * luckyResult.multiplier);
-          setIsLuckySolve(true);
-        } else if (dailyBonus.hasBonus) {
-          score = Math.round(score * dailyBonus.multiplier);
+        if (dailyBonus.hasBonus) {
+          setDayBonusMultiplier(dailyBonus.multiplier);
+        }
+        if (!(typeof serverScore === "number" && serverScore > 0)) {
+          const luckyResult = rollLuckySolve();
+          if (luckyResult.isLucky) {
+            score = Math.round(score * luckyResult.multiplier);
+            setIsLuckySolve(true);
+          } else if (dailyBonus.hasBonus) {
+            score = Math.round(score * dailyBonus.multiplier);
+          }
         }
       }
 
@@ -470,10 +490,10 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         void playInterfaceSound("near-miss");
       } else if (resolvedTier === "warm") {
         haptics.warm();
-        void playInterfaceSound("incorrect");
+        void playInterfaceSound("incorrect", { playbackRate: 1.02 });
       } else {
         haptics.error();
-        void playInterfaceSound("incorrect");
+        void playInterfaceSound("incorrect", { playbackRate: 0.94 });
       }
     },
     []
@@ -646,11 +666,17 @@ export default function GameBoard({ gameData }: GameBoardProps) {
             void streamQuip(turnId, guessToCheck, reaction.tier);
           }
 
+          const previousBest = userStats.fastestSolveSeconds;
+          setPreviousBestSeconds(
+            typeof previousBest === "number" && previousBest > 0 ? previousBest : null
+          );
+
           setCompletionState(true, guessToCheck, attempts, {
             serverScore: earnedPoints,
             celebrate: true,
           });
 
+          const cleanWin = gameState.hintsUsed === 0;
           const newStats = { ...userStats };
           newStats.totalGames += 1;
           newStats.wins += 1;
@@ -659,6 +685,10 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           newStats.points += earnedPoints;
           newStats.level = Math.floor(newStats.points / 1000) + 1;
           newStats.lastPlayDate = new Date().toISOString();
+          newStats.noHintStreak = cleanWin ? (userStats.noHintStreak || 0) + 1 : 0;
+          if (previousBest == null || previousBest <= 0 || timeTaken < previousBest) {
+            newStats.fastestSolveSeconds = timeTaken;
+          }
           setUserStats(newStats);
 
           trackPuzzleCompletion({
@@ -746,6 +776,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           const newStats = { ...userStats };
           newStats.totalGames += 1;
           newStats.streak = 0;
+          newStats.noHintStreak = 0;
           newStats.lastPlayDate = new Date().toISOString();
           setUserStats(newStats);
 
@@ -913,14 +944,65 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     };
   }, [chatLocked, gameState.wasSuccessful]);
 
+  // Pace murmur from today's solve-time percentiles.
+  useEffect(() => {
+    if (!(chatLocked && gameState.wasSuccessful)) return;
+    const elapsed = gameState.timeTakenSeconds;
+    if (elapsed <= 0) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch(
+          `/api/puzzles/stats?puzzleId=${encodeURIComponent(gameData.id)}`,
+          { credentials: "include" }
+        );
+        if (!response.ok) return;
+        const data = (await response.json()) as {
+          percentiles?: { p25?: number; p50?: number; p75?: number };
+        };
+        const p = data.percentiles;
+        if (!p?.p50 || p.p50 <= 0 || cancelled) return;
+        if (typeof p.p25 === "number" && elapsed <= p.p25) {
+          setPaceLabel("Faster than most");
+        } else if (elapsed <= p.p50) {
+          setPaceLabel("Around the middle");
+        } else if (typeof p.p75 === "number" && elapsed <= p.p75) {
+          setPaceLabel("A bit slower today");
+        } else {
+          setPaceLabel("Took your time");
+        }
+      } catch {
+        // optional murmur
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [chatLocked, gameState.wasSuccessful, gameState.timeTakenSeconds, gameData.id]);
+
   const stageCaption = useMemo(() => {
     const base = getPuzzleQuestion(puzzleType);
     if (hasThread || gameState.gameOver) return base;
+    if (isComeback) return "Welcome back · one puzzle";
+    try {
+      if (checkStreakGracePeriod().inGracePeriod && userStats.streak > 0) {
+        return "Grace window · streak safe";
+      }
+    } catch {
+      // ignore
+    }
     if (isReturner && userStats.streak > 0) {
       return `Day ${userStats.streak} · one puzzle`;
     }
     return base;
-  }, [puzzleType, hasThread, gameState.gameOver, userStats.streak, isReturner]);
+  }, [
+    puzzleType,
+    hasThread,
+    gameState.gameOver,
+    userStats.streak,
+    isReturner,
+    isComeback,
+  ]);
 
   const resultCard = chatLocked ? (
     <SolveResultCard
@@ -934,13 +1016,18 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       nextPlayTime={gameState.nextPlayTime}
       nearMiss={hadNearMiss}
       isLucky={isLuckySolve}
+      dayBonusMultiplier={dayBonusMultiplier}
       unlockedAchievementName={unlockedAchievementName}
       closestSimilarity={closestSimilarity > 0 ? closestSimilarity : null}
       maxStreak={userStats.maxStreak}
       dayRank={dayRank}
       hintsUsed={gameState.hintsUsed}
+      noHintStreak={userStats.noHintStreak}
       puzzleId={gameData.id}
       timeTakenSeconds={gameState.timeTakenSeconds}
+      previousBestSeconds={previousBestSeconds}
+      paceLabel={paceLabel}
+      totalPoints={userStats.points}
       showGuestSave={showGuestSave}
     />
   ) : null;

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -27,6 +27,7 @@ import { useLazyGuest } from "@/lib/hooks/useLazyGuest";
 import { playInterfaceSound } from "@/lib/interface-sounds";
 import { cn } from "@/lib/utils";
 import { useAuth } from "./AuthProvider";
+import { ChatClosingDock } from "./ChatClosingDock";
 import { ChatLockedDock } from "./ChatLockedDock";
 import { DifficultyBadge } from "./DifficultyBadge";
 import { useGameContext } from "./GameContext";
@@ -188,9 +189,31 @@ export default function GameBoard({ gameData }: GameBoardProps) {
   const [turns, setTurns] = useState<ThreadTurn[]>([]);
   const turnSeq = useRef(0);
   const hasThread = turns.length > 0;
+  /** Answer revealed after a loss (and stored for revisit). */
+  const [revealedAnswer, setRevealedAnswer] = useState<string | null>(null);
+  /** Celebrate when the locked dock + result card land — not at guess submit. */
+  const pendingCelebrationRef = useRef(false);
 
   const patchTurn = useCallback((id: number, patch: Partial<ThreadTurn>) => {
-    setTurns((prev) => prev.map((turn) => (turn.id === id ? { ...turn, ...patch } : turn)));
+    setTurns((prev) =>
+      prev.map((turn) => {
+        if (turn.id !== id) return turn;
+        const next = { ...turn, ...patch };
+        // Persist Eve's closing line for the soft revisit landing.
+        if (
+          (next.tier === "correct" || next.tier === "out") &&
+          typeof next.quip === "string" &&
+          next.quip.trim()
+        ) {
+          try {
+            localStorage.setItem("lastEveClosingLine", next.quip.trim());
+          } catch {
+            // Ignore quota / private mode.
+          }
+        }
+        return next;
+      })
+    );
   }, []);
 
   /**
@@ -395,12 +418,8 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       endGame();
       dismissKeyboard();
       if (success && opts?.celebrate) {
-        haptics.celebration();
+        pendingCelebrationRef.current = true;
         markJustSolvedInSession();
-        // Wait a frame so the lock UI has painted before the canvas mounts.
-        window.requestAnimationFrame(() => {
-          void fireConfetti();
-        });
       } else if (!success) {
         haptics.error();
       }
@@ -498,7 +517,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
           });
           toast({
             title: result.wasSuccessful ? "Already solved today" : "Day already locked",
-            description: "Chat is locked. Open full results anytime from the dock.",
+            description: "Chat is locked. Open full results from the card below.",
           });
           return;
         }
@@ -555,8 +574,17 @@ export default function GameBoard({ gameData }: GameBoardProps) {
             },
           });
 
+          if (typeof result.answer === "string" && result.answer.trim()) {
+            setRevealedAnswer(result.answer.trim());
+          }
+
           // Start Eve's closing riff before lock UI so the dock waits on it.
           if (reaction) {
+            try {
+              localStorage.setItem("lastEveClosingLine", reaction.line);
+            } catch {
+              // Ignore quota / private mode.
+            }
             void streamQuip(turnId, guessToCheck, reaction.tier);
           }
 
@@ -638,8 +666,17 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         if (result.gameOver || newAttemptsLeft <= 0) {
           void playInterfaceSound("failure");
 
+          if (typeof result.answer === "string" && result.answer.trim()) {
+            setRevealedAnswer(result.answer.trim());
+          }
+
           // Start Eve's closing riff before lock UI so the dock waits on it.
           if (reaction) {
+            try {
+              localStorage.setItem("lastEveClosingLine", reaction.line);
+            } catch {
+              // Ignore quota / private mode.
+            }
             void streamQuip(turnId, guessToCheck, reaction.tier);
           }
 
@@ -768,11 +805,22 @@ export default function GameBoard({ gameData }: GameBoardProps) {
     gameState.timeTakenSeconds,
   ]);
 
-  // Keep the answer bar open (disabled) until Eve's closing riff settles.
+  // Keep the answer bar open until Eve's closing riff settles.
   const awaitingClosingQuip = turns.some(
     (turn) => (turn.tier === "correct" || turn.tier === "out") && Boolean(turn.quipPending)
   );
   const chatLocked = gameState.gameOver && !awaitingClosingQuip;
+  const lastTurn = turns.at(-1);
+
+  // Confetti + celebration haptic land with the result card / locked dock.
+  useEffect(() => {
+    if (!chatLocked || !gameState.wasSuccessful || !pendingCelebrationRef.current) return;
+    pendingCelebrationRef.current = false;
+    haptics.celebration();
+    window.requestAnimationFrame(() => {
+      void fireConfetti();
+    });
+  }, [chatLocked, gameState.wasSuccessful]);
 
   const resultCard = chatLocked ? (
     <SolveResultCard
@@ -782,8 +830,13 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       attempts={gameState.finalAttempts}
       maxAttempts={gameSettings.maxAttempts}
       resultsHref={resultsHref}
+      answer={revealedAnswer}
+      nextPlayTime={gameState.nextPlayTime}
     />
   ) : null;
+
+  const showStageChrome =
+    !gameState.gameOver && (!hasThread || Boolean(gameData.hints && gameData.hints.length > 0));
 
   // Puzzle data is already on the server-rendered board — never blank it for
   // auth/guest warm-up. Guest creation only disables submit (below).
@@ -799,20 +852,24 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               {/* Puzzle area - collapses when keyboard is visible, centers content */}
               <main className="flex-1 overflow-hidden transition-all duration-300 puzzle-area flex flex-col">
                 {collapsed ? (
-                  /* COLLAPSED VIEW - minimal puzzle hint when keyboard is open */
-                  <div className="flex flex-col items-center pt-2">
+                  /* COLLAPSED VIEW - minimal puzzle + last Eve line while typing */
+                  <div className="flex flex-col items-center px-4 pt-2">
                     <PuzzleMinimal
                       puzzle={puzzleDisplay}
                       puzzleType={puzzleType}
                       visual={gameData.visual}
                       className="w-full max-w-2xl"
                     />
-                    {/* Show last guess attempt in collapsed view */}
-                    {gameState.guessHistory.length > 0 && (
-                      <div className="mt-1.5 font-mono text-[11px] text-subtle uppercase tracking-[0.08em]">
-                        Last: {gameState.guessHistory[gameState.guessHistory.length - 1]?.text}
+                    {lastTurn ? (
+                      <div className="mt-2 w-full max-w-2xl text-center">
+                        <div className="font-mono text-[11px] text-subtle uppercase tracking-[0.08em]">
+                          Last: {lastTurn.text}
+                        </div>
+                        <p className="mt-1 line-clamp-2 text-muted-foreground text-xs leading-5">
+                          Eve · {lastTurn.line}
+                        </p>
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 ) : (
                   /* EXPANDED VIEW — focused play stage */
@@ -822,13 +879,17 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                       hasThread ? "justify-start" : "justify-center"
                     )}
                   >
-                    {!gameState.gameOver ? (
+                    {showStageChrome ? (
                       <div className="mb-[clamp(0.5rem,2vh,1rem)] flex w-full max-w-2xl items-start justify-between gap-3">
-                        <DifficultyBadge
-                          className="play-fade-in"
-                          difficulty={currentEventPuzzle?.difficulty}
-                          showDescription={!hasThread}
-                        />
+                        {!hasThread ? (
+                          <DifficultyBadge
+                            className="play-fade-in"
+                            difficulty={currentEventPuzzle?.difficulty}
+                            showDescription
+                          />
+                        ) : (
+                          <span />
+                        )}
                         {gameData.hints && gameData.hints.length > 0 ? (
                           <HintBadge
                             hints={gameData.hints}
@@ -895,22 +956,35 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               )}
 
               <section
-                aria-label={chatLocked ? "Day locked" : "Answer input"}
+                aria-label={
+                  chatLocked
+                    ? "Day locked"
+                    : awaitingClosingQuip
+                      ? "Eve finishing"
+                      : "Answer input"
+                }
                 className="input-area input-area-keyboard-transition play-dock z-30 shrink-0 px-4 pt-5 pb-safe-lg md:px-6"
               >
                 <div className="mx-auto max-w-2xl">
                   {chatLocked ? (
-                    <ChatLockedDock success={gameState.wasSuccessful} resultsHref={resultsHref} />
-                  ) : (
-                    <SmartAnswerInput
-                      disabled={
-                        gameState.gameOver ||
-                        gameState.isSubmitting ||
-                        (!userId && isCreatingGuest)
-                      }
-                      isSubmitting={gameState.isSubmitting || isCreatingGuest}
-                      onSubmit={handleGuess}
+                    <ChatLockedDock
+                      success={gameState.wasSuccessful}
+                      nextPlayTime={gameState.nextPlayTime}
                     />
+                  ) : awaitingClosingQuip ? (
+                    <ChatClosingDock success={gameState.wasSuccessful} />
+                  ) : (
+                    <div className="play-dock-panel">
+                      <SmartAnswerInput
+                        disabled={
+                          gameState.gameOver ||
+                          gameState.isSubmitting ||
+                          (!userId && isCreatingGuest)
+                        }
+                        isSubmitting={gameState.isSubmitting || isCreatingGuest}
+                        onSubmit={handleGuess}
+                      />
+                    </div>
                   )}
                 </div>
               </section>

--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -44,26 +44,32 @@ const TIER_LABEL: Record<ReactionTier, string> = {
   out: "Out of guesses",
 };
 
+const NEAR_WORD_THRESHOLD = 70;
+
 function ExactWordTicks({ words }: { words: WordResult[] }) {
   if (words.length < 2) return null;
-  const anyCorrect = words.some((w) => w.correct);
-  if (!anyCorrect) return null;
+  const anySignal = words.some((w) => w.correct || w.similarity >= NEAR_WORD_THRESHOLD);
+  if (!anySignal) return null;
 
   return (
     <p className="mt-2 flex flex-wrap gap-1.5 font-mono text-[11px] uppercase tracking-[0.06em]">
-      {words.map((word, index) => (
-        <span
-          className={cn(
-            "rounded px-1.5 py-0.5",
-            word.correct
-              ? "bg-success/15 text-success"
-              : "bg-muted text-subtle line-through decoration-border-strong/60"
-          )}
-          key={`${word.word}-${index}`}
-        >
-          {word.correct ? `✓ ${word.word}` : word.word}
-        </span>
-      ))}
+      {words.map((word, index) => {
+        const near = !word.correct && word.similarity >= NEAR_WORD_THRESHOLD;
+        return (
+          <span
+            className={cn(
+              "rounded px-1.5 py-0.5",
+              word.correct && "bg-success/15 text-success",
+              near && "bg-warning/15 text-warning",
+              !(word.correct || near) &&
+                "bg-muted text-subtle line-through decoration-border-strong/60"
+            )}
+            key={`${word.word}-${index}`}
+          >
+            {word.correct ? `✓ ${word.word}` : near ? `~ ${word.word}` : word.word}
+          </span>
+        );
+      })}
     </p>
   );
 }

--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   MessageAvatar,
   MessageBubble,
@@ -41,6 +41,55 @@ const TIER_LABEL: Record<ReactionTier, string> = {
   out: "Out of guesses",
 };
 
+function AgentReply({ turn }: { turn: ThreadTurn }) {
+  const tone = REACTION_TONE[turn.tier];
+  const showRiff = Boolean(turn.quipPending || turn.quip);
+  const isClose = turn.tier === "close";
+  const staggerBody = turn.tier === "close" || turn.tier === "warm";
+  const [showBody, setShowBody] = useState(!staggerBody);
+
+  // Near-miss beat: meta lands first, then the line — sells "almost" better than more copy.
+  useEffect(() => {
+    if (!staggerBody) return;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) {
+      setShowBody(true);
+      return;
+    }
+    const delay = turn.tier === "close" ? 110 : 70;
+    const id = window.setTimeout(() => setShowBody(true), delay);
+    return () => window.clearTimeout(id);
+  }, [staggerBody, turn.tier]);
+
+  return (
+    <MessageRow from="agent">
+      <MessageAvatar />
+      <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+        <MessageMeta className={cn(isClose && "reaction-heat")} tone={tone}>
+          Eve · {TIER_LABEL[turn.tier]} · Guess {turn.attemptNumber}
+        </MessageMeta>
+
+        {showBody ? (
+          <MessageBubble
+            className={cn("min-w-0", isClose && "reaction-heat-bubble")}
+            from="agent"
+            tone={tone}
+          >
+            <p>{turn.line}</p>
+            {showRiff ? (
+              <div className="mt-2 border-border/70 border-t pt-2 text-muted-foreground">
+                {turn.quip ? turn.quip : <MessageTyping />}
+              </div>
+            ) : null}
+          </MessageBubble>
+        ) : (
+          <div aria-hidden className="h-11" />
+        )}
+      </div>
+    </MessageRow>
+  );
+}
+
 /**
  * The conversation.
  *
@@ -53,12 +102,13 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
   const endRef = useRef<HTMLLIElement>(null);
   const lastQuip = turns.at(-1)?.quip;
   const hasFooter = Boolean(footer);
+  const lastTier = turns.at(-1)?.tier;
 
   // Follow the conversation the way a chat does — including as a riff grows.
   useEffect(() => {
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     endRef.current?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "end" });
-  }, [turns.length, lastQuip, hasFooter]);
+  }, [turns.length, lastQuip, hasFooter, lastTier]);
 
   if (turns.length === 0) return null;
 
@@ -70,36 +120,14 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
       className={cn("guess-thread flex w-full flex-col gap-5 overflow-y-auto", className)}
       role="log"
     >
-      {turns.map((turn) => {
-        const tone = REACTION_TONE[turn.tier];
-        const showRiff = Boolean(turn.quipPending || turn.quip);
-
-        return (
-          <li className="flex flex-col gap-3" key={turn.id}>
-            <MessageRow from="user">
-              <MessageBubble from="user">{turn.text}</MessageBubble>
-            </MessageRow>
-
-            <MessageRow from="agent">
-              <MessageAvatar />
-              <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
-                <MessageMeta tone={tone}>
-                  Eve · {TIER_LABEL[turn.tier]} · Guess {turn.attemptNumber}
-                </MessageMeta>
-
-                <MessageBubble className="min-w-0" from="agent" tone={tone}>
-                  <p>{turn.line}</p>
-                  {showRiff ? (
-                    <div className="mt-2 border-border/70 border-t pt-2 text-muted-foreground">
-                      {turn.quip ? turn.quip : <MessageTyping />}
-                    </div>
-                  ) : null}
-                </MessageBubble>
-              </div>
-            </MessageRow>
-          </li>
-        );
-      })}
+      {turns.map((turn) => (
+        <li className="flex flex-col gap-3" key={turn.id}>
+          <MessageRow from="user">
+            <MessageBubble from="user">{turn.text}</MessageBubble>
+          </MessageRow>
+          <AgentReply turn={turn} />
+        </li>
+      ))}
 
       {footer ? <li className="list-none pt-1">{footer}</li> : null}
 

--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -9,6 +9,7 @@ import {
   MessageRow,
   MessageTyping,
 } from "@/components/ui/message";
+import type { WordResult } from "@/lib/game/build-word-results";
 import { REACTION_TONE, type ReactionTier } from "@/lib/game/reactions";
 import { cn } from "@/lib/utils";
 
@@ -24,6 +25,8 @@ export interface ThreadTurn {
   quip?: string;
   /** True between requesting the riff and the first token landing. */
   quipPending?: boolean;
+  /** Per-word ticks for multi-word guesses (exact matches only). */
+  wordResults?: WordResult[];
 }
 
 interface GuessThreadProps {
@@ -41,6 +44,30 @@ const TIER_LABEL: Record<ReactionTier, string> = {
   out: "Out of guesses",
 };
 
+function ExactWordTicks({ words }: { words: WordResult[] }) {
+  if (words.length < 2) return null;
+  const anyCorrect = words.some((w) => w.correct);
+  if (!anyCorrect) return null;
+
+  return (
+    <p className="mt-2 flex flex-wrap gap-1.5 font-mono text-[11px] uppercase tracking-[0.06em]">
+      {words.map((word, index) => (
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5",
+            word.correct
+              ? "bg-success/15 text-success"
+              : "bg-muted text-subtle line-through decoration-border-strong/60"
+          )}
+          key={`${word.word}-${index}`}
+        >
+          {word.correct ? `✓ ${word.word}` : word.word}
+        </span>
+      ))}
+    </p>
+  );
+}
+
 function AgentReply({ turn }: { turn: ThreadTurn }) {
   const tone = REACTION_TONE[turn.tier];
   const showRiff = Boolean(turn.quipPending || turn.quip);
@@ -48,7 +75,6 @@ function AgentReply({ turn }: { turn: ThreadTurn }) {
   const staggerBody = turn.tier === "close" || turn.tier === "warm";
   const [showBody, setShowBody] = useState(!staggerBody);
 
-  // Near-miss beat: meta lands first, then the line — sells "almost" better than more copy.
   useEffect(() => {
     if (!staggerBody) return;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -76,6 +102,7 @@ function AgentReply({ turn }: { turn: ThreadTurn }) {
             tone={tone}
           >
             <p>{turn.line}</p>
+            {turn.wordResults ? <ExactWordTicks words={turn.wordResults} /> : null}
             {showRiff ? (
               <div className="mt-2 border-border/70 border-t pt-2 text-muted-foreground">
                 {turn.quip ? turn.quip : <MessageTyping />}
@@ -104,7 +131,6 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
   const hasFooter = Boolean(footer);
   const lastTier = turns.at(-1)?.tier;
 
-  // Follow the conversation the way a chat does — including as a riff grows.
   useEffect(() => {
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     endRef.current?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "end" });
@@ -113,8 +139,6 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
   if (turns.length === 0) return null;
 
   return (
-    // role="log" carries an implicit polite live region, and unlike a bare div
-    // it actually accepts the label.
     <ol
       aria-label="Your guesses and Eve's replies"
       className={cn("guess-thread flex w-full flex-col gap-5 overflow-y-auto", className)}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -171,7 +171,7 @@ export default function Header({ nextPlayTime, puzzleType, gameState }: HeaderPr
 
             {isPlaying && (
               <AttemptsIndicator
-                animateOnChange={false}
+                animateOnChange
                 currentAttempts={gameState?.currentAttempts ?? 0}
                 maxAttempts={gameState?.maxAttempts ?? 3}
               />

--- a/apps/web/src/components/SmartAnswerInput.tsx
+++ b/apps/web/src/components/SmartAnswerInput.tsx
@@ -35,10 +35,22 @@ export function SmartAnswerInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const cursorPositionRef = useRef<CursorPosition | null>(null);
   const undoRedoManager = useRef(new UndoRedoManager());
+  /** One arming tap per focus session — commitment cue, not every keystroke. */
+  const armedHapticRef = useRef(false);
 
   const trimmed = value.trim();
   const canSubmit = trimmed.length > 0 && !(disabled || isSubmitting);
   const letterCount = useMemo(() => trimmed.replace(/[^\p{L}\p{N}]/gu, "").length, [trimmed]);
+
+  useEffect(() => {
+    if (letterCount > 0 && !armedHapticRef.current && !disabled) {
+      armedHapticRef.current = true;
+      haptics.hint();
+    }
+    if (letterCount === 0) {
+      armedHapticRef.current = false;
+    }
+  }, [letterCount, disabled]);
 
   const submit = useCallback(() => {
     if (!canSubmit) return;

--- a/apps/web/src/components/SolveResultCard.tsx
+++ b/apps/web/src/components/SolveResultCard.tsx
@@ -8,6 +8,7 @@ import { EnhancedShareButton } from "@/components/EnhancedShareButton";
 import { Timer } from "@/components/Timer";
 import { Button } from "@/components/ui/button";
 import { getStreakTease } from "@/lib/game/streak-tease";
+import { getLevelProgress } from "@/lib/gameSettings";
 import { haptics } from "@/lib/haptics";
 import { cn } from "@/lib/utils";
 
@@ -30,16 +31,21 @@ export interface SolveResultCardProps {
   nextPlayTime?: Date | null;
   nearMiss?: boolean;
   isLucky?: boolean;
-  /** Fresh achievement name from the guess response. */
+  dayBonusMultiplier?: number | null;
   unlockedAchievementName?: string | null;
-  /** Best similarity across the day's guesses (0–100). */
   closestSimilarity?: number | null;
   maxStreak?: number;
   dayRank?: number | null;
   hintsUsed?: number;
+  noHintStreak?: number;
   puzzleId?: string;
   timeTakenSeconds?: number;
-  /** Gate guest signup until day 2+. */
+  /** Previous best solve time in seconds (before this win). */
+  previousBestSeconds?: number | null;
+  /** Pace label from today's percentiles. */
+  paceLabel?: string | null;
+  /** Total points for level-rim (after this solve). */
+  totalPoints?: number;
   showGuestSave?: boolean;
   className?: string;
 }
@@ -88,6 +94,21 @@ function useCountUp(
   return { value, done };
 }
 
+function pbLabel(
+  success: boolean,
+  timeTakenSeconds: number,
+  previousBestSeconds: number | null | undefined
+): string | null {
+  if (!success || timeTakenSeconds <= 0) return null;
+  if (previousBestSeconds == null || previousBestSeconds <= 0) return "PB";
+  if (timeTakenSeconds < previousBestSeconds) {
+    const delta = previousBestSeconds - timeTakenSeconds;
+    return `−${delta}s vs best`;
+  }
+  if (timeTakenSeconds === previousBestSeconds) return "PB tied";
+  return null;
+}
+
 /**
  * In-thread result panel after the day locks — keeps the win/loss moment
  * inside the chat instead of hard-cutting to a separate page.
@@ -103,13 +124,18 @@ export function SolveResultCard({
   nextPlayTime = null,
   nearMiss = false,
   isLucky = false,
+  dayBonusMultiplier = null,
   unlockedAchievementName = null,
   closestSimilarity = null,
   maxStreak = 0,
   dayRank = null,
   hintsUsed = 0,
+  noHintStreak = 0,
   puzzleId,
   timeTakenSeconds = 0,
+  previousBestSeconds = null,
+  paceLabel = null,
+  totalPoints = 0,
   showGuestSave = false,
   className,
 }: SolveResultCardProps) {
@@ -125,7 +151,11 @@ export function SolveResultCard({
   const [perceptionSaving, setPerceptionSaving] = useState(false);
   const isMilestone = success && [3, 7, 14, 30, 100].includes(streak);
   const cleanSolve = success && hintsUsed === 0;
+  const clutchSolve = success && attempts >= maxAttempts;
   const showBestGhost = !success && maxStreak > 0;
+  const personalBest = pbLabel(success, timeTakenSeconds, previousBestSeconds);
+  const levelProgress = success && totalPoints > 0 ? getLevelProgress(totalPoints) : 0;
+  const showLevelRim = success && scoreDone && levelProgress >= 85;
 
   useEffect(() => {
     if (!scoreDone) return;
@@ -232,68 +262,97 @@ export function SolveResultCard({
         </div>
       ) : null}
 
-      <div className="mt-4 grid grid-cols-3 divide-x divide-border/80 overflow-hidden rounded-xl border border-border/70 bg-background/60 py-3 text-center">
-        <div>
-          <p className="font-semibold text-foreground text-xl tabular-nums tracking-tight">
-            {attempts}
-          </p>
-          <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
-            {attempts === 1 ? "Guess" : "Guesses"}
-          </p>
-          {cleanSolve && scoreDone ? (
-            <p className="mt-1 font-mono text-[10px] text-success uppercase tracking-[0.08em] animate-in fade-in duration-300">
-              No hints
+      <div className="mt-4 overflow-hidden rounded-xl border border-border/70 bg-background/60">
+        <div className="grid grid-cols-3 divide-x divide-border/80 py-3 text-center">
+          <div>
+            <p className="font-semibold text-foreground text-xl tabular-nums tracking-tight">
+              {attempts}
             </p>
-          ) : null}
+            <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+              {attempts === 1 ? "Guess" : "Guesses"}
+            </p>
+            {cleanSolve && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-success uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                {noHintStreak > 1 ? `No hints · ${noHintStreak}` : "No hints"}
+              </p>
+            ) : null}
+            {clutchSolve && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-warning uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                Clutch
+              </p>
+            ) : null}
+          </div>
+          <div>
+            <p className="font-semibold text-foreground text-xl tabular-nums tracking-tight">
+              {displayScore}
+            </p>
+            <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+              Points
+            </p>
+            {isLucky && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-warning uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                ×2 lucky
+              </p>
+            ) : null}
+            {!isLucky && dayBonusMultiplier && dayBonusMultiplier > 1 && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-warning uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                ×{dayBonusMultiplier} day
+              </p>
+            ) : null}
+            {success && typeof dayRank === "number" && dayRank > 0 && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                Day · #{dayRank}
+              </p>
+            ) : null}
+          </div>
+          <div>
+            <p
+              className={cn(
+                "flex items-center justify-center gap-1 font-semibold text-foreground text-xl tabular-nums tracking-tight",
+                streakLocked && "streak-lock-in"
+              )}
+            >
+              {streak > 0 ? (
+                <>
+                  <span className="text-warning">{streak}</span>
+                  <Flame
+                    className={cn(
+                      "h-3.5 w-3.5 text-warning",
+                      isMilestone && streakLocked && "opacity-100"
+                    )}
+                  />
+                </>
+              ) : (
+                "0"
+              )}
+            </p>
+            <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+              Streak
+            </p>
+            {showBestGhost ? (
+              <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+                Best {maxStreak}
+              </p>
+            ) : null}
+            {personalBest && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-success uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                {personalBest}
+              </p>
+            ) : null}
+            {paceLabel && scoreDone ? (
+              <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em] animate-in fade-in duration-300">
+                {paceLabel}
+              </p>
+            ) : null}
+          </div>
         </div>
-        <div>
-          <p className="font-semibold text-foreground text-xl tabular-nums tracking-tight">
-            {displayScore}
-          </p>
-          <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
-            Points
-          </p>
-          {isLucky && scoreDone ? (
-            <p className="mt-1 font-mono text-[10px] text-warning uppercase tracking-[0.08em] animate-in fade-in duration-300">
-              ×2 lucky
-            </p>
-          ) : null}
-          {success && typeof dayRank === "number" && dayRank > 0 && scoreDone ? (
-            <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em] animate-in fade-in duration-300">
-              Day · #{dayRank}
-            </p>
-          ) : null}
-        </div>
-        <div>
-          <p
-            className={cn(
-              "flex items-center justify-center gap-1 font-semibold text-foreground text-xl tabular-nums tracking-tight",
-              streakLocked && "streak-lock-in"
-            )}
-          >
-            {streak > 0 ? (
-              <>
-                <span className="text-warning">{streak}</span>
-                <Flame
-                  className={cn(
-                    "h-3.5 w-3.5 text-warning",
-                    isMilestone && streakLocked && "opacity-100"
-                  )}
-                />
-              </>
-            ) : (
-              "0"
-            )}
-          </p>
-          <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
-            Streak
-          </p>
-          {showBestGhost ? (
-            <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
-              Best {maxStreak}
-            </p>
-          ) : null}
-        </div>
+        {showLevelRim ? (
+          <div
+            aria-hidden
+            className="level-rim h-0.5 w-full bg-border/60"
+            style={{ ["--level-progress" as string]: `${levelProgress}%` }}
+          />
+        ) : null}
       </div>
 
       {puzzleId ? (
@@ -346,7 +405,12 @@ export function SolveResultCard({
           streak={streak}
           nearMiss={nearMiss}
         />
-        <Button asChild className="flex-1" size="sm" variant={success || showAnswer ? "outline" : "default"}>
+        <Button
+          asChild
+          className="flex-1"
+          size="sm"
+          variant={success || showAnswer ? "outline" : "default"}
+        >
           <Link href={resultsHref}>
             {success || showAnswer ? "Full results" : "See the answer"}
           </Link>

--- a/apps/web/src/components/SolveResultCard.tsx
+++ b/apps/web/src/components/SolveResultCard.tsx
@@ -11,6 +11,14 @@ import { getStreakTease } from "@/lib/game/streak-tease";
 import { haptics } from "@/lib/haptics";
 import { cn } from "@/lib/utils";
 
+type PerceptionChoice = "too_easy" | "just_right" | "too_hard";
+
+const PERCEPTION_OPTIONS: { id: PerceptionChoice; label: string }[] = [
+  { id: "too_easy", label: "Too easy" },
+  { id: "just_right", label: "Just right" },
+  { id: "too_hard", label: "Brutal" },
+];
+
 export interface SolveResultCardProps {
   success: boolean;
   score: number;
@@ -18,13 +26,21 @@ export interface SolveResultCardProps {
   attempts: number;
   maxAttempts: number;
   resultsHref: string;
-  /** Revealed on loss (and optionally win) once the day is locked. */
   answer?: string | null;
   nextPlayTime?: Date | null;
-  /** Brushed a close miss during the day. */
   nearMiss?: boolean;
-  /** Variable-reward lucky solve echo. */
   isLucky?: boolean;
+  /** Fresh achievement name from the guess response. */
+  unlockedAchievementName?: string | null;
+  /** Best similarity across the day's guesses (0–100). */
+  closestSimilarity?: number | null;
+  maxStreak?: number;
+  dayRank?: number | null;
+  hintsUsed?: number;
+  puzzleId?: string;
+  timeTakenSeconds?: number;
+  /** Gate guest signup until day 2+. */
+  showGuestSave?: boolean;
   className?: string;
 }
 
@@ -87,6 +103,14 @@ export function SolveResultCard({
   nextPlayTime = null,
   nearMiss = false,
   isLucky = false,
+  unlockedAchievementName = null,
+  closestSimilarity = null,
+  maxStreak = 0,
+  dayRank = null,
+  hintsUsed = 0,
+  puzzleId,
+  timeTakenSeconds = 0,
+  showGuestSave = false,
   className,
 }: SolveResultCardProps) {
   const { isGuest, userId } = useAuth();
@@ -97,9 +121,12 @@ export function SolveResultCard({
   const streakTease = getStreakTease(streak, success);
   const showAnswer = Boolean(answer) && !success;
   const [streakLocked, setStreakLocked] = useState(false);
+  const [perception, setPerception] = useState<PerceptionChoice | null>(null);
+  const [perceptionSaving, setPerceptionSaving] = useState(false);
   const isMilestone = success && [3, 7, 14, 30, 100].includes(streak);
+  const cleanSolve = success && hintsUsed === 0;
+  const showBestGhost = !success && maxStreak > 0;
 
-  // Streak lock-in + tease land after the numbers settle.
   useEffect(() => {
     if (!scoreDone) return;
     if (success && streak > 0) {
@@ -107,6 +134,45 @@ export function SolveResultCard({
       haptics.tap();
     }
   }, [scoreDone, success, streak]);
+
+  useEffect(() => {
+    if (!puzzleId) return;
+    try {
+      const stored = localStorage.getItem(`difficultyPerception:${puzzleId}`);
+      if (stored === "too_easy" || stored === "just_right" || stored === "too_hard") {
+        setPerception(stored);
+      }
+    } catch {
+      // ignore
+    }
+  }, [puzzleId]);
+
+  async function submitPerception(choice: PerceptionChoice) {
+    if (!puzzleId || perceptionSaving || perception) return;
+    setPerceptionSaving(true);
+    setPerception(choice);
+    haptics.tap();
+    try {
+      localStorage.setItem(`difficultyPerception:${puzzleId}`, choice);
+      await fetch("/api/puzzles/difficulty-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          puzzleId,
+          perception: choice,
+          solved: success,
+          timeSpentSeconds: timeTakenSeconds,
+          hintsUsed,
+          attemptNumber: attempts,
+        }),
+      });
+    } catch {
+      // Non-blocking — local selection still stands
+    } finally {
+      setPerceptionSaving(false);
+    }
+  }
 
   return (
     <div
@@ -139,12 +205,24 @@ export function SolveResultCard({
           >
             {streakTease}
           </p>
+          {unlockedAchievementName && scoreDone ? (
+            <p className="mt-1 font-mono text-[11px] text-subtle uppercase tracking-[0.08em] animate-in fade-in duration-300">
+              Unlocked · {unlockedAchievementName}
+            </p>
+          ) : null}
         </div>
       </div>
 
       {showAnswer ? (
         <div className="mt-4 rounded-xl border border-border/70 bg-background/70 px-3.5 py-3">
-          <p className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">Answer</p>
+          <div className="flex items-baseline justify-between gap-3">
+            <p className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">Answer</p>
+            {typeof closestSimilarity === "number" && closestSimilarity > 0 ? (
+              <p className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+                Closest · {closestSimilarity}%
+              </p>
+            ) : null}
+          </div>
           <p className="mt-1 font-semibold text-foreground text-lg tracking-tight">{answer}</p>
           <Button asChild className="mt-2.5" size="sm" variant="link">
             <Link className="h-auto px-0" href={resultsHref}>
@@ -162,6 +240,11 @@ export function SolveResultCard({
           <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
             {attempts === 1 ? "Guess" : "Guesses"}
           </p>
+          {cleanSolve && scoreDone ? (
+            <p className="mt-1 font-mono text-[10px] text-success uppercase tracking-[0.08em] animate-in fade-in duration-300">
+              No hints
+            </p>
+          ) : null}
         </div>
         <div>
           <p className="font-semibold text-foreground text-xl tabular-nums tracking-tight">
@@ -173,6 +256,11 @@ export function SolveResultCard({
           {isLucky && scoreDone ? (
             <p className="mt-1 font-mono text-[10px] text-warning uppercase tracking-[0.08em] animate-in fade-in duration-300">
               ×2 lucky
+            </p>
+          ) : null}
+          {success && typeof dayRank === "number" && dayRank > 0 && scoreDone ? (
+            <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em] animate-in fade-in duration-300">
+              Day · #{dayRank}
             </p>
           ) : null}
         </div>
@@ -200,8 +288,45 @@ export function SolveResultCard({
           <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
             Streak
           </p>
+          {showBestGhost ? (
+            <p className="mt-1 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+              Best {maxStreak}
+            </p>
+          ) : null}
         </div>
       </div>
+
+      {puzzleId ? (
+        <div className="mt-3">
+          <p className="mb-1.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+            How was it?
+          </p>
+          <div className="flex gap-1.5">
+            {PERCEPTION_OPTIONS.map((option) => {
+              const selected = perception === option.id;
+              return (
+                <button
+                  className={cn(
+                    "flex-1 rounded-lg border px-2 py-1.5 font-medium text-xs transition-colors",
+                    selected
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-border bg-background/50 text-muted-foreground hover:text-foreground"
+                  )}
+                  disabled={Boolean(perception) || perceptionSaving}
+                  key={option.id}
+                  onClick={() => void submitPerception(option.id)}
+                  type="button"
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+          {perception ? (
+            <p className="mt-1.5 text-center text-[11px] text-subtle">Tunes tomorrow.</p>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/40 px-3 py-2.5">
         <p className="min-w-0 truncate text-muted-foreground text-xs">Next puzzle</p>
@@ -221,22 +346,14 @@ export function SolveResultCard({
           streak={streak}
           nearMiss={nearMiss}
         />
-        {success ? (
-          <Button asChild className="flex-1" size="sm" variant="outline">
-            <Link href={resultsHref}>Full results</Link>
-          </Button>
-        ) : showAnswer ? (
-          <Button asChild className="flex-1" size="sm" variant="outline">
-            <Link href={resultsHref}>Full results</Link>
-          </Button>
-        ) : (
-          <Button asChild className="flex-1" size="sm" variant="default">
-            <Link href={resultsHref}>See the answer</Link>
-          </Button>
-        )}
+        <Button asChild className="flex-1" size="sm" variant={success || showAnswer ? "outline" : "default"}>
+          <Link href={resultsHref}>
+            {success || showAnswer ? "Full results" : "See the answer"}
+          </Link>
+        </Button>
       </div>
 
-      {(isGuest || !userId) && success ? (
+      {showGuestSave && (isGuest || !userId) && success ? (
         <div className="mt-3 rounded-xl border border-border/70 bg-background/50 px-3 py-3">
           <p className="flex items-center gap-1.5 font-medium text-foreground text-sm">
             <Trophy className="h-3.5 w-3.5 text-muted-foreground" />

--- a/apps/web/src/components/SolveResultCard.tsx
+++ b/apps/web/src/components/SolveResultCard.tsx
@@ -2,9 +2,12 @@
 
 import { Check, Flame, Lock, Trophy } from "lucide-react";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { EnhancedShareButton } from "@/components/EnhancedShareButton";
+import { Timer } from "@/components/Timer";
 import { Button } from "@/components/ui/button";
+import { getStreakTease } from "@/lib/game/streak-tease";
 import { cn } from "@/lib/utils";
 
 export interface SolveResultCardProps {
@@ -14,7 +17,45 @@ export interface SolveResultCardProps {
   attempts: number;
   maxAttempts: number;
   resultsHref: string;
+  /** Revealed on loss (and optionally win) once the day is locked. */
+  answer?: string | null;
+  nextPlayTime?: Date | null;
   className?: string;
+}
+
+function useCountUp(target: number, enabled: boolean, durationMs = 700): number {
+  const [value, setValue] = useState(enabled ? 0 : target);
+
+  useEffect(() => {
+    if (!enabled || target <= 0) {
+      setValue(target);
+      return;
+    }
+
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) {
+      setValue(target);
+      return;
+    }
+
+    let frame = 0;
+    const started = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - started) / durationMs);
+      // Ease-out cubic — lands with a little weight.
+      const eased = 1 - (1 - t) ** 3;
+      setValue(Math.round(target * eased));
+      if (t < 1) {
+        frame = window.requestAnimationFrame(tick);
+      }
+    };
+    frame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frame);
+  }, [target, enabled, durationMs]);
+
+  return value;
 }
 
 /**
@@ -28,9 +69,14 @@ export function SolveResultCard({
   attempts,
   maxAttempts,
   resultsHref,
+  answer = null,
+  nextPlayTime = null,
   className,
 }: SolveResultCardProps) {
   const { isGuest, userId } = useAuth();
+  const displayScore = useCountUp(success ? score : 0, success && score > 0);
+  const streakTease = getStreakTease(streak, success);
+  const showAnswer = Boolean(answer) && !success;
 
   return (
     <div
@@ -55,13 +101,21 @@ export function SolveResultCard({
           <p className="font-semibold text-foreground text-base tracking-tight">
             {success ? "Solved" : "Out of guesses"}
           </p>
-          <p className="mt-0.5 text-muted-foreground text-sm">
-            {success
-              ? "Today’s puzzle is done. Chat is locked until tomorrow."
-              : "That’s the day — chat is locked. See the answer on the results page."}
-          </p>
+          <p className="mt-0.5 text-muted-foreground text-sm">{streakTease}</p>
         </div>
       </div>
+
+      {showAnswer ? (
+        <div className="mt-4 rounded-xl border border-border/70 bg-background/70 px-3.5 py-3">
+          <p className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">Answer</p>
+          <p className="mt-1 font-semibold text-foreground text-lg tracking-tight">{answer}</p>
+          <Button asChild className="mt-2.5" size="sm" variant="link">
+            <Link className="h-auto px-0" href={resultsHref}>
+              Explain more
+            </Link>
+          </Button>
+        </div>
+      ) : null}
 
       <div className="mt-4 grid grid-cols-3 divide-x divide-border/80 overflow-hidden rounded-xl border border-border/70 bg-background/60 py-3 text-center">
         <div>
@@ -74,7 +128,7 @@ export function SolveResultCard({
         </div>
         <div>
           <p className="font-semibold text-foreground text-xl tabular-nums tracking-tight">
-            {success ? score : 0}
+            {displayScore}
           </p>
           <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
             Points
@@ -97,6 +151,15 @@ export function SolveResultCard({
         </div>
       </div>
 
+      <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/40 px-3 py-2.5">
+        <p className="min-w-0 truncate text-muted-foreground text-xs">Next puzzle</p>
+        <Timer
+          className="shrink-0 font-mono text-foreground text-xs tabular-nums"
+          compact
+          nextPlayTime={nextPlayTime}
+        />
+      </div>
+
       <div className="mt-4 flex flex-col gap-2 sm:flex-row">
         {success ? (
           <EnhancedShareButton
@@ -107,9 +170,15 @@ export function SolveResultCard({
             streak={streak}
           />
         ) : null}
-        <Button asChild className="flex-1" size="sm" variant={success ? "outline" : "default"}>
-          <Link href={resultsHref}>{success ? "Full results" : "See the answer"}</Link>
-        </Button>
+        {success ? (
+          <Button asChild className="flex-1" size="sm" variant="outline">
+            <Link href={resultsHref}>Full results</Link>
+          </Button>
+        ) : showAnswer ? null : (
+          <Button asChild className="flex-1" size="sm" variant="default">
+            <Link href={resultsHref}>See the answer</Link>
+          </Button>
+        )}
       </div>
 
       {(isGuest || !userId) && success ? (

--- a/apps/web/src/components/SolveResultCard.tsx
+++ b/apps/web/src/components/SolveResultCard.tsx
@@ -8,6 +8,7 @@ import { EnhancedShareButton } from "@/components/EnhancedShareButton";
 import { Timer } from "@/components/Timer";
 import { Button } from "@/components/ui/button";
 import { getStreakTease } from "@/lib/game/streak-tease";
+import { haptics } from "@/lib/haptics";
 import { cn } from "@/lib/utils";
 
 export interface SolveResultCardProps {
@@ -20,15 +21,25 @@ export interface SolveResultCardProps {
   /** Revealed on loss (and optionally win) once the day is locked. */
   answer?: string | null;
   nextPlayTime?: Date | null;
+  /** Brushed a close miss during the day. */
+  nearMiss?: boolean;
+  /** Variable-reward lucky solve echo. */
+  isLucky?: boolean;
   className?: string;
 }
 
-function useCountUp(target: number, enabled: boolean, durationMs = 700): number {
+function useCountUp(
+  target: number,
+  enabled: boolean,
+  durationMs = 700
+): { value: number; done: boolean } {
   const [value, setValue] = useState(enabled ? 0 : target);
+  const [done, setDone] = useState(!enabled || target <= 0);
 
   useEffect(() => {
     if (!enabled || target <= 0) {
       setValue(target);
+      setDone(true);
       return;
     }
 
@@ -37,25 +48,28 @@ function useCountUp(target: number, enabled: boolean, durationMs = 700): number 
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduceMotion) {
       setValue(target);
+      setDone(true);
       return;
     }
 
+    setDone(false);
     let frame = 0;
     const started = performance.now();
     const tick = (now: number) => {
       const t = Math.min(1, (now - started) / durationMs);
-      // Ease-out cubic — lands with a little weight.
       const eased = 1 - (1 - t) ** 3;
       setValue(Math.round(target * eased));
       if (t < 1) {
         frame = window.requestAnimationFrame(tick);
+      } else {
+        setDone(true);
       }
     };
     frame = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(frame);
   }, [target, enabled, durationMs]);
 
-  return value;
+  return { value, done };
 }
 
 /**
@@ -71,12 +85,28 @@ export function SolveResultCard({
   resultsHref,
   answer = null,
   nextPlayTime = null,
+  nearMiss = false,
+  isLucky = false,
   className,
 }: SolveResultCardProps) {
   const { isGuest, userId } = useAuth();
-  const displayScore = useCountUp(success ? score : 0, success && score > 0);
+  const { value: displayScore, done: scoreDone } = useCountUp(
+    success ? score : 0,
+    success && score > 0
+  );
   const streakTease = getStreakTease(streak, success);
   const showAnswer = Boolean(answer) && !success;
+  const [streakLocked, setStreakLocked] = useState(false);
+  const isMilestone = success && [3, 7, 14, 30, 100].includes(streak);
+
+  // Streak lock-in + tease land after the numbers settle.
+  useEffect(() => {
+    if (!scoreDone) return;
+    if (success && streak > 0) {
+      setStreakLocked(true);
+      haptics.tap();
+    }
+  }, [scoreDone, success, streak]);
 
   return (
     <div
@@ -101,7 +131,14 @@ export function SolveResultCard({
           <p className="font-semibold text-foreground text-base tracking-tight">
             {success ? "Solved" : "Out of guesses"}
           </p>
-          <p className="mt-0.5 text-muted-foreground text-sm">{streakTease}</p>
+          <p
+            className={cn(
+              "mt-0.5 text-muted-foreground text-sm transition-opacity duration-200",
+              scoreDone ? "opacity-100" : "opacity-0"
+            )}
+          >
+            {streakTease}
+          </p>
         </div>
       </div>
 
@@ -133,13 +170,28 @@ export function SolveResultCard({
           <p className="mt-0.5 font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
             Points
           </p>
+          {isLucky && scoreDone ? (
+            <p className="mt-1 font-mono text-[10px] text-warning uppercase tracking-[0.08em] animate-in fade-in duration-300">
+              ×2 lucky
+            </p>
+          ) : null}
         </div>
         <div>
-          <p className="flex items-center justify-center gap-1 font-semibold text-foreground text-xl tabular-nums tracking-tight">
+          <p
+            className={cn(
+              "flex items-center justify-center gap-1 font-semibold text-foreground text-xl tabular-nums tracking-tight",
+              streakLocked && "streak-lock-in"
+            )}
+          >
             {streak > 0 ? (
               <>
                 <span className="text-warning">{streak}</span>
-                <Flame className="h-3.5 w-3.5 text-warning" />
+                <Flame
+                  className={cn(
+                    "h-3.5 w-3.5 text-warning",
+                    isMilestone && streakLocked && "opacity-100"
+                  )}
+                />
               </>
             ) : (
               "0"
@@ -160,21 +212,24 @@ export function SolveResultCard({
         />
       </div>
 
-      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-        {success ? (
-          <EnhancedShareButton
-            className="flex-1"
-            success
-            attempts={attempts}
-            maxAttempts={maxAttempts}
-            streak={streak}
-          />
-        ) : null}
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-stretch">
+        <EnhancedShareButton
+          className="flex-1"
+          success={success}
+          attempts={attempts}
+          maxAttempts={maxAttempts}
+          streak={streak}
+          nearMiss={nearMiss}
+        />
         {success ? (
           <Button asChild className="flex-1" size="sm" variant="outline">
             <Link href={resultsHref}>Full results</Link>
           </Button>
-        ) : showAnswer ? null : (
+        ) : showAnswer ? (
+          <Button asChild className="flex-1" size="sm" variant="outline">
+            <Link href={resultsHref}>Full results</Link>
+          </Button>
+        ) : (
           <Button asChild className="flex-1" size="sm" variant="default">
             <Link href={resultsHref}>See the answer</Link>
           </Button>

--- a/apps/web/src/components/Timer.tsx
+++ b/apps/web/src/components/Timer.tsx
@@ -26,10 +26,13 @@ function formatCountdown(diffMs: number): string {
 export function Timer({ nextPlayTime, className, compact = false }: TimerProps) {
   const router = useRouter();
   const [timeLeft, setTimeLeft] = useState("--:--:--");
+  const [underHour, setUnderHour] = useState(false);
+  const [minuteTick, setMinuteTick] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const reloadedRef = useRef(false);
   // Fixed target for this mount when nextPlayTime is null — set in effect to avoid prerender Date()
   const fallbackTargetRef = useRef<Date | null>(null);
+  const lastMinuteRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!fallbackTargetRef.current) {
@@ -45,7 +48,21 @@ export function Timer({ nextPlayTime, className, compact = false }: TimerProps) 
           reloadedRef.current = true;
           router.replace("/");
         }
+        setUnderHour(false);
         return "00:00:00";
+      }
+
+      const isUnderHour = difference < 60 * 60 * 1000;
+      setUnderHour(isUnderHour);
+
+      // Once a minute under an hour: a single opacity dip — anticipation, not alarm.
+      if (compact && isUnderHour) {
+        const minuteBucket = Math.floor(difference / 60_000);
+        if (lastMinuteRef.current !== null && minuteBucket !== lastMinuteRef.current) {
+          setMinuteTick(true);
+          window.setTimeout(() => setMinuteTick(false), 280);
+        }
+        lastMinuteRef.current = minuteBucket;
       }
 
       return formatCountdown(difference);
@@ -72,7 +89,14 @@ export function Timer({ nextPlayTime, className, compact = false }: TimerProps) 
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className={cn("cursor-default font-mono text-subtle text-xs", className)}>
+          <div
+            className={cn(
+              "cursor-default font-mono text-subtle text-xs transition-opacity duration-300",
+              underHour && compact && "font-medium text-foreground",
+              minuteTick && "opacity-45",
+              className
+            )}
+          >
             {compact ? null : (
               <>
                 <span className="xs:inline hidden">Next puzzle in </span>

--- a/apps/web/src/components/Timer.tsx
+++ b/apps/web/src/components/Timer.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { haptics } from "@/lib/haptics";
 import { cn } from "@/lib/utils";
 
 interface TimerProps {
@@ -83,7 +84,19 @@ export function Timer({ nextPlayTime, className, compact = false }: TimerProps) 
         intervalRef.current = null;
       }
     };
-  }, [nextPlayTime, router]);
+  }, [nextPlayTime, router, compact]);
+
+  // Tab-return itch: one soft tap when coming back under an hour to midnight.
+  useEffect(() => {
+    if (!underHour) return;
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        haptics.tap();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [underHour]);
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/apps/web/src/components/Timer.tsx
+++ b/apps/web/src/components/Timer.tsx
@@ -9,6 +9,8 @@ import { cn } from "@/lib/utils";
 interface TimerProps {
   nextPlayTime: Date | null;
   className?: string;
+  /** Digits only — for docks / cards that already label "Next puzzle". */
+  compact?: boolean;
 }
 
 function formatCountdown(diffMs: number): string {
@@ -21,7 +23,7 @@ function formatCountdown(diffMs: number): string {
     .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
 }
 
-export function Timer({ nextPlayTime, className }: TimerProps) {
+export function Timer({ nextPlayTime, className, compact = false }: TimerProps) {
   const router = useRouter();
   const [timeLeft, setTimeLeft] = useState("--:--:--");
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -71,8 +73,12 @@ export function Timer({ nextPlayTime, className }: TimerProps) {
       <Tooltip>
         <TooltipTrigger asChild>
           <div className={cn("cursor-default font-mono text-subtle text-xs", className)}>
-            <span className="xs:inline hidden">Next puzzle in </span>
-            <span className="xs:hidden">Next </span>
+            {compact ? null : (
+              <>
+                <span className="xs:inline hidden">Next puzzle in </span>
+                <span className="xs:hidden">Next </span>
+              </>
+            )}
             <span className="text-foreground tabular-nums">{timeLeft}</span>
           </div>
         </TooltipTrigger>

--- a/apps/web/src/components/ui/message.tsx
+++ b/apps/web/src/components/ui/message.tsx
@@ -112,7 +112,9 @@ export function MessageMeta({
         className
       )}
     >
-      {tone ? <span aria-hidden className={dotVariants({ tone })} /> : null}
+      {tone ? (
+        <span aria-hidden className={dotVariants({ tone })} data-tone-dot />
+      ) : null}
       {children}
     </p>
   );

--- a/apps/web/src/lib/confetti.ts
+++ b/apps/web/src/lib/confetti.ts
@@ -9,33 +9,38 @@ export async function fireConfetti(options?: { durationMs?: number }): Promise<v
   const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   if (prefersReduced) return;
 
-  const { default: confetti } = await import("canvas-confetti");
-  const duration = options?.durationMs ?? 2200;
-  const animationEnd = Date.now() + duration;
-  const defaults = { startVelocity: 28, spread: 360, ticks: 55, zIndex: 80 };
+  try {
+    const { default: confetti } = await import("canvas-confetti");
+    const duration = options?.durationMs ?? 2200;
+    const animationEnd = Date.now() + duration;
+    // Above play dock / header chrome so the burst is visible on solve.
+    const defaults = { startVelocity: 28, spread: 360, ticks: 55, zIndex: 9999 };
 
-  const randomInRange = (min: number, max: number) => Math.random() * (max - min) + min;
+    const randomInRange = (min: number, max: number) => Math.random() * (max - min) + min;
 
-  await new Promise<void>((resolve) => {
-    const interval = window.setInterval(() => {
-      const timeLeft = animationEnd - Date.now();
-      if (timeLeft <= 0) {
-        window.clearInterval(interval);
-        resolve();
-        return;
-      }
+    await new Promise<void>((resolve) => {
+      const interval = window.setInterval(() => {
+        const timeLeft = animationEnd - Date.now();
+        if (timeLeft <= 0) {
+          window.clearInterval(interval);
+          resolve();
+          return;
+        }
 
-      const particleCount = 42 * (timeLeft / duration);
-      void confetti({
-        ...defaults,
-        particleCount,
-        origin: { x: randomInRange(0.12, 0.28), y: Math.random() - 0.15 },
-      });
-      void confetti({
-        ...defaults,
-        particleCount,
-        origin: { x: randomInRange(0.72, 0.88), y: Math.random() - 0.15 },
-      });
-    }, 220);
-  });
+        const particleCount = 42 * (timeLeft / duration);
+        void confetti({
+          ...defaults,
+          particleCount,
+          origin: { x: randomInRange(0.12, 0.28), y: Math.random() - 0.15 },
+        });
+        void confetti({
+          ...defaults,
+          particleCount,
+          origin: { x: randomInRange(0.72, 0.88), y: Math.random() - 0.15 },
+        });
+      }, 220);
+    });
+  } catch (error) {
+    console.warn("[confetti] failed to load", error);
+  }
 }

--- a/apps/web/src/lib/dev-mode.ts
+++ b/apps/web/src/lib/dev-mode.ts
@@ -34,6 +34,8 @@ export function clearDevClientGameState(): void {
     "lastGameCompletion",
     "lastGameSolution",
     "lastEveClosingLine",
+    "rebuzzlePlayDays",
+    "rebuzzleEmailNudgeDismissed",
     "gameCompletion",
     "userStats",
   ];

--- a/apps/web/src/lib/dev-mode.ts
+++ b/apps/web/src/lib/dev-mode.ts
@@ -33,6 +33,7 @@ export function clearDevClientGameState(): void {
   const keys = [
     "lastGameCompletion",
     "lastGameSolution",
+    "lastEveClosingLine",
     "gameCompletion",
     "userStats",
   ];

--- a/apps/web/src/lib/game/__tests__/play-days.test.ts
+++ b/apps/web/src/lib/game/__tests__/play-days.test.ts
@@ -1,0 +1,43 @@
+import { getPlayDayCount, recordPlayDay, shouldPromptGuestSave } from "../play-days";
+
+describe("play-days", () => {
+  const store = new Map<string, string>();
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: globalThis,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        clear: () => {
+          store.clear();
+        },
+      },
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it("records distinct days and gates guest save on day 2", () => {
+    expect(getPlayDayCount()).toBe(0);
+    expect(shouldPromptGuestSave()).toBe(false);
+
+    expect(recordPlayDay("2026-08-01")).toBe(1);
+    expect(shouldPromptGuestSave()).toBe(false);
+
+    expect(recordPlayDay("2026-08-01")).toBe(1);
+    expect(recordPlayDay("2026-08-02")).toBe(2);
+    expect(shouldPromptGuestSave()).toBe(true);
+  });
+});

--- a/apps/web/src/lib/game/__tests__/reactions-cold-escalate.test.ts
+++ b/apps/web/src/lib/game/__tests__/reactions-cold-escalate.test.ts
@@ -13,13 +13,13 @@ describe("buildGuessReaction cold escalation", () => {
     expect(reaction.line).not.toMatch(/Cold streak|Two swings|collecting misses/i);
   });
 
-  it("uses sharper lines after two consecutive colds", () => {
+  it("uses sharper lines from the second consecutive cold", () => {
     const reaction = buildGuessReaction({
       correct: false,
       similarity: 10,
       attemptsLeft: 1,
       guess: "banana split",
-      consecutiveCold: 2,
+      consecutiveCold: 1,
     });
     expect(reaction.tier).toBe("cold");
     expect(reaction.line).toMatch(

--- a/apps/web/src/lib/game/__tests__/reactions-cold-escalate.test.ts
+++ b/apps/web/src/lib/game/__tests__/reactions-cold-escalate.test.ts
@@ -1,0 +1,29 @@
+import { buildGuessReaction } from "../reactions";
+
+describe("buildGuessReaction cold escalation", () => {
+  it("uses the base cold pool on the first cold", () => {
+    const reaction = buildGuessReaction({
+      correct: false,
+      similarity: 10,
+      attemptsLeft: 2,
+      guess: "banana split",
+      consecutiveCold: 0,
+    });
+    expect(reaction.tier).toBe("cold");
+    expect(reaction.line).not.toMatch(/Cold streak|Two swings|collecting misses/i);
+  });
+
+  it("uses sharper lines after two consecutive colds", () => {
+    const reaction = buildGuessReaction({
+      correct: false,
+      similarity: 10,
+      attemptsLeft: 1,
+      guess: "banana split",
+      consecutiveCold: 2,
+    });
+    expect(reaction.tier).toBe("cold");
+    expect(reaction.line).toMatch(
+      /Still cold|Two swings|collecting misses|Persistence noted|Cold streak/i
+    );
+  });
+});

--- a/apps/web/src/lib/game/__tests__/streak-tease.test.ts
+++ b/apps/web/src/lib/game/__tests__/streak-tease.test.ts
@@ -1,0 +1,17 @@
+import { getStreakTease } from "../streak-tease";
+
+describe("getStreakTease", () => {
+  it("encourages a fresh start after a loss", () => {
+    expect(getStreakTease(0, false)).toMatch(/Start a streak tomorrow/i);
+    expect(getStreakTease(4, false)).toMatch(/Streak reset/i);
+  });
+
+  it("celebrates milestone streaks", () => {
+    expect(getStreakTease(7, true)).toMatch(/7-day streak locked in/i);
+  });
+
+  it("teases the next milestone", () => {
+    expect(getStreakTease(5, true)).toMatch(/2 days to a 7-day streak/i);
+    expect(getStreakTease(6, true)).toMatch(/One more day for a 7-day streak/i);
+  });
+});

--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -34,3 +34,4 @@ export {
   type ReactionTier,
 } from "./reactions";
 export { getStreakTease } from "./streak-tease";
+export { getPlayDayCount, recordPlayDay, shouldPromptGuestSave } from "./play-days";

--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -33,3 +33,4 @@ export {
   type GuessReaction,
   type ReactionTier,
 } from "./reactions";
+export { getStreakTease } from "./streak-tease";

--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -34,4 +34,10 @@ export {
   type ReactionTier,
 } from "./reactions";
 export { getStreakTease } from "./streak-tease";
-export { getPlayDayCount, recordPlayDay, shouldPromptGuestSave } from "./play-days";
+export {
+  getLastPlayDay,
+  getPlayDayCount,
+  isComebackVisit,
+  recordPlayDay,
+  shouldPromptGuestSave,
+} from "./play-days";

--- a/apps/web/src/lib/game/play-days.ts
+++ b/apps/web/src/lib/game/play-days.ts
@@ -41,3 +41,27 @@ export function getPlayDayCount(): number {
 export function shouldPromptGuestSave(): boolean {
   return getPlayDayCount() >= 2;
 }
+
+export function getLastPlayDay(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const days = raw ? (JSON.parse(raw) as string[]) : [];
+    if (!Array.isArray(days) || days.length === 0) return null;
+    const sorted = [...days].sort();
+    return sorted[sorted.length - 1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the player has history but last play was before yesterday (gap ≥ 2 days). */
+export function isComebackVisit(): boolean {
+  const last = getLastPlayDay();
+  if (!last) return false;
+  const lastMs = Date.parse(`${last}T00:00:00.000Z`);
+  const todayMs = Date.parse(`${todayKey()}T00:00:00.000Z`);
+  if (Number.isNaN(lastMs) || Number.isNaN(todayMs)) return false;
+  const gapDays = Math.round((todayMs - lastMs) / (24 * 60 * 60 * 1000));
+  return gapDays >= 2;
+}

--- a/apps/web/src/lib/game/play-days.ts
+++ b/apps/web/src/lib/game/play-days.ts
@@ -1,0 +1,43 @@
+/**
+ * Track distinct UTC puzzle days played on this device.
+ * Used to gate guest signup until day 2 — conversion feels earned.
+ */
+
+const STORAGE_KEY = "rebuzzlePlayDays";
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function recordPlayDay(dateKey: string = todayKey()): number {
+  if (typeof window === "undefined") return 0;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const days: string[] = raw ? (JSON.parse(raw) as string[]) : [];
+    const next = Array.isArray(days) ? [...days] : [];
+    if (!next.includes(dateKey)) {
+      next.push(dateKey);
+      // Cap growth — we only care about early retention.
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next.slice(-60)));
+    }
+    return next.length;
+  } catch {
+    return 0;
+  }
+}
+
+export function getPlayDayCount(): number {
+  if (typeof window === "undefined") return 0;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const days = raw ? (JSON.parse(raw) as string[]) : [];
+    return Array.isArray(days) ? days.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Guest “keep your streak” after the second distinct play day. */
+export function shouldPromptGuestSave(): boolean {
+  return getPlayDayCount() >= 2;
+}

--- a/apps/web/src/lib/game/reactions.ts
+++ b/apps/web/src/lib/game/reactions.ts
@@ -24,6 +24,8 @@ interface ReactionInput {
   similarity: number;
   attemptsLeft: number;
   guess: string;
+  /** Prior consecutive cold misses this session (before this guess). */
+  consecutiveCold?: number;
 }
 
 /**
@@ -68,6 +70,15 @@ const LINES: Record<ReactionTier, readonly string[]> = {
   ],
 };
 
+/** Sharper colds after a streak of misses — still affectionate, never mean. */
+const COLD_ESCALATED: readonly string[] = [
+  "Still cold. The puzzle isn't moving — you are.",
+  "Two swings, same thin air. Reset and look again.",
+  "We're collecting misses. Charming collection.",
+  "Persistence noted. Accuracy pending.",
+  "Cold streak. Break it with a smaller thought.",
+];
+
 /** Stable small hash so the same guess always gets the same line. */
 function hash(input: string): number {
   let h = 0;
@@ -82,7 +93,7 @@ export function getReactionTier({
   correct,
   similarity,
   attemptsLeft,
-}: Omit<ReactionInput, "guess">): ReactionTier {
+}: Omit<ReactionInput, "guess" | "consecutiveCold">): ReactionTier {
   if (correct) return "correct";
   if (attemptsLeft <= 0) return "out";
   if (similarity >= 70) return "close";
@@ -92,7 +103,8 @@ export function getReactionTier({
 
 export function buildGuessReaction(input: ReactionInput): GuessReaction {
   const tier = getReactionTier(input);
-  const pool = LINES[tier];
+  const escalateCold = tier === "cold" && (input.consecutiveCold ?? 0) >= 2;
+  const pool = escalateCold ? COLD_ESCALATED : LINES[tier];
   const line = pool[hash(input.guess.toLowerCase()) % pool.length] ?? pool[0];
   return { tier, line: line as string };
 }

--- a/apps/web/src/lib/game/reactions.ts
+++ b/apps/web/src/lib/game/reactions.ts
@@ -6,8 +6,9 @@
  * client never needs the answer to know how badly it missed.
  *
  * These lines are the floor, not the ceiling: /api/puzzles/quip streams a
- * written-fresh line over the top when the model is available. If it isn't,
- * these stand on their own and nobody can tell the difference.
+ * written-fresh line over the top when the model is available — including a
+ * closing win/loss riff before chat locks. If it isn't, these stand on their
+ * own and nobody can tell the difference.
  */
 
 export type ReactionTier = "correct" | "close" | "warm" | "cold" | "out";

--- a/apps/web/src/lib/game/reactions.ts
+++ b/apps/web/src/lib/game/reactions.ts
@@ -103,7 +103,8 @@ export function getReactionTier({
 
 export function buildGuessReaction(input: ReactionInput): GuessReaction {
   const tier = getReactionTier(input);
-  const escalateCold = tier === "cold" && (input.consecutiveCold ?? 0) >= 2;
+  // Escalate from the second cold onward (3-attempt days rarely reach a third).
+  const escalateCold = tier === "cold" && (input.consecutiveCold ?? 0) >= 1;
   const pool = escalateCold ? COLD_ESCALATED : LINES[tier];
   const line = pool[hash(input.guess.toLowerCase()) % pool.length] ?? pool[0];
   return { tier, line: line as string };

--- a/apps/web/src/lib/game/streak-tease.ts
+++ b/apps/web/src/lib/game/streak-tease.ts
@@ -1,0 +1,28 @@
+/**
+ * Short retention copy for streak / tomorrow hooks.
+ * Keeps the joke about the chain, never about the player.
+ */
+
+const MILESTONES = [3, 7, 14, 30, 100] as const;
+
+export function getStreakTease(streak: number, success: boolean): string {
+  if (!success) {
+    return streak > 0
+      ? "Streak reset. Tomorrow is a clean start — one puzzle."
+      : "Start a streak tomorrow. One puzzle a day.";
+  }
+
+  if ((MILESTONES as readonly number[]).includes(streak)) {
+    return `${streak}-day streak locked in. Don't break it tomorrow.`;
+  }
+
+  const next = MILESTONES.find((milestone) => milestone > streak);
+  if (next) {
+    const left = next - streak;
+    return left === 1
+      ? `One more day for a ${next}-day streak.`
+      : `${left} days to a ${next}-day streak. Protect it tomorrow.`;
+  }
+
+  return `${streak}-day streak. Keep the chain going tomorrow.`;
+}

--- a/apps/web/src/lib/haptics.ts
+++ b/apps/web/src/lib/haptics.ts
@@ -34,20 +34,26 @@ export const haptics = {
   /** Double pulse - correct word typed */
   success: () => vibrate([30, 50, 30]),
 
-  /** Single longer buzz - wrong guess */
+  /** Single longer buzz - cold / wrong guess */
   error: () => vibrate(100),
 
-  /** Warning pulse - last attempt */
+  /** Soft double tick - warm (partly on track) */
+  warm: () => vibrate([20, 40, 20]),
+
+  /** Warning pulse - close miss / last attempt */
   warning: () => vibrate([50, 30, 50]),
 
   /** Celebration pattern - puzzle complete */
   celebration: () => vibrate([100, 50, 100, 50, 200]),
 
-  /** Soft tick - hint revealed */
+  /** Soft tick - hint revealed / send armed */
   hint: () => vibrate(15),
 
   /** Medium impact - submit action */
   submit: () => vibrate(40),
+
+  /** Soft lock click - day closed */
+  lock: () => vibrate([12, 30, 18]),
 
   /** Cancel any ongoing vibration */
   cancel: () => vibrate(0),

--- a/apps/web/src/lib/interface-sounds.ts
+++ b/apps/web/src/lib/interface-sounds.ts
@@ -41,6 +41,8 @@ const CUES: Record<InterfaceSoundCue, CueDefinition> = {
 interface PlayInterfaceSoundOptions {
   /** Used only by the sound preference control so users can hear the setting change. */
   ignorePreference?: boolean;
+  /** Override cue pitch — used for graded incorrect feedback. */
+  playbackRate?: number;
 }
 
 export async function playInterfaceSound(
@@ -55,7 +57,7 @@ export async function playInterfaceSound(
   try {
     await playSound(definition.asset.dataUri, {
       volume: definition.volume,
-      playbackRate: definition.playbackRate,
+      playbackRate: options.playbackRate ?? definition.playbackRate,
     });
     return true;
   } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Ships the completion celebration cleanup plus a dense set of retention micro-hooks in the in-thread play loop.

### Completion polish (earlier)
- Confetti / haptics on lock, Eve closing quip, ChatClosingDock
- Widget cleanup after solve; streak teases and countdown rituals

### Twelve addictive hooks (this revision)
1. **Near-word ticks** — amber `~ word` at ≥70% similarity in GuessThread  
2. **Clutch chip** — last-heart win label on SolveResultCard  
3. **Daily-bonus whisper** — `×N day` when the date-seeded bonus is live  
4. **Pace murmur** — percentile label from `/api/puzzles/stats` after a win  
5. **PB delta** — `PB` / `−Ns vs best` vs prior `fastestSolveSeconds`  
6. **No-hint streak** — `No hints · N` on clean solves  
7. **Incorrect pitch climb** — cold 0.94 / warm 1.02 / near-miss cue  
8. **Tab-return itch** — soft haptic when returning to the tab under 1h to midnight  
9. **Grace caption** — `Grace window · streak safe` in 00–02 UTC  
10. **Comeback caption** — `Welcome back · one puzzle` after a ≥2 day gap  
11. **Level-rim flicker** — warning bar when within ~15% of next level  
12. **Clutch / perfect share lines** — first-guess & last-heart copy in EnhancedShareButton  

## Test plan
- [ ] Solve with a ≥70% wrong word in a multi-word answer → amber `~` tick  
- [ ] Win on last heart → Clutch chip + share text mentions clutch  
- [ ] Win first guess → share says “First guess”  
- [ ] Clean win after prior no-hint streak → `No hints · N`  
- [ ] Beat prior best time → PB / −Ns label  
- [ ] After win, pace murmur appears when puzzle stats exist  
- [ ] Cold / warm / close misses play distinct incorrect pitches  
- [ ] Under 1h to midnight, switch tabs and return → haptic  
- [ ] Visit during UTC grace with streak → grace caption  
- [ ] Gap ≥ 2 play days → welcome-back caption  
- [ ] Near next level after win → level-rim flicker  

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

