### PR TITLE
fix(web): pin game shell to visualViewport for mobile keyboards

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -828,16 +828,24 @@
   --stage-radius: 12px;
 }
 
-/* Keyboard-open: medium tiles, top-pinned — header is hidden so use the room. */
+/* Keyboard-open: near-hero plate, top-pinned — chrome is gone, use the room. */
 .puzzle-stage[data-state="compact"] {
-  --stage-pad: clamp(0.65rem, 1.8vh, 1rem);
-  --stage-min: clamp(88px, 14vh, 132px);
-  --stage-scale: 1;
-  --stage-radius: 14px;
+  --stage-pad: clamp(0.9rem, 3.5vh, 1.5rem);
+  --stage-min: clamp(120px, 22vh, 200px);
+  --stage-scale: 1.05;
+  --stage-radius: 16px;
 }
 
 .puzzle-stage[data-state="compact"] .puzzle-stage-plate {
   overflow: visible;
+}
+
+.puzzle-stage[data-state="compact"] .puzzle-stage-content {
+  transform-origin: top center;
+}
+
+.puzzle-stage[data-state="compact"] .puzzle-container-responsive {
+  padding: clamp(0.35rem, 1.2vh, 0.75rem) clamp(0.75rem, 3vw, 1.25rem);
 }
 
 .puzzle-stage-plate {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -828,16 +828,15 @@
   --stage-radius: 12px;
 }
 
-/* Keyboard-open: real small tiles (no transform shrink that clips glyphs). */
+/* Keyboard-open: medium tiles, top-pinned — header is hidden so use the room. */
 .puzzle-stage[data-state="compact"] {
-  --stage-pad: 0.5rem;
-  --stage-min: 0px;
+  --stage-pad: clamp(0.65rem, 1.8vh, 1rem);
+  --stage-min: clamp(88px, 14vh, 132px);
   --stage-scale: 1;
-  --stage-radius: 12px;
+  --stage-radius: 14px;
 }
 
 .puzzle-stage[data-state="compact"] .puzzle-stage-plate {
-  min-height: 0;
   overflow: visible;
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1111,14 +1111,12 @@
 }
 
 /* ============================================================
-   KEYBOARD-AWARE LAYOUT
+   KEYBOARD / VISUAL VIEWPORT SHELL
+   Shell is position:fixed to visualViewport (top + height).
+   Do not use body { position:fixed } hacks — they fight iOS pan.
    ============================================================ */
 
 @supports (-webkit-touch-callout: none) {
-  .keyboard-aware-container {
-    height: -webkit-fill-available;
-  }
-
   /* Stop iOS zooming the viewport on input focus */
   input,
   textarea,
@@ -1127,13 +1125,16 @@
   }
 }
 
+.visual-viewport-shell {
+  overscroll-behavior: none;
+}
+
 .keyboard-aware-container {
   display: flex;
   flex-direction: column;
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  transition: height 0.2s ease-out;
 }
 
 .keyboard-visible .puzzle-area {
@@ -1146,23 +1147,9 @@
   flex: 0 0 auto;
 }
 
-.keyboard-visible .play-dock {
-  padding-top: 0.75rem;
-  padding-bottom: max(env(safe-area-inset-bottom), 12px);
-}
-
-.input-area-keyboard-transition {
-  transition:
-    padding 240ms var(--ease),
-    transform 240ms var(--ease);
-  will-change: padding, transform;
-}
-
-.keyboard-layout-active {
-  overflow: hidden;
-  position: fixed;
-  width: 100%;
-  height: 100%;
+/* Free vertical space for the puzzle while typing. */
+.visual-viewport-shell.keyboard-open .play-chrome {
+  display: none;
 }
 
 /* ============================================================

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -59,6 +59,8 @@ export const viewport: Viewport = {
     { media: "(prefers-color-scheme: light)", color: "#fafafa" },
     { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
   ],
+  // Chromium/Android: resize layout viewport with the OSK. Safari ignores.
+  interactiveWidget: "resizes-content",
 };
 
 // Pre-compute metadata with mobile-optimized PWA settings

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,6 +39,11 @@ export const viewport: Viewport = {
   initialScale: 1,
   viewportFit: "cover",
   themeColor: "#0f766e",
+  // Android/Chrome: shrink the layout viewport with the keyboard so flex shells
+  // and dvh track the visible band. iOS Safari ignores this (no-op) and we pin
+  // to visualViewport in VisualViewportShell instead.
+  // https://developer.chrome.com/blog/viewport-resize-behavior
+  interactiveWidget: "resizes-content",
 };
 
 interface SearchParams {

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -1052,7 +1052,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                   className={cn(
                     "play-stage flex min-h-0 flex-1 flex-col items-center overflow-hidden px-4 md:px-6",
                     keyboardOpen
-                      ? "justify-between gap-2 py-2"
+                      ? "justify-start gap-2 pt-1 pb-2"
                       : hasThread
                         ? "justify-start py-[clamp(0.5rem,2vh,1rem)]"
                         : "justify-center py-[clamp(0.5rem,2vh,1rem)]"
@@ -1086,12 +1086,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                     </div>
                   ) : null}
 
-                  <div
-                    className={cn(
-                      "flex w-full max-w-2xl flex-col items-center",
-                      keyboardOpen ? "min-h-0 flex-1 justify-center" : "shrink-0"
-                    )}
-                  >
+                  <div className="flex w-full max-w-2xl shrink-0 flex-col items-center">
                     <section aria-label="Puzzle" className="w-full shrink-0">
                       <PuzzleStage
                         puzzle={puzzleDisplay}

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -1052,7 +1052,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                   className={cn(
                     "play-stage flex min-h-0 flex-1 flex-col items-center overflow-hidden px-4 md:px-6",
                     keyboardOpen
-                      ? "justify-start gap-2 pt-1 pb-2"
+                      ? "justify-start gap-1.5 pt-0 pb-1"
                       : hasThread
                         ? "justify-start py-[clamp(0.5rem,2vh,1rem)]"
                         : "justify-center py-[clamp(0.5rem,2vh,1rem)]"

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -1052,7 +1052,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                   className={cn(
                     "play-stage flex min-h-0 flex-1 flex-col items-center overflow-hidden px-4 md:px-6",
                     keyboardOpen
-                      ? "justify-start py-2"
+                      ? "justify-between gap-2 py-2"
                       : hasThread
                         ? "justify-start py-[clamp(0.5rem,2vh,1rem)]"
                         : "justify-center py-[clamp(0.5rem,2vh,1rem)]"
@@ -1086,32 +1086,39 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                     </div>
                   ) : null}
 
-                  <section aria-label="Puzzle" className="w-full max-w-2xl shrink-0">
-                    <PuzzleStage
-                      puzzle={puzzleDisplay}
-                      puzzleType={puzzleType}
-                      question={keyboardOpen ? undefined : stageCaption}
-                      state={stageState}
-                      visual={gameData.visual}
-                    />
-                  </section>
+                  <div
+                    className={cn(
+                      "flex w-full max-w-2xl flex-col items-center",
+                      keyboardOpen ? "min-h-0 flex-1 justify-center" : "shrink-0"
+                    )}
+                  >
+                    <section aria-label="Puzzle" className="w-full shrink-0">
+                      <PuzzleStage
+                        puzzle={puzzleDisplay}
+                        puzzleType={puzzleType}
+                        question={keyboardOpen ? undefined : stageCaption}
+                        state={stageState}
+                        visual={gameData.visual}
+                      />
+                    </section>
 
-                  {keyboardOpen && lastTurn ? (
-                    <p
-                      className={cn(
-                        "mt-1.5 w-full max-w-2xl truncate text-center text-xs leading-5",
-                        lastTurn.tier === "close" || lastTurn.tier === "warm"
-                          ? "text-warning"
-                          : "text-muted-foreground"
-                      )}
-                    >
-                      <span className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
-                        {lastTurn.text}
-                      </span>
-                      <span className="mx-1.5 text-border-strong">·</span>
-                      Eve · {lastTurn.line}
-                    </p>
-                  ) : null}
+                    {keyboardOpen && lastTurn ? (
+                      <p
+                        className={cn(
+                          "mt-1.5 w-full truncate text-center text-xs leading-5",
+                          lastTurn.tier === "close" || lastTurn.tier === "warm"
+                            ? "text-warning"
+                            : "text-muted-foreground"
+                        )}
+                      >
+                        <span className="font-mono text-[10px] text-subtle uppercase tracking-[0.08em]">
+                          {lastTurn.text}
+                        </span>
+                        <span className="mx-1.5 text-border-strong">·</span>
+                        Eve · {lastTurn.line}
+                      </p>
+                    ) : null}
+                  </div>
 
                   {hasThread && !keyboardOpen ? (
                     <GuessThread
@@ -1160,7 +1167,10 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                       ? "Eve finishing"
                       : "Answer input"
                 }
-                className="input-area input-area-keyboard-transition play-dock z-30 shrink-0 px-4 pt-5 pb-safe-lg md:px-6"
+                className={cn(
+                  "input-area play-dock z-30 shrink-0 px-4 md:px-6",
+                  keyboardOpen ? "pt-2 pb-2" : "pt-5 pb-safe-lg"
+                )}
               >
                 <div className="mx-auto max-w-2xl">
                   {chatLocked ? (

--- a/apps/web/src/components/KeyboardAwareLayout.tsx
+++ b/apps/web/src/components/KeyboardAwareLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
-import { useVisualViewport } from "@/lib/hooks/useVisualViewport";
+import type { ReactNode } from "react";
+import { useVisualViewportFrame } from "@/lib/hooks/useVisualViewport";
 import { cn } from "@/lib/utils";
 
 interface KeyboardAwareRenderProps {
@@ -13,56 +13,29 @@ interface KeyboardAwareRenderProps {
 interface KeyboardAwareLayoutProps {
   children: (props: KeyboardAwareRenderProps) => ReactNode;
   className?: string;
-  /** @default true on touch devices */
+  /** Kept for API compat — scroll locking lives on the VV frame hook. */
   lockBodyScroll?: boolean;
 }
 
 /**
- * Fills the game shell and shrinks to the visual viewport when the keyboard opens.
+ * Fills the VisualViewportShell and reports keyboard state to children.
+ * Height ownership is the shell's job; this is just a flex column + state.
  */
-export function KeyboardAwareLayout({
-  children,
-  className,
-  lockBodyScroll = true,
-}: KeyboardAwareLayoutProps) {
-  const { isKeyboardVisible, keyboardHeight, visualViewportHeight } = useVisualViewport();
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!containerRef.current) return;
-    containerRef.current.style.setProperty("--keyboard-height", `${keyboardHeight}px`);
-    containerRef.current.style.setProperty("--visible-height", `${visualViewportHeight}px`);
-  }, [keyboardHeight, visualViewportHeight]);
-
-  useEffect(() => {
-    if (!lockBodyScroll) return;
-    const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
-    if (!isTouchDevice) return;
-
-    document.body.classList.add("keyboard-layout-active");
-    return () => {
-      document.body.classList.remove("keyboard-layout-active");
-    };
-  }, [lockBodyScroll]);
+export function KeyboardAwareLayout({ children, className }: KeyboardAwareLayoutProps) {
+  const frame = useVisualViewportFrame();
 
   return (
     <div
-      ref={containerRef}
       className={cn(
         "keyboard-aware-container flex h-full min-h-0 flex-col overflow-hidden",
-        isKeyboardVisible && "keyboard-visible",
+        frame.isKeyboardOpen && "keyboard-visible",
         className
       )}
-      style={
-        isKeyboardVisible && visualViewportHeight > 0
-          ? { height: `${visualViewportHeight}px`, maxHeight: `${visualViewportHeight}px` }
-          : undefined
-      }
     >
       {children({
-        isKeyboardVisible,
-        keyboardHeight,
-        visualViewportHeight,
+        isKeyboardVisible: frame.isKeyboardOpen,
+        keyboardHeight: frame.keyboardInset,
+        visualViewportHeight: frame.height,
       })}
     </div>
   );

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { Footer } from "./Footer";
 import { GameProvider, useGameContext } from "./GameContext";
 import Header from "./Header";
+import { VisualViewportShell } from "./VisualViewportShell";
 
 const DevToolsPanel = dynamic(
   () => import("./DevToolsPanel").then((m) => m.DevToolsPanel),
@@ -34,6 +35,9 @@ interface LayoutProps {
  * - Header with navigation
  * - Main content area
  * - Four-column footer on scrolling pages
+ *
+ * Game pages pin to the Visual Viewport so iOS/Android keyboards don't
+ * shove the puzzle off-screen.
  */
 export default function Layout({
   children,
@@ -65,15 +69,8 @@ function LayoutContent({
 }: LayoutProps) {
   const { gameState } = useGameContext();
 
-  return (
-    <div
-      className={cn(
-        "relative flex flex-col bg-background",
-        // Game page: fixed height, no scroll
-        isGamePage ? "h-dvh overflow-hidden" : "min-h-screen"
-      )}
-    >
-      {/* Skip to main content link for accessibility */}
+  const chrome = (
+    <>
       <a
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-foreground focus:px-4 focus:py-2 focus:font-medium focus:text-background focus:text-sm"
         href="#main-content"
@@ -88,7 +85,6 @@ function LayoutContent({
       <main
         className={cn(
           "relative z-10 flex min-h-0 flex-1 flex-col",
-          // Game page: no page scroll — the chat scroller owns overflow.
           isGamePage && "overflow-hidden",
           className
         )}
@@ -97,23 +93,23 @@ function LayoutContent({
         {children}
       </main>
 
-      {!isGamePage && (
+      {!isGamePage ? (
         <div className="relative z-10">
           <Footer />
         </div>
-      )}
+      ) : null}
 
-      {/* Temporary Dev Mode tools — enable in Settings */}
       <DevToolsPanel />
-    </div>
+    </>
   );
+
+  if (isGamePage) {
+    return <VisualViewportShell className="game-vv-shell">{chrome}</VisualViewportShell>;
+  }
+
+  return <div className="relative flex min-h-screen flex-col bg-background">{chrome}</div>;
 }
 
-/**
- * The brand mesh, used once per page at hero scale behind the top band, plus a
- * faint engineered grid. Both sit at very low opacity so the ink stays the
- * loudest thing on the page.
- */
 function AtmosphericBackdrop() {
   return (
     <div

--- a/apps/web/src/components/PuzzleStage.tsx
+++ b/apps/web/src/components/PuzzleStage.tsx
@@ -36,11 +36,11 @@ export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: Puz
   const composed = hasComposedVisual(visual);
   const surface = useMemo(() => resolvePuzzleSurface(visual), [visual]);
   const onPaper = surface.mode === "paper";
-  // Keyboard preview uses medium tiles — header is gone, so we can breathe.
+  // Compact (keyboard) keeps large tiles — chrome is hidden, so match hero scale.
   const size =
     SMALL_TEXT_TYPES.has(puzzleType)
       ? "small"
-      : state === "compact" || state === "docked"
+      : state === "docked"
         ? "medium"
         : "large";
 

--- a/apps/web/src/components/PuzzleStage.tsx
+++ b/apps/web/src/components/PuzzleStage.tsx
@@ -15,7 +15,7 @@ interface PuzzleStageProps {
   /**
    * `hero` before the first guess — the puzzle owns the screen.
    * `docked` once the thread starts — it shrinks and pins to the top.
-   * `compact` while the mobile keyboard is open — full puzzle, smaller plate.
+   * `compact` while the mobile keyboard is open — full puzzle, top-pinned plate.
    */
   state: StageState;
   question?: string;

--- a/apps/web/src/components/PuzzleStage.tsx
+++ b/apps/web/src/components/PuzzleStage.tsx
@@ -36,10 +36,11 @@ export function PuzzleStage({ puzzle, puzzleType, state, question, visual }: Puz
   const composed = hasComposedVisual(visual);
   const surface = useMemo(() => resolvePuzzleSurface(visual), [visual]);
   const onPaper = surface.mode === "paper";
+  // Keyboard preview uses medium tiles — header is gone, so we can breathe.
   const size =
-    state === "compact" || SMALL_TEXT_TYPES.has(puzzleType)
+    SMALL_TEXT_TYPES.has(puzzleType)
       ? "small"
-      : state === "docked"
+      : state === "compact" || state === "docked"
         ? "medium"
         : "large";
 

--- a/apps/web/src/components/VisualViewportShell.tsx
+++ b/apps/web/src/components/VisualViewportShell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { useVisualViewportFrame } from "@/lib/hooks/useVisualViewport";
+import { cn } from "@/lib/utils";
+
+interface VisualViewportShellProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Pins children to the *visual* viewport (top + height).
+ *
+ * This is the reliable keyboard pattern on iOS Safari / Android Chrome:
+ * don't shrink a relative h-dvh box — mirror visualViewport.offsetTop/height
+ * onto a position:fixed shell so the puzzle + input stay in the visible band
+ * above the keyboard without blank gaps from viewport pan.
+ *
+ * @see https://developer.chrome.com/blog/viewport-resize-behavior
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
+ */
+export function VisualViewportShell({ children, className }: VisualViewportShellProps) {
+  const frame = useVisualViewportFrame();
+
+  const style: CSSProperties = {
+    position: "fixed",
+    left: 0,
+    width: frame.width > 0 ? `${frame.width}px` : "100%",
+    top: `${frame.top}px`,
+    height: frame.height > 0 ? `${frame.height}px` : "100dvh",
+    // Expose for children / CSS
+    ["--vv-height" as string]: `${frame.height || 0}px`,
+    ["--vv-top" as string]: `${frame.top}px`,
+    ["--keyboard-inset" as string]: `${frame.keyboardInset}px`,
+  };
+
+  return (
+    <div
+      className={cn(
+        "visual-viewport-shell flex flex-col overflow-hidden bg-background",
+        frame.isKeyboardOpen && "keyboard-open",
+        className
+      )}
+      data-keyboard={frame.isKeyboardOpen ? "open" : "closed"}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/lib/hooks/useVisualViewport.ts
+++ b/apps/web/src/lib/hooks/useVisualViewport.ts
@@ -2,115 +2,136 @@
 
 import { useCallback, useEffect, useState } from "react";
 
-interface VisualViewportState {
-  keyboardHeight: number;
-  isKeyboardVisible: boolean;
-  visualViewportHeight: number;
-  visualViewportWidth: number;
+export interface VisualViewportFrame {
+  /** visualViewport.offsetTop — iOS pans this when the keyboard opens */
+  top: number;
+  /** visualViewport.height — visible area above the keyboard */
+  height: number;
+  width: number;
+  /** Layout-viewport overlap under the keyboard (≈0 when resizes-content works) */
+  keyboardInset: number;
+  isKeyboardOpen: boolean;
 }
 
-const KEYBOARD_THRESHOLD = 120;
+const KEYBOARD_THRESHOLD = 80;
 
-function isTouchDevice(): boolean {
-  if (typeof window === "undefined") return false;
-  return "ontouchstart" in window || navigator.maxTouchPoints > 0;
-}
+function readFrame(): VisualViewportFrame {
+  if (typeof window === "undefined") {
+    return { top: 0, height: 0, width: 0, keyboardInset: 0, isKeyboardOpen: false };
+  }
 
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target.isContentEditable
-  );
+  const vv = window.visualViewport;
+  const layoutHeight = document.documentElement.clientHeight || window.innerHeight;
+  const layoutWidth = document.documentElement.clientWidth || window.innerWidth;
+
+  if (!vv) {
+    return {
+      top: 0,
+      height: layoutHeight,
+      width: layoutWidth,
+      keyboardInset: 0,
+      isKeyboardOpen: false,
+    };
+  }
+
+  const top = vv.offsetTop;
+  const height = vv.height;
+  const width = vv.width;
+  // True overlap of the keyboard with the layout viewport (accounts for iOS pan).
+  const keyboardInset = Math.max(0, layoutHeight - height - top);
+  const isKeyboardOpen = keyboardInset > KEYBOARD_THRESHOLD || top > KEYBOARD_THRESHOLD;
+
+  return { top, height, width, keyboardInset, isKeyboardOpen };
 }
 
 /**
- * Detect virtual keyboard via Visual Viewport + optimistic input focus on touch.
+ * Sync layout to the Visual Viewport.
+ *
+ * On iOS Safari the layout viewport does NOT shrink for the keyboard — the
+ * visual viewport pans/resizes instead. Consumers should pin a fixed shell with
+ * `top` + `height` from this hook (not `bottom` / translateY).
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
  */
-export function useVisualViewport(): VisualViewportState {
-  const [state, setState] = useState<VisualViewportState>(() => ({
-    keyboardHeight: 0,
-    isKeyboardVisible: false,
-    visualViewportHeight: typeof window !== "undefined" ? window.innerHeight : 0,
-    visualViewportWidth: typeof window !== "undefined" ? window.innerWidth : 0,
-  }));
-  const [focusArmed, setFocusArmed] = useState(false);
+export function useVisualViewportFrame(): VisualViewportFrame {
+  // Start empty for SSR/hydration parity — first client effect fills real VV metrics.
+  const [frame, setFrame] = useState<VisualViewportFrame>({
+    top: 0,
+    height: 0,
+    width: 0,
+    keyboardInset: 0,
+    isKeyboardOpen: false,
+  });
 
-  const updateViewportState = useCallback((opts?: { focusArmed?: boolean }) => {
-    if (typeof window === "undefined") return;
-
-    const viewport = window.visualViewport;
-    const touch = isTouchDevice();
-    const armed = opts?.focusArmed ?? false;
-
-    if (!viewport) {
-      setState({
-        keyboardHeight: 0,
-        isKeyboardVisible: touch && armed,
-        visualViewportHeight: window.innerHeight,
-        visualViewportWidth: window.innerWidth,
-      });
-      return;
-    }
-
-    const heightDifference = Math.max(0, window.innerHeight - viewport.height);
-    const viewportSaysOpen = touch && heightDifference > KEYBOARD_THRESHOLD;
-    const isKeyboardVisible = viewportSaysOpen || (touch && armed);
-
-    setState({
-      keyboardHeight: viewportSaysOpen ? heightDifference : armed ? Math.max(heightDifference, 280) : 0,
-      isKeyboardVisible,
-      visualViewportHeight: viewport.height,
-      visualViewportWidth: viewport.width,
-    });
+  const sync = useCallback(() => {
+    setFrame(readFrame());
   }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const viewport = window.visualViewport;
-    updateViewportState({ focusArmed });
+    const vv = window.visualViewport;
+    sync();
 
-    const onResize = () => updateViewportState({ focusArmed });
-    if (viewport) {
-      viewport.addEventListener("resize", onResize);
-      viewport.addEventListener("scroll", onResize);
-    }
-    window.addEventListener("resize", onResize);
-
-    const handleFocusIn = (e: FocusEvent) => {
-      if (!isEditableTarget(e.target) || !isTouchDevice()) return;
-      setFocusArmed(true);
-      updateViewportState({ focusArmed: true });
-      window.setTimeout(() => updateViewportState({ focusArmed: true }), 80);
-      window.setTimeout(() => updateViewportState({ focusArmed: true }), 240);
+    vv?.addEventListener("resize", sync);
+    vv?.addEventListener("scroll", sync);
+    window.addEventListener("resize", sync);
+    // Focus can precede the first VV resize on iOS — remeasure shortly after.
+    const onFocusIn = (e: FocusEvent) => {
+      const t = e.target;
+      if (
+        t instanceof HTMLInputElement ||
+        t instanceof HTMLTextAreaElement ||
+        (t instanceof HTMLElement && t.isContentEditable)
+      ) {
+        window.requestAnimationFrame(sync);
+        window.setTimeout(sync, 50);
+        window.setTimeout(sync, 200);
+      }
     };
-
-    const handleFocusOut = () => {
-      setFocusArmed(false);
-      window.setTimeout(() => updateViewportState({ focusArmed: false }), 80);
-      window.setTimeout(() => updateViewportState({ focusArmed: false }), 280);
+    const onFocusOut = () => {
+      window.setTimeout(sync, 50);
+      window.setTimeout(sync, 250);
     };
-
-    document.addEventListener("focusin", handleFocusIn);
-    document.addEventListener("focusout", handleFocusOut);
+    document.addEventListener("focusin", onFocusIn);
+    document.addEventListener("focusout", onFocusOut);
 
     return () => {
-      if (viewport) {
-        viewport.removeEventListener("resize", onResize);
-        viewport.removeEventListener("scroll", onResize);
-      }
-      window.removeEventListener("resize", onResize);
-      document.removeEventListener("focusin", handleFocusIn);
-      document.removeEventListener("focusout", handleFocusOut);
+      vv?.removeEventListener("resize", sync);
+      vv?.removeEventListener("scroll", sync);
+      window.removeEventListener("resize", sync);
+      document.removeEventListener("focusin", onFocusIn);
+      document.removeEventListener("focusout", onFocusOut);
     };
-  }, [focusArmed, updateViewportState]);
+  }, [sync]);
 
-  return state;
+  // While the keyboard is open, kill document scroll jumps (iOS Safari).
+  useEffect(() => {
+    if (!frame.isKeyboardOpen) return;
+    const lock = () => {
+      if (window.scrollY !== 0 || window.scrollX !== 0) {
+        window.scrollTo(0, 0);
+      }
+    };
+    lock();
+    window.addEventListener("scroll", lock, { passive: true });
+    return () => window.removeEventListener("scroll", lock);
+  }, [frame.isKeyboardOpen]);
+
+  return frame;
+}
+
+/** @deprecated Prefer useVisualViewportFrame — kept for older call sites. */
+export function useVisualViewport() {
+  const frame = useVisualViewportFrame();
+  return {
+    keyboardHeight: frame.keyboardInset,
+    isKeyboardVisible: frame.isKeyboardOpen,
+    visualViewportHeight: frame.height,
+    visualViewportWidth: frame.width,
+  };
 }
 
 export function useIsKeyboardVisible(): boolean {
-  const { isKeyboardVisible } = useVisualViewport();
-  return isKeyboardVisible;
+  return useVisualViewportFrame().isKeyboardOpen;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the iPhone keyboard bug where the puzzle vanished and the answer bar floated in blank space.

### Research
- iOS Safari **does not resize the layout viewport** for the on-screen keyboard — it pans/resizes the **visual viewport** ([MDN Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API), [Chrome viewport resize behavior](https://developer.chrome.com/blog/viewport-resize-behavior)).
- `100dvh` alone ignores the keyboard; shrinking height without tracking `offsetTop` creates the blank gap.
- Android/Chromium can opt into layout resize via `interactive-widget=resizes-content` ([Chrome blog](https://developer.chrome.com/blog/viewport-resize-behavior)); Safari ignores it (safe no-op).
- Proven pattern: pin a `position: fixed` shell with `top = visualViewport.offsetTop` and `height = visualViewport.height`, then dock the input at the bottom of that shell.

### Implementation
- `VisualViewportShell` — fixed shell synced on VV `resize` + `scroll`
- Keyboard inset = `clientHeight - vv.height - vv.offsetTop` (accounts for iOS pan)
- `interactiveWidget: "resizes-content"` on root + home viewport meta
- Header hides while typing; compact puzzle stays in the visible band above the answer bar
- Document scroll lock while keyboard is open
- Compact keyboard preview is **top-pinned** (not vertically centered) with **large tiles** and a taller plate so it reads clearly with chrome removed

## Test plan
- [ ] iPhone Safari: focus answer → puzzle visible above input, no mid-screen blank gap
- [ ] iPhone: puzzle sits near the top and is readable (not a tiny centered thumbnail)
- [ ] iPhone: dismiss keyboard → full stage + header return
- [ ] Android Chrome: same behavior (layout may also shrink via meta)
- [ ] Desktop play loop unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

