### PR TITLE
fix(web): standardize puzzle colors with contrast-aware surfaces

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "@react-email/render": "^2.0.0",
     "@rebuzzle/config": "workspace:^",
     "@rebuzzle/game-logic": "workspace:^",
+    "@shadcn/react": "^0.2.1",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/web-push": "^3.6.4",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -828,6 +828,19 @@
   --stage-radius: 12px;
 }
 
+/* Keyboard-open: real small tiles (no transform shrink that clips glyphs). */
+.puzzle-stage[data-state="compact"] {
+  --stage-pad: 0.5rem;
+  --stage-min: 0px;
+  --stage-scale: 1;
+  --stage-radius: 12px;
+}
+
+.puzzle-stage[data-state="compact"] .puzzle-stage-plate {
+  min-height: 0;
+  overflow: visible;
+}
+
 .puzzle-stage-plate {
   position: relative;
   display: flex;
@@ -941,6 +954,12 @@
 
 .guess-thread {
   min-height: 0;
+  flex: 1 1 auto;
+}
+
+.guess-thread [data-slot="message-scroller-viewport"] {
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .guess-thread [data-slot="message-scroller-item"] {
@@ -1112,17 +1131,24 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
   overflow: hidden;
-  transition: height 0.3s ease-out;
+  transition: height 0.2s ease-out;
 }
 
-.keyboard-visible .puzzle-area,
+.keyboard-visible .puzzle-area {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
 .keyboard-visible .input-area {
   flex: 0 0 auto;
 }
 
-.keyboard-visible .puzzle-area {
-  overflow: hidden;
+.keyboard-visible .play-dock {
+  padding-top: 0.75rem;
+  padding-bottom: max(env(safe-area-inset-bottom), 12px);
 }
 
 .input-area-keyboard-transition {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -838,8 +838,9 @@
   min-height: var(--stage-min);
   padding: var(--stage-pad) clamp(1rem, 4vw, 2rem);
   border-radius: var(--stage-radius);
-  /* Near-black in both themes: the plate is the room, not a card. */
+  /* Cinema default: near-black room for unicode / emoji boards. */
   background: radial-gradient(120% 140% at 50% 0%, #1c1c1c 0%, #0a0a0a 62%);
+  color: #f5f5f4;
   box-shadow:
     0 1px 2px rgb(0 0 0 / 0.3),
     0 24px 60px -24px rgb(0 0 0 / 0.45),
@@ -848,7 +849,19 @@
     min-height 420ms var(--ease),
     padding 420ms var(--ease),
     border-radius 420ms var(--ease),
-    box-shadow 420ms var(--ease);
+    box-shadow 420ms var(--ease),
+    background 280ms var(--ease),
+    color 280ms var(--ease);
+}
+
+/* Ink Pictogram boards — authored for paper; never sit on cinema black. */
+.puzzle-stage-plate--paper {
+  background: var(--puzzle-canvas, #f4f6f3);
+  color: var(--puzzle-ink, #1a1f1c);
+  box-shadow:
+    0 1px 2px rgb(26 31 28 / 0.08),
+    0 18px 40px -24px rgb(26 31 28 / 0.22),
+    inset 0 0 0 1px rgb(26 31 28 / 0.08);
 }
 
 .puzzle-stage[data-state="docked"] .puzzle-stage-plate {
@@ -856,6 +869,13 @@
     0 1px 2px rgb(0 0 0 / 0.25),
     0 12px 28px -18px rgb(0 0 0 / 0.4),
     inset 0 0 0 1px rgb(255 255 255 / 0.07);
+}
+
+.puzzle-stage[data-state="docked"] .puzzle-stage-plate--paper {
+  box-shadow:
+    0 1px 2px rgb(26 31 28 / 0.06),
+    0 10px 22px -16px rgb(26 31 28 / 0.18),
+    inset 0 0 0 1px rgb(26 31 28 / 0.08);
 }
 
 /* The light behind the puzzle. Sits under the content, never over it. */

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -940,16 +940,10 @@
    ============================================================ */
 
 .guess-thread {
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
+  min-height: 0;
 }
 
-.guess-thread::-webkit-scrollbar {
-  display: none;
-}
-
-.guess-thread > * {
+.guess-thread [data-slot="message-scroller-item"] {
   animation: message-in 320ms var(--ease) both;
 }
 
@@ -966,7 +960,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .guess-thread > * {
+  .guess-thread [data-slot="message-scroller-item"] {
     animation: none !important;
   }
 }

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -1111,7 +1111,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                       </div>
                     ) : null}
 
-                    <section aria-label="Puzzle" className="w-full max-w-2xl">
+                    <section aria-label="Puzzle" className="w-full max-w-2xl shrink-0">
                       <PuzzleStage
                         puzzle={puzzleDisplay}
                         puzzleType={puzzleType}
@@ -1123,7 +1123,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
 
                     {hasThread ? (
                       <GuessThread
-                        className="mt-[clamp(0.75rem,2.5vh,1.25rem)] max-w-2xl flex-1 px-0.5 pb-2"
+                        className="mt-[clamp(0.75rem,2.5vh,1.25rem)] max-w-2xl min-h-0 flex-1 px-0.5"
                         footer={resultCard}
                         turns={turns}
                       />

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -38,7 +38,6 @@ import { GuessThread, type ThreadTurn } from "./GuessThread";
 import { HintBadge } from "./HintBadge";
 import { KeyboardAwareLayout } from "./KeyboardAwareLayout";
 import { getPuzzleQuestion } from "./PuzzleDisplay";
-import { PuzzleMinimal } from "./PuzzleMinimal";
 import { PuzzleStage } from "./PuzzleStage";
 import { SmartAnswerInput } from "./SmartAnswerInput";
 import { SolveResultCard } from "./SolveResultCard";
@@ -1042,98 +1041,92 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       {/* Main content area - keyboard-aware layout */}
       <KeyboardAwareLayout>
         {({ isKeyboardVisible }) => {
-          // After lock, always show the full thread + result — never the collapsed keyboard view.
-          const collapsed = isKeyboardVisible && !gameState.gameOver;
+          // After lock, keep the full thread — don't collapse for the keyboard.
+          const keyboardOpen = isKeyboardVisible && !gameState.gameOver;
+          const stageState = keyboardOpen ? "compact" : hasThread ? "docked" : "hero";
+
           return (
-            <div className="flex flex-col h-full">
-              {/* Puzzle area - collapses when keyboard is visible, centers content */}
-              <main className="flex-1 overflow-hidden transition-all duration-300 puzzle-area flex flex-col">
-                {collapsed ? (
-                  /* COLLAPSED VIEW - minimal puzzle + last Eve line while typing */
-                  <div className="flex flex-col items-center px-4 pt-2">
-                    <PuzzleMinimal
+            <div className="flex h-full min-h-0 flex-col">
+              <main className="puzzle-area flex min-h-0 flex-1 flex-col overflow-hidden">
+                <div
+                  className={cn(
+                    "play-stage flex min-h-0 flex-1 flex-col items-center overflow-hidden px-4 md:px-6",
+                    keyboardOpen
+                      ? "justify-start py-2"
+                      : hasThread
+                        ? "justify-start py-[clamp(0.5rem,2vh,1rem)]"
+                        : "justify-center py-[clamp(0.5rem,2vh,1rem)]"
+                  )}
+                >
+                  {showStageChrome && !keyboardOpen ? (
+                    <div className="mb-[clamp(0.5rem,2vh,1rem)] flex w-full max-w-2xl items-start justify-between gap-3">
+                      {!hasThread ? (
+                        <DifficultyBadge
+                          className="play-fade-in"
+                          difficulty={currentEventPuzzle?.difficulty}
+                          showDescription
+                        />
+                      ) : (
+                        <span />
+                      )}
+                      {gameData.hints && gameData.hints.length > 0 ? (
+                        <HintBadge
+                          hints={gameData.hints}
+                          gameId={gameData.id}
+                          onHintReveal={(hintIndex) => {
+                            dispatch({ type: "REVEAL_HINT" });
+                            void playInterfaceSound("hint");
+                            trackEvent(analyticsEvents.HINT_USED, {
+                              puzzleId: gameData.id || "unknown",
+                              hintIndex,
+                            });
+                          }}
+                        />
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  <section aria-label="Puzzle" className="w-full max-w-2xl shrink-0">
+                    <PuzzleStage
                       puzzle={puzzleDisplay}
                       puzzleType={puzzleType}
+                      question={keyboardOpen ? undefined : stageCaption}
+                      state={stageState}
                       visual={gameData.visual}
-                      className="w-full max-w-2xl"
                     />
-                    {lastTurn ? (
-                      <div className="mt-2 w-full max-w-2xl text-center">
-                        <div className="font-mono text-[11px] text-subtle uppercase tracking-[0.08em]">
-                          Last: {lastTurn.text}
-                        </div>
-                        <p
-                          className={cn(
-                            "mt-1 line-clamp-2 text-xs leading-5",
-                            lastTurn.tier === "close" || lastTurn.tier === "warm"
-                              ? "text-warning"
-                              : "text-muted-foreground"
-                          )}
-                        >
-                          Eve · {lastTurn.line}
-                        </p>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : (
-                  /* EXPANDED VIEW — focused play stage */
-                  <div
-                    className={cn(
-                      "play-stage flex flex-1 flex-col items-center overflow-hidden px-4 py-[clamp(0.5rem,2vh,1rem)] md:px-6",
-                      hasThread ? "justify-start" : "justify-center"
-                    )}
-                  >
-                    {showStageChrome ? (
-                      <div className="mb-[clamp(0.5rem,2vh,1rem)] flex w-full max-w-2xl items-start justify-between gap-3">
-                        {!hasThread ? (
-                          <DifficultyBadge
-                            className="play-fade-in"
-                            difficulty={currentEventPuzzle?.difficulty}
-                            showDescription
-                          />
-                        ) : (
-                          <span />
-                        )}
-                        {gameData.hints && gameData.hints.length > 0 ? (
-                          <HintBadge
-                            hints={gameData.hints}
-                            gameId={gameData.id}
-                            onHintReveal={(hintIndex) => {
-                              dispatch({ type: "REVEAL_HINT" });
-                              void playInterfaceSound("hint");
-                              trackEvent(analyticsEvents.HINT_USED, {
-                                puzzleId: gameData.id || "unknown",
-                                hintIndex,
-                              });
-                            }}
-                          />
-                        ) : null}
-                      </div>
-                    ) : null}
+                  </section>
 
-                    <section aria-label="Puzzle" className="w-full max-w-2xl shrink-0">
-                      <PuzzleStage
-                        puzzle={puzzleDisplay}
-                        puzzleType={puzzleType}
-                        question={stageCaption}
-                        state={hasThread ? "docked" : "hero"}
-                        visual={gameData.visual}
-                      />
-                    </section>
+                  {keyboardOpen && lastTurn ? (
+                    <p
+                      className={cn(
+                        "mt-1.5 w-full max-w-2xl truncate text-center text-xs leading-5",
+                        lastTurn.tier === "close" || lastTurn.tier === "warm"
+                          ? "text-warning"
+                          : "text-muted-foreground"
+                      )}
+                    >
+                      <span className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+                        {lastTurn.text}
+                      </span>
+                      <span className="mx-1.5 text-border-strong">·</span>
+                      Eve · {lastTurn.line}
+                    </p>
+                  ) : null}
 
-                    {hasThread ? (
-                      <GuessThread
-                        className="mt-[clamp(0.75rem,2.5vh,1.25rem)] max-w-2xl min-h-0 flex-1 px-0.5"
-                        footer={resultCard}
-                        turns={turns}
-                      />
-                    ) : resultCard ? (
-                      <div className="mt-[clamp(0.75rem,2.5vh,1.25rem)] w-full max-w-2xl px-0.5 pb-2">
-                        {resultCard}
-                      </div>
-                    ) : null}
-                  </div>
-                )}
+                  {hasThread && !keyboardOpen ? (
+                    <GuessThread
+                      className="mt-[clamp(0.75rem,2.5vh,1.25rem)] max-w-2xl"
+                      footer={resultCard}
+                      turns={turns}
+                    />
+                  ) : null}
+
+                  {!hasThread && resultCard && !keyboardOpen ? (
+                    <div className="mt-[clamp(0.75rem,2.5vh,1.25rem)] w-full max-w-2xl px-0.5 pb-2">
+                      {resultCard}
+                    </div>
+                  ) : null}
+                </div>
               </main>
 
               {/* Error display - positioned above input area */}

--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -132,43 +132,41 @@ function AgentReply({ turn }: { turn: ThreadTurn }) {
 }
 
 /**
- * The conversation.
- *
- * Uses shadcn MessageScroller so the thread can scroll on mobile and desktop,
- * anchors each new guess, and follows Eve's streamed riff while the reader
- * stays at the live edge.
+ * The conversation — shadcn MessageScroller owns scroll / anchor / jump-to-latest.
  */
 export function GuessThread({ turns, footer, className }: GuessThreadProps) {
   if (turns.length === 0) return null;
 
   return (
-    <MessageScrollerProvider autoScroll defaultScrollPosition="last-anchor">
-      <MessageScroller className={cn("guess-thread w-full min-h-0 flex-1", className)}>
-        <MessageScrollerViewport aria-label="Your guesses and Eve's replies">
-          <MessageScrollerContent className="pb-2" role="log" aria-live="polite">
-            {turns.map((turn) => (
-              <MessageScrollerItem
-                key={turn.id}
-                messageId={`guess-${turn.id}`}
-                scrollAnchor
-                className="flex flex-col gap-3"
-              >
-                <MessageRow from="user">
-                  <MessageBubble from="user">{turn.text}</MessageBubble>
-                </MessageRow>
-                <AgentReply turn={turn} />
-              </MessageScrollerItem>
-            ))}
+    <div className={cn("guess-thread flex min-h-0 w-full flex-1 flex-col", className)}>
+      <MessageScrollerProvider autoScroll defaultScrollPosition="last-anchor">
+        <MessageScroller>
+          <MessageScrollerViewport aria-label="Your guesses and Eve's replies">
+            <MessageScrollerContent className="px-0.5 pb-3" role="log" aria-live="polite">
+              {turns.map((turn) => (
+                <MessageScrollerItem
+                  key={turn.id}
+                  messageId={`guess-${turn.id}`}
+                  scrollAnchor
+                  className="flex flex-col gap-3"
+                >
+                  <MessageRow from="user">
+                    <MessageBubble from="user">{turn.text}</MessageBubble>
+                  </MessageRow>
+                  <AgentReply turn={turn} />
+                </MessageScrollerItem>
+              ))}
 
-            {footer ? (
-              <MessageScrollerItem messageId="solve-result" className="pt-1">
-                {footer}
-              </MessageScrollerItem>
-            ) : null}
-          </MessageScrollerContent>
-        </MessageScrollerViewport>
-        <MessageScrollerButton />
-      </MessageScroller>
-    </MessageScrollerProvider>
+              {footer ? (
+                <MessageScrollerItem messageId="solve-result" className="pt-1">
+                  {footer}
+                </MessageScrollerItem>
+              ) : null}
+            </MessageScrollerContent>
+          </MessageScrollerViewport>
+          <MessageScrollerButton />
+        </MessageScroller>
+      </MessageScrollerProvider>
+    </div>
   );
 }

--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   MessageAvatar,
   MessageBubble,
@@ -9,6 +9,14 @@ import {
   MessageRow,
   MessageTyping,
 } from "@/components/ui/message";
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from "@/components/ui/message-scroller";
 import type { WordResult } from "@/lib/game/build-word-results";
 import { REACTION_TONE, type ReactionTier } from "@/lib/game/reactions";
 import { cn } from "@/lib/utils";
@@ -126,42 +134,41 @@ function AgentReply({ turn }: { turn: ThreadTurn }) {
 /**
  * The conversation.
  *
- * Each guess is a turn: what you said, Eve's instant read on it, and — if the
- * model gets there in time — an extra riff where she can't help adding
- * something. The instant line never waits on the model, so feedback is always
- * immediate; the riff types itself into the same reply if it shows up.
+ * Uses shadcn MessageScroller so the thread can scroll on mobile and desktop,
+ * anchors each new guess, and follows Eve's streamed riff while the reader
+ * stays at the live edge.
  */
 export function GuessThread({ turns, footer, className }: GuessThreadProps) {
-  const endRef = useRef<HTMLLIElement>(null);
-  const lastQuip = turns.at(-1)?.quip;
-  const hasFooter = Boolean(footer);
-  const lastTier = turns.at(-1)?.tier;
-
-  useEffect(() => {
-    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    endRef.current?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "end" });
-  }, [turns.length, lastQuip, hasFooter, lastTier]);
-
   if (turns.length === 0) return null;
 
   return (
-    <ol
-      aria-label="Your guesses and Eve's replies"
-      className={cn("guess-thread flex w-full flex-col gap-5 overflow-y-auto", className)}
-      role="log"
-    >
-      {turns.map((turn) => (
-        <li className="flex flex-col gap-3" key={turn.id}>
-          <MessageRow from="user">
-            <MessageBubble from="user">{turn.text}</MessageBubble>
-          </MessageRow>
-          <AgentReply turn={turn} />
-        </li>
-      ))}
+    <MessageScrollerProvider autoScroll defaultScrollPosition="last-anchor">
+      <MessageScroller className={cn("guess-thread w-full min-h-0 flex-1", className)}>
+        <MessageScrollerViewport aria-label="Your guesses and Eve's replies">
+          <MessageScrollerContent className="pb-2" role="log" aria-live="polite">
+            {turns.map((turn) => (
+              <MessageScrollerItem
+                key={turn.id}
+                messageId={`guess-${turn.id}`}
+                scrollAnchor
+                className="flex flex-col gap-3"
+              >
+                <MessageRow from="user">
+                  <MessageBubble from="user">{turn.text}</MessageBubble>
+                </MessageRow>
+                <AgentReply turn={turn} />
+              </MessageScrollerItem>
+            ))}
 
-      {footer ? <li className="list-none pt-1">{footer}</li> : null}
-
-      <li aria-hidden ref={endRef} />
-    </ol>
+            {footer ? (
+              <MessageScrollerItem messageId="solve-result" className="pt-1">
+                {footer}
+              </MessageScrollerItem>
+            ) : null}
+          </MessageScrollerContent>
+        </MessageScrollerViewport>
+        <MessageScrollerButton />
+      </MessageScroller>
+    </MessageScrollerProvider>
   );
 }

--- a/apps/web/src/components/KeyboardAwareLayout.tsx
+++ b/apps/web/src/components/KeyboardAwareLayout.tsx
@@ -11,42 +11,14 @@ interface KeyboardAwareRenderProps {
 }
 
 interface KeyboardAwareLayoutProps {
-  /**
-   * Render props pattern - children receive keyboard state
-   */
   children: (props: KeyboardAwareRenderProps) => ReactNode;
-  /**
-   * Additional CSS classes for the container
-   */
   className?: string;
-  /**
-   * Whether to apply body scroll lock when mounted
-   * @default true on mobile
-   */
+  /** @default true on touch devices */
   lockBodyScroll?: boolean;
 }
 
 /**
- * KeyboardAwareLayout - A wrapper component that handles virtual keyboard visibility.
- *
- * Uses the Visual Viewport API to detect when the virtual keyboard is open and
- * provides this state to children via render props.
- *
- * @example
- * ```tsx
- * <KeyboardAwareLayout>
- *   {({ isKeyboardVisible, keyboardHeight }) => (
- *     <div className="flex flex-col h-full">
- *       {isKeyboardVisible ? (
- *         <MinimalPuzzleView />
- *       ) : (
- *         <FullPuzzleView />
- *       )}
- *       <InputArea />
- *     </div>
- *   )}
- * </KeyboardAwareLayout>
- * ```
+ * Fills the game shell and shrinks to the visual viewport when the keyboard opens.
  */
 export function KeyboardAwareLayout({
   children,
@@ -56,46 +28,36 @@ export function KeyboardAwareLayout({
   const { isKeyboardVisible, keyboardHeight, visualViewportHeight } = useVisualViewport();
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Set CSS custom properties for use in child components
   useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.style.setProperty("--keyboard-height", `${keyboardHeight}px`);
-      containerRef.current.style.setProperty("--visible-height", `${visualViewportHeight}px`);
-    }
+    if (!containerRef.current) return;
+    containerRef.current.style.setProperty("--keyboard-height", `${keyboardHeight}px`);
+    containerRef.current.style.setProperty("--visible-height", `${visualViewportHeight}px`);
   }, [keyboardHeight, visualViewportHeight]);
 
-  // Optional body scroll lock on mobile
   useEffect(() => {
     if (!lockBodyScroll) return;
-
-    // Only apply on touch devices
     const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) return;
 
-    // Add class to body to prevent background scroll
     document.body.classList.add("keyboard-layout-active");
-
     return () => {
       document.body.classList.remove("keyboard-layout-active");
     };
   }, [lockBodyScroll]);
 
-  // Calculate the container height
-  // When keyboard is visible, use the visual viewport height
-  // Otherwise, use 100dvh (or 100vh as fallback)
-  const containerStyle = isKeyboardVisible
-    ? { height: `${visualViewportHeight}px` }
-    : undefined; // Let CSS handle it with 100dvh
-
   return (
     <div
       ref={containerRef}
       className={cn(
-        "keyboard-aware-container",
+        "keyboard-aware-container flex h-full min-h-0 flex-col overflow-hidden",
         isKeyboardVisible && "keyboard-visible",
         className
       )}
-      style={containerStyle}
+      style={
+        isKeyboardVisible && visualViewportHeight > 0
+          ? { height: `${visualViewportHeight}px`, maxHeight: `${visualViewportHeight}px` }
+          : undefined
+      }
     >
       {children({
         isKeyboardVisible,

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -87,8 +87,8 @@ function LayoutContent({
 
       <main
         className={cn(
-          "relative z-10 flex-1",
-          // Game page: no overflow/scroll
+          "relative z-10 flex min-h-0 flex-1 flex-col",
+          // Game page: no page scroll — the chat scroller owns overflow.
           isGamePage && "overflow-hidden",
           className
         )}

--- a/apps/web/src/components/PuzzleMinimal.tsx
+++ b/apps/web/src/components/PuzzleMinimal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useMemo } from "react";
 import type { PuzzleVisual } from "@/lib/gameSettings";
+import { resolvePuzzleSurface } from "@/lib/puzzle-surface";
 import { cn } from "@/lib/utils";
 import { hasComposedVisual, PuzzleVisualBoard } from "./PuzzleVisualBoard";
 
@@ -79,6 +81,8 @@ export function PuzzleMinimal({ puzzle, puzzleType, visual, className }: PuzzleM
 
   const content = getMinimalContent();
   const fontSizeClass = getFontSizeClass();
+  const composed = hasComposedVisual(visual) && Boolean(visual);
+  const surface = useMemo(() => resolvePuzzleSurface(visual), [visual]);
 
   return (
     <div
@@ -94,20 +98,28 @@ export function PuzzleMinimal({ puzzle, puzzleType, visual, className }: PuzzleM
       <div
         className={cn(
           "rounded-xl",
-          "bg-muted/50",
-          "border border-dashed border-border/50",
+          !composed && "bg-muted/50 border border-dashed border-border/50",
+          composed && surface.mode === "paper" && "border border-black/10",
+          composed && surface.mode === "cinema" && "border border-white/10",
           "px-4 py-2",
           "max-w-full",
           "overflow-hidden"
         )}
+        style={
+          composed
+            ? {
+                background: surface.canvas,
+                color: surface.ink,
+              }
+            : undefined
+        }
       >
-        {hasComposedVisual(visual) && visual ? (
+        {composed && visual ? (
           <PuzzleVisualBoard
             visual={visual}
             fallback={content}
             compact
             size="small"
-            className="text-foreground/90"
           />
         ) : (
           <span

--- a/apps/web/src/components/PuzzleStage.tsx
+++ b/apps/web/src/components/PuzzleStage.tsx
@@ -7,16 +7,15 @@ import { cn } from "@/lib/utils";
 import { hasComposedVisual } from "./PuzzleVisualBoard";
 import { PuzzleDisplay } from "./PuzzleDisplay";
 
-export type StageState = "hero" | "docked";
+export type StageState = "hero" | "docked" | "compact";
 
 interface PuzzleStageProps {
   puzzle: string;
   puzzleType: string;
   /**
    * `hero` before the first guess — the puzzle owns the screen.
-   * `docked` once the thread starts — it shrinks and pins to the top so the
-   * conversation has room, the way a video collapses when you start reading
-   * the comments.
+   * `docked` once the thread starts — it shrinks and pins to the top.
+   * `compact` while the mobile keyboard is open — full puzzle, smaller plate.
    */
   state: StageState;
   question?: string;
@@ -34,10 +33,15 @@ const SMALL_TEXT_TYPES = new Set(["riddle", "trivia", "logic-grid", "cryptic-cro
  * non-palette meaning colors, the surface flips for contrast.
  */
 export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: PuzzleStageProps) {
-  const size = SMALL_TEXT_TYPES.has(puzzleType) ? "small" : "large";
   const composed = hasComposedVisual(visual);
   const surface = useMemo(() => resolvePuzzleSurface(visual), [visual]);
   const onPaper = surface.mode === "paper";
+  const size =
+    state === "compact" || SMALL_TEXT_TYPES.has(puzzleType)
+      ? "small"
+      : state === "docked"
+        ? "medium"
+        : "large";
 
   return (
     <div className="puzzle-stage w-full" data-state={state} data-surface={surface.mode}>
@@ -52,13 +56,8 @@ export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: Puz
             : undefined
         }
       >
-        {/* Atmospheric wash — cinema only; paper boards stay clean. */}
         {!onPaper ? <div aria-hidden className="puzzle-stage-glow" /> : null}
 
-        {/*
-         * The docked state scales this wrapper rather than swapping the type
-         * size, so the shrink is one continuous motion instead of a cut.
-         */}
         <div className="puzzle-stage-content">
           <PuzzleDisplay
             className={onPaper || composed ? undefined : "text-white"}
@@ -70,7 +69,9 @@ export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: Puz
         </div>
       </div>
 
-      {question ? <p className="puzzle-stage-caption">{question}</p> : null}
+      {question && state !== "compact" ? (
+        <p className="puzzle-stage-caption">{question}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/PuzzleStage.tsx
+++ b/apps/web/src/components/PuzzleStage.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import { type CSSProperties, useMemo } from "react";
 import type { PuzzleVisual } from "@/lib/gameSettings";
+import { resolvePuzzleSurface } from "@/lib/puzzle-surface";
+import { cn } from "@/lib/utils";
+import { hasComposedVisual } from "./PuzzleVisualBoard";
 import { PuzzleDisplay } from "./PuzzleDisplay";
 
 export type StageState = "hero" | "docked";
@@ -25,18 +29,31 @@ const SMALL_TEXT_TYPES = new Set(["riddle", "trivia", "logic-grid", "cryptic-cro
 /**
  * The puzzle plate.
  *
- * A single dark, letterboxed surface with no visible chrome beyond its own
- * edge — the puzzle is the only lit thing on it. Both states share one element
- * so the shrink is a real transition rather than a swap.
+ * Standard ink boards sit on paper (the surface they were drawn for).
+ * Unicode/emoji boards keep the dark cinema plate. If a board paints
+ * non-palette meaning colors, the surface flips for contrast.
  */
 export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: PuzzleStageProps) {
   const size = SMALL_TEXT_TYPES.has(puzzleType) ? "small" : "large";
+  const composed = hasComposedVisual(visual);
+  const surface = useMemo(() => resolvePuzzleSurface(visual), [visual]);
+  const onPaper = surface.mode === "paper";
 
   return (
-    <div className="puzzle-stage w-full" data-state={state}>
-      <div className="puzzle-stage-plate">
-        {/* Atmospheric wash — the plate is lit from behind, not decorated. */}
-        <div aria-hidden className="puzzle-stage-glow" />
+    <div className="puzzle-stage w-full" data-state={state} data-surface={surface.mode}>
+      <div
+        className={cn("puzzle-stage-plate", onPaper && "puzzle-stage-plate--paper")}
+        style={
+          onPaper
+            ? ({
+                "--puzzle-canvas": surface.canvas,
+                "--puzzle-ink": surface.ink,
+              } as CSSProperties)
+            : undefined
+        }
+      >
+        {/* Atmospheric wash — cinema only; paper boards stay clean. */}
+        {!onPaper ? <div aria-hidden className="puzzle-stage-glow" /> : null}
 
         {/*
          * The docked state scales this wrapper rather than swapping the type
@@ -44,7 +61,7 @@ export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: Puz
          */}
         <div className="puzzle-stage-content">
           <PuzzleDisplay
-            className="text-white"
+            className={onPaper || composed ? undefined : "text-white"}
             puzzle={puzzle}
             puzzleType={puzzleType}
             size={size}

--- a/apps/web/src/components/PuzzleVisualBoard.tsx
+++ b/apps/web/src/components/PuzzleVisualBoard.tsx
@@ -6,7 +6,9 @@ import {
   type PuzzleBoardSize,
 } from "@/ai/puzzle-agent/visual/presentation";
 import { sanitizePictogramSvg } from "@/ai/puzzle-agent/visual/sanitize-svg";
+import { INK_PICTOGRAM_PALETTE } from "@/ai/puzzle-agent/visual/style";
 import type { PuzzleVisual, PuzzleVisualLayer } from "@/lib/gameSettings";
+import { resolvePuzzleSurface } from "@/lib/puzzle-surface";
 import { cn } from "@/lib/utils";
 
 interface PuzzleVisualBoardProps {
@@ -97,12 +99,15 @@ function TextTile({
   return (
     <span
       className={cn(
-        "puzzle-text-layer inline-block text-foreground animate-in fade-in slide-in-from-bottom-1 duration-500 fill-mode-both motion-reduce:animate-none",
+        "puzzle-text-layer inline-block animate-in fade-in slide-in-from-bottom-1 duration-500 fill-mode-both motion-reduce:animate-none",
         sizeClass,
         textEmphasisClass(layer.emphasis),
         stacked && "whitespace-pre text-center"
       )}
-      style={{ animationDelay: `${Math.min(index, 6) * 45}ms` }}
+      style={{
+        animationDelay: `${Math.min(index, 6) * 45}ms`,
+        color: "var(--rb-ink)",
+      }}
     >
       {content}
     </span>
@@ -119,10 +124,11 @@ function OperatorTile({
   return (
     <span
       className={cn(
-        "inline-flex items-center justify-center text-subtle opacity-80",
+        "inline-flex items-center justify-center opacity-75",
         sizeClass,
         "font-medium"
       )}
+      style={{ color: "var(--rb-mist, var(--rb-ink))" }}
       aria-hidden
     >
       {layer.symbol}
@@ -210,14 +216,17 @@ export function PuzzleVisualBoard({
     return true;
   });
 
+  const surface = resolvePuzzleSurface(visual);
+
   if (!hasRenderable || visual.mode === "unicode") {
     return (
       <div
         className={cn(
-          "text-center text-foreground font-semibold whitespace-pre-wrap break-words",
+          "text-center font-semibold whitespace-pre-wrap break-words",
           textClass,
           className
         )}
+        style={{ color: surface.ink }}
       >
         {fallback || visual.unicodeFallback}
       </div>
@@ -236,12 +245,15 @@ export function PuzzleVisualBoard({
   return (
     <div
       className={cn("puzzle-visual-board flex w-full max-w-full", layoutClass, className)}
+      data-surface={surface.mode}
       style={
         {
-          "--rb-ink": "#1a1f1c",
-          "--rb-canvas": "#f4f6f3",
-          "--rb-accent": "#2f6f5e",
-          "--rb-strike": "#b23a2d",
+          "--rb-ink": surface.ink,
+          "--rb-canvas": surface.canvas,
+          "--rb-mist": INK_PICTOGRAM_PALETTE.mist,
+          "--rb-accent": INK_PICTOGRAM_PALETTE.accent,
+          "--rb-strike": INK_PICTOGRAM_PALETTE.strike,
+          color: surface.ink,
           gap: dims.gap,
         } as CSSProperties
       }
@@ -258,7 +270,10 @@ export function PuzzleVisualBoard({
         />
       ))}
       {visual.caption ? (
-        <p className="basis-full mt-2 text-center text-sm text-subtle animate-in fade-in duration-700 delay-200 motion-reduce:animate-none">
+        <p
+          className="basis-full mt-2 text-center text-sm opacity-70 animate-in fade-in duration-700 delay-200 motion-reduce:animate-none"
+          style={{ color: "var(--rb-ink)" }}
+        >
           {visual.caption}
         </p>
       ) : null}

--- a/apps/web/src/components/ui/message-scroller.tsx
+++ b/apps/web/src/components/ui/message-scroller.tsx
@@ -26,7 +26,7 @@ function MessageScroller({
     <MessageScrollerPrimitive.Root
       data-slot="message-scroller"
       className={cn(
-        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        "group/message-scroller relative flex min-h-0 w-full flex-1 flex-col overflow-hidden",
         className
       )}
       {...props}
@@ -42,9 +42,8 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain contain-content",
+        "min-h-0 min-w-0 flex-1 touch-pan-y overflow-y-auto overscroll-y-contain",
         "[-webkit-overflow-scrolling:touch] [scrollbar-width:thin]",
-        "data-[autoscrolling]:[scrollbar-width:none]",
         className
       )}
       {...props}
@@ -74,10 +73,7 @@ function MessageScrollerItem({
     <MessageScrollerPrimitive.Item
       data-slot="message-scroller-item"
       scrollAnchor={scrollAnchor}
-      className={cn(
-        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
-        className
-      )}
+      className={cn("min-w-0 shrink-0", className)}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/message-scroller.tsx
+++ b/apps/web/src/components/ui/message-scroller.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  MessageScroller as MessageScrollerPrimitive,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from "@shadcn/react/message-scroller";
+import { ArrowDownIcon } from "lucide-react";
+import type * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function MessageScrollerProvider(
+  props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
+) {
+  return <MessageScrollerPrimitive.Provider {...props} />;
+}
+
+function MessageScroller({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Root>) {
+  return (
+    <MessageScrollerPrimitive.Root
+      data-slot="message-scroller"
+      className={cn(
+        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function MessageScrollerViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+  return (
+    <MessageScrollerPrimitive.Viewport
+      data-slot="message-scroller-viewport"
+      className={cn(
+        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain contain-content",
+        "[-webkit-overflow-scrolling:touch] [scrollbar-width:thin]",
+        "data-[autoscrolling]:[scrollbar-width:none]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function MessageScrollerContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Content>) {
+  return (
+    <MessageScrollerPrimitive.Content
+      data-slot="message-scroller-content"
+      className={cn("flex h-max min-h-full flex-col gap-5", className)}
+      {...props}
+    />
+  );
+}
+
+function MessageScrollerItem({
+  className,
+  scrollAnchor = false,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+  return (
+    <MessageScrollerPrimitive.Item
+      data-slot="message-scroller-item"
+      scrollAnchor={scrollAnchor}
+      className={cn(
+        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function MessageScrollerButton({
+  direction = "end",
+  className,
+  children,
+  render,
+  variant = "secondary",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Button> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <MessageScrollerPrimitive.Button
+      data-slot="message-scroller-button"
+      data-direction={direction}
+      data-variant={variant}
+      data-size={size}
+      direction={direction}
+      className={cn(
+        "absolute left-1/2 z-10 -translate-x-1/2 border-border bg-background text-foreground shadow-sm transition-[transform,opacity] duration-200 hover:bg-muted hover:text-foreground",
+        "data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0",
+        "data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100",
+        "data-[direction=end]:bottom-3 data-[direction=end]:data-[active=false]:translate-y-full",
+        "data-[direction=start]:top-3 data-[direction=start]:data-[active=false]:-translate-y-full",
+        "data-[direction=start]:[&_svg]:rotate-180",
+        className
+      )}
+      render={render ?? <Button variant={variant} size={size} />}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <ArrowDownIcon />
+          <span className="sr-only">
+            {direction === "end" ? "Scroll to end" : "Scroll to start"}
+          </span>
+        </>
+      )}
+    </MessageScrollerPrimitive.Button>
+  );
+}
+
+export {
+  MessageScrollerProvider,
+  MessageScroller,
+  MessageScrollerViewport,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerButton,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+};

--- a/apps/web/src/lib/__tests__/puzzle-surface.test.ts
+++ b/apps/web/src/lib/__tests__/puzzle-surface.test.ts
@@ -1,0 +1,80 @@
+import { INK_PICTOGRAM_PALETTE } from "@/ai/puzzle-agent/visual/style";
+import type { PuzzleVisual } from "@/lib/gameSettings";
+import {
+  contrastRatio,
+  extractSvgColors,
+  relativeLuminance,
+  resolvePuzzleSurface,
+} from "@/lib/puzzle-surface";
+
+function visual(layers: PuzzleVisual["layers"]): PuzzleVisual {
+  return {
+    styleId: "ink-pictogram-v1",
+    mode: "composed",
+    layout: "row",
+    layers,
+  };
+}
+
+describe("puzzle-surface", () => {
+  it("uses cinema for unicode / empty boards", () => {
+    expect(resolvePuzzleSurface(undefined).mode).toBe("cinema");
+    expect(
+      resolvePuzzleSurface({
+        styleId: "ink-pictogram-v1",
+        mode: "unicode",
+        layout: "row",
+        layers: [],
+      }).mode
+    ).toBe("cinema");
+  });
+
+  it("uses paper for standard ink-palette pictograms", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="20" fill="${INK_PICTOGRAM_PALETTE.canvas}" stroke="${INK_PICTOGRAM_PALETTE.ink}" stroke-width="2"/><path d="M20 40h24" stroke="${INK_PICTOGRAM_PALETTE.mist}"/></svg>`;
+    const surface = resolvePuzzleSurface(
+      visual([{ kind: "pictogram", concept: "cloud", svg, emojiFallback: "☁️" }])
+    );
+    expect(surface.mode).toBe("paper");
+    expect(surface.usesMeaningColors).toBe(false);
+    expect(surface.canvas).toBe(INK_PICTOGRAM_PALETTE.canvas);
+  });
+
+  it("keeps paper for accent/strike palette accents", () => {
+    const svg = `<svg viewBox="0 0 64 64"><circle fill="${INK_PICTOGRAM_PALETTE.accent}" stroke="${INK_PICTOGRAM_PALETTE.strike}" cx="32" cy="32" r="10"/></svg>`;
+    const surface = resolvePuzzleSurface(
+      visual([{ kind: "pictogram", concept: "dot", svg, emojiFallback: "•" }])
+    );
+    expect(surface.mode).toBe("paper");
+    expect(surface.usesMeaningColors).toBe(false);
+  });
+
+  it("flips to cinema when meaning colors are light-on-dark friendly", () => {
+    const svg = `<svg viewBox="0 0 64 64"><circle fill="#ffe566" stroke="#fff8c4" cx="32" cy="32" r="18"/></svg>`;
+    const surface = resolvePuzzleSurface(
+      visual([{ kind: "pictogram", concept: "sun", svg, emojiFallback: "☀️" }])
+    );
+    expect(surface.usesMeaningColors).toBe(true);
+    expect(surface.mode).toBe("cinema");
+  });
+
+  it("stays on paper when meaning colors are dark paints", () => {
+    const svg = `<svg viewBox="0 0 64 64"><rect fill="#1e3a8a" stroke="#0f172a" width="40" height="40" x="12" y="12"/></svg>`;
+    const surface = resolvePuzzleSurface(
+      visual([{ kind: "pictogram", concept: "block", svg, emojiFallback: "🟦" }])
+    );
+    expect(surface.usesMeaningColors).toBe(true);
+    expect(surface.mode).toBe("paper");
+  });
+
+  it("extracts hex colors from SVG", () => {
+    expect(extractSvgColors(`<path fill="#Abc" stroke="#112233"/>`)).toEqual(
+      expect.arrayContaining(["#aabbcc", "#112233"])
+    );
+  });
+
+  it("computes WCAG contrast", () => {
+    expect(relativeLuminance("#ffffff")).toBeCloseTo(1, 2);
+    expect(relativeLuminance("#000000")).toBeCloseTo(0, 2);
+    expect(contrastRatio("#1a1f1c", "#f4f6f3")).toBeGreaterThan(10);
+  });
+});

--- a/apps/web/src/lib/__tests__/puzzle-surface.test.ts
+++ b/apps/web/src/lib/__tests__/puzzle-surface.test.ts
@@ -13,6 +13,7 @@ function visual(layers: PuzzleVisual["layers"]): PuzzleVisual {
     mode: "composed",
     layout: "row",
     layers,
+    unicodeFallback: "puzzle",
   };
 }
 

--- a/apps/web/src/lib/hooks/useVisualViewport.ts
+++ b/apps/web/src/lib/hooks/useVisualViewport.ts
@@ -9,26 +9,24 @@ interface VisualViewportState {
   visualViewportWidth: number;
 }
 
-const KEYBOARD_THRESHOLD = 150; // Minimum height difference to consider keyboard visible
+const KEYBOARD_THRESHOLD = 120;
+
+function isTouchDevice(): boolean {
+  if (typeof window === "undefined") return false;
+  return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target.isContentEditable
+  );
+}
 
 /**
- * Hook to detect virtual keyboard visibility using the Visual Viewport API.
- *
- * This hook listens to viewport changes and calculates whether a virtual keyboard
- * is likely visible by comparing window.innerHeight to visualViewport.height.
- *
- * @returns {VisualViewportState} Object containing keyboard state information
- *
- * @example
- * ```tsx
- * const { isKeyboardVisible, keyboardHeight } = useVisualViewport();
- *
- * return (
- *   <div style={{ paddingBottom: keyboardHeight }}>
- *     {isKeyboardVisible ? <MinimalView /> : <FullView />}
- *   </div>
- * );
- * ```
+ * Detect virtual keyboard via Visual Viewport + optimistic input focus on touch.
  */
 export function useVisualViewport(): VisualViewportState {
   const [state, setState] = useState<VisualViewportState>(() => ({
@@ -37,34 +35,31 @@ export function useVisualViewport(): VisualViewportState {
     visualViewportHeight: typeof window !== "undefined" ? window.innerHeight : 0,
     visualViewportWidth: typeof window !== "undefined" ? window.innerWidth : 0,
   }));
+  const [focusArmed, setFocusArmed] = useState(false);
 
-  const updateViewportState = useCallback(() => {
+  const updateViewportState = useCallback((opts?: { focusArmed?: boolean }) => {
     if (typeof window === "undefined") return;
 
     const viewport = window.visualViewport;
+    const touch = isTouchDevice();
+    const armed = opts?.focusArmed ?? false;
 
     if (!viewport) {
-      // Fallback for browsers without Visual Viewport API
       setState({
         keyboardHeight: 0,
-        isKeyboardVisible: false,
+        isKeyboardVisible: touch && armed,
         visualViewportHeight: window.innerHeight,
         visualViewportWidth: window.innerWidth,
       });
       return;
     }
 
-    // Calculate the difference between window height and visual viewport height
-    // This difference represents the keyboard + any browser chrome
-    const heightDifference = window.innerHeight - viewport.height;
-
-    // Consider keyboard visible if the difference exceeds threshold
-    // and we're on a device likely to have a virtual keyboard (touch device)
-    const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
-    const isKeyboardVisible = isTouchDevice && heightDifference > KEYBOARD_THRESHOLD;
+    const heightDifference = Math.max(0, window.innerHeight - viewport.height);
+    const viewportSaysOpen = touch && heightDifference > KEYBOARD_THRESHOLD;
+    const isKeyboardVisible = viewportSaysOpen || (touch && armed);
 
     setState({
-      keyboardHeight: Math.max(0, heightDifference),
+      keyboardHeight: viewportSaysOpen ? heightDifference : armed ? Math.max(heightDifference, 280) : 0,
       isKeyboardVisible,
       visualViewportHeight: viewport.height,
       visualViewportWidth: viewport.width,
@@ -75,38 +70,27 @@ export function useVisualViewport(): VisualViewportState {
     if (typeof window === "undefined") return;
 
     const viewport = window.visualViewport;
+    updateViewportState({ focusArmed });
 
-    // Initial state
-    updateViewportState();
-
+    const onResize = () => updateViewportState({ focusArmed });
     if (viewport) {
-      // Listen to viewport resize (keyboard open/close)
-      viewport.addEventListener("resize", updateViewportState);
-      viewport.addEventListener("scroll", updateViewportState);
+      viewport.addEventListener("resize", onResize);
+      viewport.addEventListener("scroll", onResize);
     }
+    window.addEventListener("resize", onResize);
 
-    // Also listen to window resize as a fallback
-    window.addEventListener("resize", updateViewportState);
-
-    // Listen for focus events on input elements
-    // This helps detect keyboard on devices where Visual Viewport might be slow
     const handleFocusIn = (e: FocusEvent) => {
-      const target = e.target as HTMLElement;
-      if (
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        target.isContentEditable
-      ) {
-        // Small delay to let keyboard animation start
-        setTimeout(updateViewportState, 100);
-        setTimeout(updateViewportState, 300);
-      }
+      if (!isEditableTarget(e.target) || !isTouchDevice()) return;
+      setFocusArmed(true);
+      updateViewportState({ focusArmed: true });
+      window.setTimeout(() => updateViewportState({ focusArmed: true }), 80);
+      window.setTimeout(() => updateViewportState({ focusArmed: true }), 240);
     };
 
     const handleFocusOut = () => {
-      // Delay to let keyboard close animation complete
-      setTimeout(updateViewportState, 100);
-      setTimeout(updateViewportState, 300);
+      setFocusArmed(false);
+      window.setTimeout(() => updateViewportState({ focusArmed: false }), 80);
+      window.setTimeout(() => updateViewportState({ focusArmed: false }), 280);
     };
 
     document.addEventListener("focusin", handleFocusIn);
@@ -114,22 +98,18 @@ export function useVisualViewport(): VisualViewportState {
 
     return () => {
       if (viewport) {
-        viewport.removeEventListener("resize", updateViewportState);
-        viewport.removeEventListener("scroll", updateViewportState);
+        viewport.removeEventListener("resize", onResize);
+        viewport.removeEventListener("scroll", onResize);
       }
-      window.removeEventListener("resize", updateViewportState);
+      window.removeEventListener("resize", onResize);
       document.removeEventListener("focusin", handleFocusIn);
       document.removeEventListener("focusout", handleFocusOut);
     };
-  }, [updateViewportState]);
+  }, [focusArmed, updateViewportState]);
 
   return state;
 }
 
-/**
- * Simpler hook that just returns whether keyboard is visible.
- * Use this when you don't need the full viewport state.
- */
 export function useIsKeyboardVisible(): boolean {
   const { isKeyboardVisible } = useVisualViewport();
   return isKeyboardVisible;

--- a/apps/web/src/lib/puzzle-surface.ts
+++ b/apps/web/src/lib/puzzle-surface.ts
@@ -1,0 +1,174 @@
+/**
+ * Puzzle stage surface pairing.
+ *
+ * Ink Pictogram boards are authored for light paper. Unicode/emoji boards
+ * use the dark cinema plate. When a board carries non-palette (meaning) colors,
+ * the background flips to whichever surface keeps contrast readable.
+ */
+
+import { INK_PICTOGRAM_PALETTE } from "@/ai/puzzle-agent/visual/style";
+import type { PuzzleVisual } from "@/lib/gameSettings";
+
+export type PuzzleSurfaceMode = "paper" | "cinema";
+
+export interface PuzzleSurface {
+  mode: PuzzleSurfaceMode;
+  /** CSS background for the glyph area / plate fill */
+  canvas: string;
+  /** Primary readable ink for text/operators on that surface */
+  ink: string;
+  /** True when non-palette colors were found in the board */
+  usesMeaningColors: boolean;
+}
+
+const PAPER: PuzzleSurface = {
+  mode: "paper",
+  canvas: INK_PICTOGRAM_PALETTE.canvas,
+  ink: INK_PICTOGRAM_PALETTE.ink,
+  usesMeaningColors: false,
+};
+
+const CINEMA: PuzzleSurface = {
+  mode: "cinema",
+  canvas: "#0a0a0a",
+  ink: "#f5f5f4",
+  usesMeaningColors: false,
+};
+
+const PALETTE_HEX = new Set(
+  Object.values(INK_PICTOGRAM_PALETTE).map((hex) => normalizeHex(hex))
+);
+
+const HEX_RE = /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b/g;
+const RGB_RE = /rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})/gi;
+
+function normalizeHex(hex: string): string {
+  const raw = hex.trim().toLowerCase().replace(/^#/, "");
+  if (raw.length === 3) {
+    return `#${raw
+      .split("")
+      .map((c) => c + c)
+      .join("")}`;
+  }
+  return `#${raw}`;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const n = normalizeHex(hex).slice(1);
+  if (n.length !== 6) return null;
+  const r = Number.parseInt(n.slice(0, 2), 16);
+  const g = Number.parseInt(n.slice(2, 4), 16);
+  const b = Number.parseInt(n.slice(4, 6), 16);
+  if ([r, g, b].some((v) => Number.isNaN(v))) return null;
+  return { r, g, b };
+}
+
+/** Relative luminance (sRGB) — WCAG. */
+export function relativeLuminance(hex: string): number {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 0;
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+}
+
+export function contrastRatio(a: string, b: string): number {
+  const l1 = relativeLuminance(a);
+  const l2 = relativeLuminance(b);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function nearPalette(hex: string, tolerance = 28): boolean {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return false;
+  if (PALETTE_HEX.has(normalizeHex(hex))) return true;
+  for (const paletteHex of PALETTE_HEX) {
+    const p = hexToRgb(paletteHex);
+    if (!p) continue;
+    const dist = Math.hypot(rgb.r - p.r, rgb.g - p.g, rgb.b - p.b);
+    if (dist <= tolerance) return true;
+  }
+  return false;
+}
+
+/** Pull fill/stroke colors from SVG markup (hex + rgb). */
+export function extractSvgColors(svg: string): string[] {
+  const colors = new Set<string>();
+  for (const match of svg.matchAll(HEX_RE)) {
+    colors.add(normalizeHex(match[0]));
+  }
+  for (const match of svg.matchAll(RGB_RE)) {
+    const r = Number(match[1]);
+    const g = Number(match[2]);
+    const b = Number(match[3]);
+    if ([r, g, b].every((v) => v >= 0 && v <= 255)) {
+      const hex = `#${[r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
+      colors.add(normalizeHex(hex));
+    }
+  }
+  return [...colors];
+}
+
+function collectBoardColors(visual: PuzzleVisual): string[] {
+  const colors = new Set<string>();
+  for (const layer of visual.layers ?? []) {
+    if (layer.kind === "pictogram" && layer.svg) {
+      for (const c of extractSvgColors(layer.svg)) colors.add(c);
+    }
+  }
+  return [...colors];
+}
+
+function pickSurfaceForMeaningColors(colors: string[]): PuzzleSurface {
+  // Ignore near-white / near-black noise; focus on chromatic meaning paints.
+  const meaningful = colors.filter((c) => {
+    const l = relativeLuminance(c);
+    return l > 0.04 && l < 0.92;
+  });
+  const sample = meaningful.length > 0 ? meaningful : colors;
+  if (sample.length === 0) return { ...PAPER, usesMeaningColors: true };
+
+  const paperScore =
+    sample.reduce((sum, c) => sum + contrastRatio(c, PAPER.canvas), 0) / sample.length;
+  const cinemaScore =
+    sample.reduce((sum, c) => sum + contrastRatio(c, CINEMA.canvas), 0) / sample.length;
+
+  if (cinemaScore > paperScore + 0.15) {
+    return { ...CINEMA, usesMeaningColors: true };
+  }
+  return { ...PAPER, usesMeaningColors: true };
+}
+
+/**
+ * Resolve the play surface for a puzzle visual.
+ * - No composed layers → cinema (white unicode/emoji on dark plate)
+ * - Standard ink palette only → paper
+ * - Non-palette colors → contrast-aware paper or cinema
+ */
+export function resolvePuzzleSurface(visual?: PuzzleVisual | null): PuzzleSurface {
+  if (!visual?.layers?.length || visual.mode === "unicode") {
+    return CINEMA;
+  }
+
+  const hasComposed = visual.layers.some(
+    (l) =>
+      (l.kind === "pictogram" && (l.svg || l.emojiFallback)) ||
+      l.kind === "text" ||
+      (l.kind === "image" && l.src) ||
+      l.kind === "operator"
+  );
+  if (!hasComposed) return CINEMA;
+
+  const colors = collectBoardColors(visual);
+  const meaningColors = colors.filter((c) => !nearPalette(c));
+
+  if (meaningColors.length === 0) {
+    return PAPER;
+  }
+
+  return pickSurfaceForMeaningColors(meaningColors);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@rebuzzle/game-logic':
         specifier: workspace:^
         version: link:../../packages/game-logic
+      '@shadcn/react':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react@19.2.18)(react@19.2.8)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.17)
@@ -3297,6 +3300,17 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@shadcn/react@0.2.1':
+    resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
+    peerDependencies:
+      '@types/react': '>=19'
+      react: '>=19'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -12120,6 +12134,11 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@shadcn/react@0.2.1(@types/react@19.2.18)(react@19.2.8)':
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8
 
   '@sinclair/typebox@0.27.8': {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Play-surface fixes for contrast, chat scrolling, and mobile keyboard.

### Puzzle color contrast
Ink Pictogram boards sit on paper; unicode/emoji keep cinema; non-palette meaning colors flip the surface for contrast.

### Chat scrolling
- Fixed the `min-h-0` height chain (`Layout` → keyboard shell → play stage → thread)
- Removed `contain-content` from MessageScroller viewport (it blocked overflow)
- Thread uses shadcn `MessageScroller` with anchor + jump-to-latest

### Mobile keyboard
- Optimistic keyboard detection on input focus (touch)
- Shell height tracks `visualViewport`
- New `compact` PuzzleStage: real small tiles, no transform clipping
- Shows full puzzle + last Eve line above the answer bar while typing

## Test plan
- [ ] Desktop: multiple guesses → thread scrolls; jump-to-latest appears when scrolled up
- [ ] Mobile: open keyboard → full puzzle stays visible (not cut mid-board)
- [ ] Mobile: dismiss keyboard → docked puzzle + scrollable thread return
- [ ] Composed rebus still readable on paper surface
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

