### PR TITLE
feat(ai): agent efficiency tools — digester, preflight, repair, calibration, hints

### DIFF
--- a/apps/web/agent/skills/generate-daily-puzzle.md
+++ b/apps/web/agent/skills/generate-daily-puzzle.md
@@ -5,23 +5,23 @@ description: End-to-end workflow for assembling a daily Rebuzzle puzzle with gen
 
 # Generate daily puzzle
 
-1. `get_puzzle_type_spec` + `get_difficulty_brief` + `get_generation_brief` for the target score.
+1. `get_puzzle_type_spec` + `get_difficulty_brief` + `get_generation_brief` for the target score (brief includes recent reject-mode avoid/prefer).
 2. `list_recent_answers` (lookback 60 days) — ban those answers (exact reuse fails publish).
-3. `propose_concept_seeds` → choose one seed, invent a **new** answer (phrase-bank classics are tropes to avoid, not templates).
-4. Pick a technique from the brief; optionally `list_technique_library`.
-5. **Compose a generative visual** (required path):
+3. `list_pictogram_catalog` for exact reviewed concept IDs.
+4. If the host reserved an **answer-first cue plan**: `inspect_answer_seed_cues` / `preflight_compose_cue_plan` first (no invent). Otherwise `propose_concept_seeds` → invent a **new** answer (phrase-bank classics are tropes to avoid, not templates).
+5. Pick a technique from the brief; optionally `list_technique_library`.
+6. **Compose a generative visual** (required path):
    - Plan layers: pictogram concepts + text emphasis + operators (+ rare image).
-   - Pictogram concepts must be **concrete nouns** a human can sketch (key, umbrella, lighthouse) — never abstract words alone. Icons must be instantly recognizable.
+   - Pictogram concepts must be **exact catalog IDs** (or approved-cache) — never invent nouns.
    - Prefer fresh answers — avoid before / sunflower / piece of cake cousins unless the twist is new.
    - Call `compose_puzzle_visual` with those layers until within budget and funScore ≥ 68.
-   - Optionally preview a tile with `generate_pictogram` and regenerate if clarity/recognition fails.
    - Set `rebusPuzzle` = returned `unicodeFallback`; keep the full `visual` for persist/UI.
    - Unicode-only / unreadable blob SVGs are rejected — ensure ≥1 clear pictogram SVG or styled text layers.
-6. Write an explanation that maps each visual part → answer token; `craft_hint_ladder` for 3–5 hints.
-7. Pipeline: `validate_puzzle` → `check_uniqueness` → `calibrate_difficulty` → `stress_test_solvability` → `score_quality`.
-8. `critique_candidate` + `simulate_player_solve` + `score_rubric` — revise if not ship-worthy.
-9. If off-band, duplicate answer, weak visual, or quality < threshold — redesign layers (not just the number).
-10. Emit final structured puzzle with `difficultyLevel` ∈ Hard | Difficult | Evil | Impossible, required `techniqueId`, and required `visual`.
+7. Write an explanation that maps each visual part → answer token; `craft_hint_ladder` for 3–5 hints.
+8. Pipeline: `validate_puzzle` → `check_uniqueness` → `calibrate_difficulty` → `stress_test_solvability` → `score_quality`.
+9. `critique_candidate` + `simulate_player_solve` + `score_rubric` — revise if not ship-worthy.
+10. If off-band, duplicate answer, weak visual, or quality < threshold — redesign layers (not just the number).
+11. Emit final structured puzzle with `difficultyLevel` ∈ Hard | Difficult | Evil | Impossible, required `techniqueId`, and required `visual`.
 
 Daily cron uses the **Apex tournament** (multiple candidates + rubric). Be excellent — only the winner publishes.
 

--- a/apps/web/agent/tools/inspect_answer_seed_cues.ts
+++ b/apps/web/agent/tools/inspect_answer_seed_cues.ts
@@ -1,0 +1,48 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { inspectAnswerSeedCuePlan } from "../../src/ai/puzzle-agent/apex/cue-plan-preflight";
+import type { AnswerSeedVisualCue } from "../../src/ai/puzzle-agent/apex/types";
+import { PuzzleVisualSchema } from "../../src/ai/puzzle-agent/visual/composition";
+
+const CueSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("catalog"),
+    concept: z.string(),
+    role: z.enum([
+      "word-part",
+      "phonetic-anchor",
+      "semantic-anchor",
+      "structural-anchor",
+    ]),
+  }),
+  z.object({
+    kind: z.literal("text"),
+    content: z.string(),
+    role: z.enum([
+      "word-part",
+      "phonetic-anchor",
+      "semantic-anchor",
+      "structural-anchor",
+    ]),
+  }),
+  z.object({
+    kind: z.literal("operator"),
+    symbol: z.string(),
+    role: z.literal("structural-anchor"),
+  }),
+]);
+
+export default defineTool({
+  description:
+    "Inspect a host-owned answer-seed cue contract: catalog validity, draft layers, and whether a board is missing required cues. Call before compose when an answer-first seed is reserved.",
+  inputSchema: z.object({
+    cues: z.array(CueSchema).optional(),
+    visual: PuzzleVisualSchema.optional(),
+  }),
+  async execute(input) {
+    return inspectAnswerSeedCuePlan({
+      cues: input.cues as AnswerSeedVisualCue[] | undefined,
+      visual: input.visual,
+    });
+  },
+});

--- a/apps/web/agent/tools/list_pictogram_catalog.ts
+++ b/apps/web/agent/tools/list_pictogram_catalog.ts
@@ -1,0 +1,19 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import {
+  CURATED_PICTOGRAM_CATALOG_VERSION,
+  listCuratedPictogramIds,
+} from "../../src/ai/puzzle-agent/visual/curated-pictograms";
+
+export default defineTool({
+  description:
+    "List exact, reviewed pictogram concept IDs that are immediately eligible for publication. Use these exact nouns in compose_puzzle_visual.",
+  inputSchema: z.object({}),
+  async execute() {
+    return {
+      version: CURATED_PICTOGRAM_CATALOG_VERSION,
+      concepts: listCuratedPictogramIds(),
+      rule: "Publication compositions must use these exact concept IDs or an existing approved-cache asset.",
+    };
+  },
+});

--- a/apps/web/agent/tools/preflight_compose_cue_plan.ts
+++ b/apps/web/agent/tools/preflight_compose_cue_plan.ts
@@ -1,0 +1,61 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { preflightComposeAnswerSeedCuePlan } from "../../src/ai/puzzle-agent/apex/cue-plan-preflight";
+import type { AnswerSeedVisualCue } from "../../src/ai/puzzle-agent/apex/types";
+
+const CueSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("catalog"),
+    concept: z.string(),
+    role: z.enum([
+      "word-part",
+      "phonetic-anchor",
+      "semantic-anchor",
+      "structural-anchor",
+    ]),
+  }),
+  z.object({
+    kind: z.literal("text"),
+    content: z.string(),
+    role: z.enum([
+      "word-part",
+      "phonetic-anchor",
+      "semantic-anchor",
+      "structural-anchor",
+    ]),
+  }),
+  z.object({
+    kind: z.literal("operator"),
+    symbol: z.string(),
+    role: z.literal("structural-anchor"),
+  }),
+]);
+
+export default defineTool({
+  description:
+    "Cheap host preflight: compose a board deterministically from an answer-seed cue plan (no invent). Use to prove catalog cues compose before a creative rewrite.",
+  inputSchema: z.object({
+    answer: z.string(),
+    targetDifficulty: z.number(),
+    techniqueId: z.string().optional(),
+    layout: z.enum(["row", "stack", "grid", "overlay"]).optional(),
+    cues: z.array(CueSchema),
+  }),
+  async execute(input) {
+    const result = await preflightComposeAnswerSeedCuePlan({
+      ...input,
+      cues: input.cues as AnswerSeedVisualCue[],
+    });
+    if (!result.ok) {
+      throw new Error(
+        `Cue-plan preflight failed (${result.stage}): ${result.issues.join("; ")}`
+      );
+    }
+    return {
+      ...result,
+      publicationReady: true,
+      visual: result.composition?.visual,
+      unicodeFallback: result.composition?.visual.unicodeFallback,
+    };
+  },
+});

--- a/apps/web/e2e/generation-health.spec.ts
+++ b/apps/web/e2e/generation-health.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Backend contract E2E for generation observability.
+ * Does not invent puzzles live — it proves the admin health surface stays wired
+ * so operators can verify reject modes / audits in production.
+ */
+test.describe("Generation health API contract", () => {
+  test("rejects anonymous access", async ({ request }) => {
+    const response = await request.get("/api/admin/ai/generation-health");
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body.error).toMatch(/admin/i);
+  });
+});

--- a/apps/web/src/ai/learning/__tests__/rejection-digest.test.ts
+++ b/apps/web/src/ai/learning/__tests__/rejection-digest.test.ts
@@ -1,0 +1,40 @@
+import { digestRejectionTexts } from "../rejection-digest";
+
+describe("rejection digester", () => {
+  it("aggregates known failure modes into avoid/prefer curriculum guidance", () => {
+    const digest = digestRejectionTexts(
+      [
+        "Answer-first visual cue contract failed: Missing catalog cue flower",
+        "Answer-first visual cue contract failed: Missing text cue POT",
+        "Semantic alignment failed (token-coverage): board cannot produce answer",
+        "Pictogram lighthouse is pending human approval",
+        "Random unrelated gateway timeout noise",
+      ],
+      { lookbackDays: 14, topN: 3 }
+    );
+
+    expect(digest.sampleSize).toBe(5);
+    expect(digest.buckets[0]?.code).toBe("missing_seed_cues");
+    expect(digest.buckets[0]?.count).toBe(2);
+    expect(digest.avoidPatterns).toEqual(
+      expect.arrayContaining([
+        "Composing boards that omit host-owned answer-seed cues",
+        "Boards whose visible parts cannot plausibly produce the answer",
+      ])
+    );
+    expect(digest.preferPatterns).toEqual(
+      expect.arrayContaining([
+        "Place every mandatory catalog/text/operator cue before returning a draft",
+        "Use reviewed catalog pictograms (or approved-cache) only",
+      ])
+    );
+    expect(digest.notes.some((note) => note.includes("missing_seed_cues"))).toBe(true);
+  });
+
+  it("stays quiet when there are no reject texts", () => {
+    const digest = digestRejectionTexts([]);
+    expect(digest.sampleSize).toBe(0);
+    expect(digest.avoidPatterns).toEqual([]);
+    expect(digest.preferPatterns).toEqual([]);
+  });
+});

--- a/apps/web/src/ai/learning/generation-audit.ts
+++ b/apps/web/src/ai/learning/generation-audit.ts
@@ -33,6 +33,8 @@ export type GenerationAuditRecord = {
   candidateCount?: number;
   durationMs?: number;
   error?: string;
+  /** Structured reject taxonomy strings when the host captured gate failures. */
+  rejectReasons?: string[];
   attemptedGeneration?: boolean;
   createdAt: Date;
 };

--- a/apps/web/src/ai/learning/index.ts
+++ b/apps/web/src/ai/learning/index.ts
@@ -29,6 +29,13 @@ export {
   recordGenerationAudit,
 } from "./generation-audit";
 export {
+  digestRejectionTexts,
+  loadRejectionDigest,
+  type RejectionBucket,
+  type RejectionDigest,
+  type RejectionTaxonomyCode,
+} from "./rejection-digest";
+export {
   type LearningPolicySnapshot,
   recordFinalAttemptSignal,
   resolveAdaptiveDifficultyForDate,

--- a/apps/web/src/ai/learning/rejection-digest.ts
+++ b/apps/web/src/ai/learning/rejection-digest.ts
@@ -1,0 +1,224 @@
+/**
+ * Rejection digester — turn recent generation failures into curriculum guidance.
+ *
+ * Parses durable audit error strings (and optional structured rejectReasons)
+ * into a small taxonomy, then emits avoid/prefer patterns for Eve/Apex briefs.
+ */
+
+import { getCollection } from "@/db/mongodb";
+
+export type RejectionTaxonomyCode =
+  | "missing_seed_cues"
+  | "bad_seed_contract"
+  | "semantic_alignment"
+  | "unapproved_asset"
+  | "board_recognition"
+  | "blind_solve"
+  | "critique_reject"
+  | "composition"
+  | "uniqueness"
+  | "quality_threshold"
+  | "tournament_empty"
+  | "budget"
+  | "other";
+
+export type RejectionBucket = {
+  code: RejectionTaxonomyCode;
+  count: number;
+  examples: string[];
+};
+
+export type RejectionDigest = {
+  lookbackDays: number;
+  sampleSize: number;
+  buckets: RejectionBucket[];
+  avoidPatterns: string[];
+  preferPatterns: string[];
+  notes: string[];
+};
+
+const TAXONOMY: Array<{
+  code: RejectionTaxonomyCode;
+  match: RegExp;
+  avoid: string;
+  prefer: string;
+}> = [
+  {
+    code: "missing_seed_cues",
+    match: /answer-first visual cue contract|missing (catalog|text|operator) cue/i,
+    avoid: "Composing boards that omit host-owned answer-seed cues",
+    prefer: "Place every mandatory catalog/text/operator cue before returning a draft",
+  },
+  {
+    code: "bad_seed_contract",
+    match: /invalid answer-seed cue|not an approved catalog concept|duplicate answer-seed cue/i,
+    avoid: "Inventing pictogram concepts outside the reviewed catalog",
+    prefer: "Call list_pictogram_catalog / inspect_answer_seed_cues and use exact concept IDs",
+  },
+  {
+    code: "semantic_alignment",
+    match: /semantic alignment failed/i,
+    avoid: "Boards whose visible parts cannot plausibly produce the answer",
+    prefer: "Map each layer to an answer token in the explanation before compose",
+  },
+  {
+    code: "unapproved_asset",
+    match: /approved.?asset|asset approval|pending human approval|unapproved/i,
+    avoid: "Fresh generate_pictogram art on the publication path",
+    prefer: "Use reviewed catalog pictograms (or approved-cache) only",
+  },
+  {
+    code: "board_recognition",
+    match: /board objects not recognized|board recognition|rendered board/i,
+    avoid: "Abstract or ambiguous silhouettes that blind judges misread",
+    prefer: "Concrete, high-clarity catalog nouns with one dominant reading",
+  },
+  {
+    code: "blind_solve",
+    match: /blind solve|playability|estimated solve rate/i,
+    avoid: "Mechanisms that only work after spoilers or dense false leads",
+    prefer: "One fair aha with progressive hints that unlock the mechanism",
+  },
+  {
+    code: "critique_reject",
+    match: /critique reject|critique revise/i,
+    avoid: "Overused trope mechanisms without a fresh twist",
+    prefer: "Respond to critique instructions with a cleaner catalog-backed board",
+  },
+  {
+    code: "composition",
+    match: /composition rejected|compose_puzzle_visual|within budget|component budget/i,
+    avoid: "Over-budget or unknown-concept layer plans",
+    prefer: "Inspect the cue plan, then compose once with exact catalog IDs",
+  },
+  {
+    code: "uniqueness",
+    match: /uniqueness|duplicate answer|banned answer|not unique/i,
+    avoid: "Recycling recent or archived answers / near-duplicate boards",
+    prefer: "Pick a fresh answer-first seed outside bannedAnswerKeys",
+  },
+  {
+    code: "quality_threshold",
+    match: /quality|funscore|publishable|rubric/i,
+    avoid: "Padding with extra icons instead of a clear technique fit",
+    prefer: "Strong technique fit + mapping clarity over emoji count",
+  },
+  {
+    code: "tournament_empty",
+    match: /produced no candidates|answer.?first seed unavailable/i,
+    avoid: "Slots that cannot be grounded by a cue-backed seed",
+    prefer: "Fail closed early when cue coverage is missing for the tier",
+  },
+  {
+    code: "budget",
+    match: /budget|quota|rate limit|AI_BUDGET/i,
+    avoid: "Retry loops that multiply model spend after a hard budget error",
+    prefer: "Keep publication tool loops short; host owns scoring retries",
+  },
+];
+
+function classifyRejection(text: string): RejectionTaxonomyCode {
+  const trimmed = text.trim();
+  if (!trimmed) return "other";
+  for (const rule of TAXONOMY) {
+    if (rule.match.test(trimmed)) return rule.code;
+  }
+  return "other";
+}
+
+/**
+ * Pure aggregator — used by loaders and unit tests.
+ */
+export function digestRejectionTexts(
+  texts: readonly string[],
+  options?: { lookbackDays?: number; topN?: number }
+): RejectionDigest {
+  const lookbackDays = options?.lookbackDays ?? 14;
+  const topN = options?.topN ?? 4;
+  const counts = new Map<RejectionTaxonomyCode, { count: number; examples: string[] }>();
+
+  for (const text of texts) {
+    if (!text?.trim()) continue;
+    const code = classifyRejection(text);
+    const bucket = counts.get(code) ?? { count: 0, examples: [] };
+    bucket.count += 1;
+    if (bucket.examples.length < 3) {
+      bucket.examples.push(text.replace(/[\r\n]+/g, " ").slice(0, 180));
+    }
+    counts.set(code, bucket);
+  }
+
+  const buckets = [...counts.entries()]
+    .map(([code, value]) => ({ code, ...value }))
+    .sort((a, b) => b.count - a.count);
+
+  const top = buckets.filter((b) => b.code !== "other").slice(0, topN);
+  const avoidPatterns: string[] = [];
+  const preferPatterns: string[] = [];
+  const notes: string[] = [];
+
+  for (const bucket of top) {
+    const rule = TAXONOMY.find((entry) => entry.code === bucket.code);
+    if (!rule) continue;
+    avoidPatterns.push(rule.avoid);
+    preferPatterns.push(rule.prefer);
+    notes.push(
+      `Recent reject mode ${bucket.code} ×${bucket.count}: ${rule.prefer}`
+    );
+  }
+
+  if (buckets.some((b) => b.code === "other") && !top.length) {
+    notes.push("Recent generation failures lack a known taxonomy match — keep cue contracts strict");
+  }
+
+  return {
+    lookbackDays,
+    sampleSize: texts.filter((t) => t?.trim()).length,
+    buckets,
+    avoidPatterns,
+    preferPatterns,
+    notes,
+  };
+}
+
+/**
+ * Load recent failed/fallback audit errors and digest them for curriculum.
+ */
+export async function loadRejectionDigest(input?: {
+  lookbackDays?: number;
+  limit?: number;
+}): Promise<RejectionDigest> {
+  const lookbackDays = input?.lookbackDays ?? 14;
+  const limit = Math.min(input?.limit ?? 120, 300);
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - lookbackDays);
+
+  try {
+    const docs = (await getCollection("generationAudits")
+      .find({
+        createdAt: { $gte: cutoff },
+        status: { $in: ["failed", "fallback"] },
+      })
+      .project({ error: 1, rejectReasons: 1 })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .toArray()) as Array<{ error?: string; rejectReasons?: string[] }>;
+
+    const texts = docs.flatMap((doc) => {
+      const reasons = Array.isArray(doc.rejectReasons) ? doc.rejectReasons : [];
+      if (reasons.length) return reasons;
+      return doc.error ? [doc.error] : [];
+    });
+
+    return digestRejectionTexts(texts, { lookbackDays });
+  } catch {
+    return {
+      lookbackDays,
+      sampleSize: 0,
+      buckets: [],
+      avoidPatterns: [],
+      preferPatterns: [],
+      notes: ["Rejection digest unavailable — continue without failure-mode bias"],
+    };
+  }
+}

--- a/apps/web/src/ai/puzzle-agent/__tests__/efficiency-pipeline.contract.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/efficiency-pipeline.contract.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Contract tests for the agent-efficiency buildout.
+ *
+ * These do not call live models. They prove the host surfaces, tool wiring,
+ * and fail-closed invariants actually exist and stay consistent — so we cannot
+ * claim a capability the runtime never exposes.
+ *
+ * Note: we assert in-process tool keys via source (not by importing tools.ts)
+ * so Jest never loads the AI SDK ESM graph through critique/client.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { digestRejectionTexts } from "../../learning/rejection-digest";
+import {
+  answerSeedCuePlanIssues,
+  missingAnswerSeedCues,
+} from "../apex/answer-seed-cues";
+import {
+  buildCritiqueRepairParams,
+  critiqueRepairIssues,
+} from "../apex/critique-repair";
+import {
+  inspectAnswerSeedCuePlan,
+  layersFromAnswerSeedCues,
+} from "../apex/cue-plan-preflight";
+import {
+  progressiveHintPublishBlockers,
+  shouldRunProgressiveHintVision,
+} from "../apex/progressive-hint-vision";
+import { biasTechniquesBySolveRates } from "../apex/technique-calibration";
+import { EFFICIENCY_AGENT_TOOLS, PUBLICATION_AGENT_TOOLS } from "../publication-tools";
+import { resolveCuratedPictogram } from "../visual/curated-pictograms";
+
+const AGENT_TOOLS_DIR = join(process.cwd(), "agent/tools");
+const IN_PROCESS_TOOLS_SOURCE = readFileSync(
+  join(process.cwd(), "src/ai/puzzle-agent/tools.ts"),
+  "utf8"
+);
+const RUN_GENERATION_SOURCE = readFileSync(
+  join(process.cwd(), "src/ai/puzzle-agent/run-generation.ts"),
+  "utf8"
+);
+
+function toolDefinedInSource(source: string, toolName: string): boolean {
+  return new RegExp(`${toolName}\\s*:\\s*tool\\s*\\(`).test(source);
+}
+
+describe("efficiency pipeline contracts", () => {
+  describe("tool surface parity", () => {
+    it("defines every efficiency + publication tool on the in-process ToolLoop surface", () => {
+      for (const toolName of EFFICIENCY_AGENT_TOOLS) {
+        expect(toolDefinedInSource(IN_PROCESS_TOOLS_SOURCE, toolName)).toBe(true);
+      }
+      for (const toolName of PUBLICATION_AGENT_TOOLS) {
+        expect(toolDefinedInSource(IN_PROCESS_TOOLS_SOURCE, toolName)).toBe(true);
+      }
+    });
+
+    it("mirrors efficiency tools under agent/tools for Eve", () => {
+      expect(existsSync(AGENT_TOOLS_DIR)).toBe(true);
+      const eveTools = new Set(
+        readdirSync(AGENT_TOOLS_DIR)
+          .filter((name) => name.endsWith(".ts"))
+          .map((name) => name.replace(/\.ts$/, ""))
+      );
+      for (const toolName of EFFICIENCY_AGENT_TOOLS) {
+        expect(eveTools.has(toolName)).toBe(true);
+      }
+    });
+
+    it("wires publication activeTools from publication-tools (not a stale inline list)", () => {
+      expect(RUN_GENERATION_SOURCE).toMatch(/PUBLICATION_AGENT_TOOLS/);
+      expect(RUN_GENERATION_SOURCE).toMatch(/from ["'].*publication-tools["']/);
+      const missing = PUBLICATION_AGENT_TOOLS.filter(
+        (name) => !toolDefinedInSource(IN_PROCESS_TOOLS_SOURCE, name)
+      );
+      expect(missing).toEqual([]);
+    });
+  });
+
+  describe("cue-plan host contracts", () => {
+    const validCues = [
+      { kind: "catalog" as const, concept: "key", role: "word-part" as const },
+      { kind: "text" as const, content: "BOARD", role: "word-part" as const },
+    ];
+
+    it("accepts reviewed catalog cues and rejects quarantined ones", () => {
+      expect(resolveCuratedPictogram("key")).not.toBeNull();
+      expect(answerSeedCuePlanIssues(validCues)).toEqual([]);
+      expect(
+        answerSeedCuePlanIssues([
+          { kind: "catalog", concept: "box", role: "word-part" },
+        ])
+      ).not.toEqual([]);
+    });
+
+    it("builds deterministic layers that still satisfy the cue contract", () => {
+      const layers = layersFromAnswerSeedCues(validCues);
+      const visual = {
+        styleId: "ink-pictogram-v1" as const,
+        mode: "composed" as const,
+        layout: "row" as const,
+        layers,
+        unicodeFallback: "key BOARD",
+      };
+      expect(missingAnswerSeedCues({ visual, cues: validCues })).toEqual([]);
+      const inspection = inspectAnswerSeedCuePlan({ cues: validCues, visual });
+      expect(inspection.ready).toBe(true);
+      expect(inspection.issues).toEqual([]);
+      expect(inspection.layerPlan).toHaveLength(2);
+    });
+
+    it("marks incomplete boards as not ready", () => {
+      const inspection = inspectAnswerSeedCuePlan({
+        cues: validCues,
+        visual: {
+          styleId: "ink-pictogram-v1",
+          mode: "composed",
+          layout: "row",
+          unicodeFallback: "🔑",
+          layers: [
+            {
+              kind: "pictogram",
+              concept: "key",
+              emojiFallback: "🔑",
+            },
+          ],
+        },
+      });
+      expect(inspection.ready).toBe(false);
+      expect(inspection.missingOnBoard).toContain("Missing text cue BOARD");
+    });
+  });
+
+  describe("rejection digester taxonomy", () => {
+    it("classifies every known failure family into avoid/prefer guidance", () => {
+      const samples = [
+        "Answer-first visual cue contract failed: Missing catalog cue flower",
+        "Invalid answer-seed cue contract: not an approved catalog concept",
+        "Semantic alignment failed (token-coverage): missing part",
+        "Pictogram lighthouse is pending human approval",
+        "Rendered board objects not recognized: door",
+        "Blind solve tournament rejected candidate",
+        "Critique reject: overused trope",
+        "Composition rejected: unknown concept",
+        "Answer is not unique / banned answer",
+        "Quality below threshold / funScore too low",
+        "Apex engine produced no candidates",
+        "AI_BUDGET_EXCEEDED rate limit",
+      ];
+      const digest = digestRejectionTexts(samples, { topN: 8 });
+      expect(digest.sampleSize).toBe(samples.length);
+      expect(digest.buckets.length).toBeGreaterThanOrEqual(8);
+      expect(digest.avoidPatterns.length).toBeGreaterThan(0);
+      expect(digest.preferPatterns.length).toBeGreaterThan(0);
+      // Unknown noise must not invent fake guidance by itself.
+      expect(digestRejectionTexts(["totally novel mystery"]).avoidPatterns).toEqual([]);
+    });
+  });
+
+  describe("critique-locked repair contracts", () => {
+    it("refuses unlocked repairs and builds locked ToolLoop params", () => {
+      expect(
+        critiqueRepairIssues({
+          answer: "keyboard",
+          reviseInstructions: ["clearer icon"],
+        })
+      ).not.toEqual([]);
+
+      const params = buildCritiqueRepairParams({
+        answer: "keyboard",
+        answerSeedCuePlan: [
+          { kind: "catalog", concept: "key", role: "word-part" },
+          { kind: "text", content: "BOARD", role: "word-part" },
+        ],
+        techniqueId: "simple_compound",
+        reviseInstructions: ["Use a clearer key silhouette"],
+        targetDifficulty: 5,
+      });
+      expect(params.repairMode).toBe("critique-locked");
+      expect(params.answerSeed).toBe("keyboard");
+      expect(params.phraseSeeds).toEqual([]);
+      expect(params.maxAttempts).toBe(1);
+      expect(params.modelChainLimit).toBe(1);
+    });
+  });
+
+  describe("technique calibration contracts", () => {
+    it("reorders techniques under too-easy and too-hard pressure only", () => {
+      const preferred = [
+        "simple_compound",
+        "false_lead_visual",
+        "positional_phrase",
+      ] as const;
+      const rates = [
+        { techniqueId: "simple_compound", sampleSize: 10, solveRate: 0.9 },
+        { techniqueId: "false_lead_visual", sampleSize: 10, solveRate: 0.3 },
+        { techniqueId: "positional_phrase", sampleSize: 10, solveRate: 0.6 },
+      ];
+
+      expect(
+        biasTechniquesBySolveRates({
+          preferredTechniques: [...preferred],
+          rates,
+          tooEasy: true,
+          tooHard: false,
+        }).techniques[0]
+      ).toBe("false_lead_visual");
+
+      expect(
+        biasTechniquesBySolveRates({
+          preferredTechniques: [...preferred],
+          rates,
+          tooEasy: false,
+          tooHard: true,
+        }).techniques[0]
+      ).toBe("simple_compound");
+
+      expect(
+        biasTechniquesBySolveRates({
+          preferredTechniques: [...preferred],
+          rates,
+          tooEasy: false,
+          tooHard: false,
+        }).techniques
+      ).toEqual([...preferred]);
+    });
+  });
+
+  describe("progressive-hint vision contracts", () => {
+    it("only spends after blind dominance fails, and blocks unlock failures", () => {
+      expect(
+        shouldRunProgressiveHintVision({
+          profilesWithDominantTarget: 3,
+          profileCount: 3,
+          topTargetFoundBy: 6,
+          requiredVotes: 2,
+        })
+      ).toBe(false);
+
+      expect(
+        shouldRunProgressiveHintVision({
+          profilesWithDominantTarget: 0,
+          profileCount: 3,
+          topTargetFoundBy: 1,
+          requiredVotes: 2,
+        })
+      ).toBe(true);
+
+      expect(
+        progressiveHintPublishBlockers({
+          hintedAttempted: true,
+          hintedUnlocksVisualSolve: false,
+        } as never).join(" ")
+      ).toMatch(/Progressive-hint vision failed/i);
+    });
+  });
+
+  describe("host invent fail-closed order", () => {
+    it("keeps cue validation → preflight → invent spend in that order", () => {
+      // Scope to the generation function body so import lines don't invert order.
+      const fnAt = RUN_GENERATION_SOURCE.indexOf("export async function runPuzzleAgentGeneration");
+      expect(fnAt).toBeGreaterThan(-1);
+      const body = RUN_GENERATION_SOURCE.slice(fnAt);
+      const cueValidationAt = body.indexOf("answerSeedCuePlanIssues");
+      const preflightAt = body.indexOf("preflightComposeAnswerSeedCuePlan");
+      const ensureKeyAt = body.indexOf("ensureGatewayKey()");
+      const toolLoopAt = body.indexOf("new ToolLoopAgent");
+      expect(cueValidationAt).toBeGreaterThan(-1);
+      expect(preflightAt).toBeGreaterThan(cueValidationAt);
+      expect(ensureKeyAt).toBeGreaterThan(preflightAt);
+      expect(toolLoopAt).toBeGreaterThan(ensureKeyAt);
+      expect(body).toMatch(/Cue-plan preflight failed/);
+      // Prompt seed lives in the invent-prompt helper above the generation entrypoint.
+      expect(RUN_GENERATION_SOURCE).toMatch(/HOST CUE-PLAN PREFLIGHT/);
+    });
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/run-generation-asset-gate.test.ts
@@ -60,6 +60,35 @@ jest.mock("../tool-impl", () => ({
   stressTestSolvability,
 }));
 jest.mock("../tools", () => ({ puzzleAgentTools: {} }));
+jest.mock("../apex/cue-plan-preflight", () => ({
+  preflightComposeAnswerSeedCuePlan: jest.fn(async ({ answer }: { answer: string }) => ({
+    ok: true,
+    stage: "cue-presence",
+    issues: [],
+    inspection: { ready: true, issues: [], missingOnBoard: [], layerPlan: [], plan: "" },
+    composition: {
+      issues: [],
+      visual: {
+        styleId: "ink-pictogram-v1",
+        mode: "composed",
+        layout: "row",
+        unicodeFallback: "🔑 BOARD",
+        layers: [
+          {
+            kind: "pictogram",
+            concept: "key",
+            emojiFallback: "🔑",
+            svg: "<svg />",
+            source: "catalog",
+          },
+          { kind: "text", content: "BOARD", emphasis: "normal" },
+        ],
+      },
+      // answer echoed for host fallback capture
+      answer,
+    },
+  })),
+}));
 jest.mock("../visual/composition", () => ({
   PuzzleVisualSchema: { safeParse: jest.fn((visual) => ({ success: true, data: visual })) },
 }));

--- a/apps/web/src/ai/puzzle-agent/__tests__/run-generation-preflight.integration.test.ts
+++ b/apps/web/src/ai/puzzle-agent/__tests__/run-generation-preflight.integration.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Host-path integration: cue-plan preflight must fail closed before ToolLoop spend,
+ * and successful preflight must seed the prompt + authoritative board fallback.
+ */
+
+const generate = jest.fn();
+const ToolLoopAgent = jest.fn();
+const preflightComposeAnswerSeedCuePlan = jest.fn();
+const ensureGatewayKey = jest.fn();
+const assertGatewayAuthConfigured = jest.fn();
+const enforceQuota = jest.fn(async () => undefined);
+
+jest.mock("ai", () => ({
+  Output: { object: jest.fn(() => ({})) },
+  ToolLoopAgent: jest.fn().mockImplementation(function MockToolLoopAgent(this: unknown, options: unknown) {
+    ToolLoopAgent(options);
+    return {
+      generate: (...args: unknown[]) => generate(options, ...args),
+    };
+  }),
+  stepCountIs: jest.fn(() => () => false),
+}));
+jest.mock("../../client", () => ({
+  assertGatewayAuthConfigured: (...args: unknown[]) => assertGatewayAuthConfigured(...args),
+  ensureGatewayKey: (...args: unknown[]) => ensureGatewayKey(...args),
+  getAiGateway: jest.fn(() => jest.fn(() => "mock-model")),
+  getGatewayModelChain: jest.fn(() => []),
+}));
+jest.mock("../../config", () => ({
+  AI_CONFIG: {
+    puzzleAgent: {
+      model: "test/model",
+      qualityThreshold: 74,
+      minFunScore: 68,
+      maxAttempts: 1,
+      maxSteps: 8,
+    },
+    generation: { temperature: { creative: 0.7 }, maxTokens: { blog: 1000 } },
+    timeouts: { agent: 1000 },
+  },
+}));
+jest.mock("../../errors", () => ({
+  isHardAIBudgetError: jest.fn(() => false),
+  parseAIError: jest.fn((error) => error),
+}));
+jest.mock("../../quota-manager", () => ({
+  enforceQuota: (...args: unknown[]) => enforceQuota(...args),
+}));
+jest.mock("../authoritative-draft", () => ({
+  applyAuthoritativeComposition: jest.fn((puzzle, composition) => ({
+    ...puzzle,
+    rebusPuzzle: composition.visual.unicodeFallback,
+    visual: composition.visual,
+  })),
+}));
+jest.mock("../difficulty-levels", () => ({
+  getDifficultyLevelForScore: jest.fn(() => ({
+    label: "Hard",
+    min: 4,
+    max: 6,
+    target: 5,
+    techniques: ["simple_compound"],
+    componentBudget: { min: 1, max: 4 },
+  })),
+}));
+jest.mock("../quality", () => ({
+  evaluatePublishGates: jest.fn(() => ({
+    ok: true,
+    reasons: [],
+    scores: { overall: 90, fun: 80 },
+  })),
+  normalizeAnswerKey: (answer: string) => answer.toLowerCase().replace(/[^a-z0-9]/g, ""),
+}));
+jest.mock("../schemas", () => ({
+  normalizePuzzleAgentDraft: jest.fn((output) => output),
+  PuzzleAgentDraftSchema: {},
+}));
+jest.mock("../tool-impl", () => ({
+  calibratePuzzleDifficulty: jest.fn(async () => ({
+    calibratedDifficulty: 5,
+    inBand: true,
+    difficultyLevel: "Hard",
+  })),
+  checkUniqueness: jest.fn(async () => ({ isUnique: true, uniquenessScore: 90 })),
+  fingerprintCandidate: jest.fn(() => "fingerprint"),
+  scorePuzzleQuality: jest.fn(async () => ({
+    scores: { overall: 90, fun: 80 },
+    analysis: { strengths: [], weaknesses: [], improvements: [], verdict: "good" },
+    detailedFeedback: "ok",
+  })),
+  stressTestSolvability: jest.fn(() => ({ solvable: true, reasons: [] })),
+}));
+jest.mock("../tools", () => ({ puzzleAgentTools: { compose_puzzle_visual: {} } }));
+jest.mock("../apex/cue-plan-preflight", () => ({
+  preflightComposeAnswerSeedCuePlan: (...args: unknown[]) =>
+    preflightComposeAnswerSeedCuePlan(...args),
+}));
+jest.mock("../visual/composition", () => ({
+  PuzzleVisualSchema: { safeParse: jest.fn((visual) => ({ success: true, data: visual })) },
+}));
+jest.mock("../visual/critique-board", () => ({
+  recognizePuzzleBoard: jest.fn(async () => ({ ok: true, confidence: 0.9 })),
+}));
+jest.mock("../visual/publication-assets", () => ({
+  verifyPublicationAssets: jest.fn(async () => ({ ok: true })),
+}));
+jest.mock("../semantic-alignment", () => ({
+  evaluateSemanticAlignment: jest.fn(() => ({
+    ok: true,
+    rule: "ok",
+    blockers: [],
+    warnings: [],
+    score: 1,
+  })),
+}));
+jest.mock("../apex/player-sim", () => ({
+  applyPlayerSimHeuristics: jest.fn((sim) => sim),
+  playerSimPublishBlockers: jest.fn(() => []),
+  simulatePlayerSolve: jest.fn(async () => ({
+    firstWrongParses: [],
+    likelySolvePath: "ok",
+    hintUnlockOrderLooksFair: true,
+    unfairReasons: [],
+    estimatedSolveRate: 0.5,
+    confidence: 0.9,
+  })),
+}));
+jest.mock("../apex/blind-solve-consensus", () => ({
+  toPlayabilityEvidence: jest.fn(() => undefined),
+}));
+
+import { runPuzzleAgentGeneration } from "../run-generation";
+
+const cuePlan = [
+  { kind: "catalog" as const, concept: "key", role: "word-part" as const },
+  { kind: "text" as const, content: "BOARD", role: "word-part" as const },
+];
+
+const preflightVisual = {
+  styleId: "ink-pictogram-v1",
+  mode: "composed",
+  layout: "row",
+  unicodeFallback: "🔑 BOARD",
+  layers: [
+    {
+      kind: "pictogram",
+      concept: "key",
+      emojiFallback: "🔑",
+      svg: "<svg />",
+      source: "catalog",
+    },
+    { kind: "text", content: "BOARD", emphasis: "normal" },
+  ],
+};
+
+describe("runPuzzleAgentGeneration cue-plan preflight integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    preflightComposeAnswerSeedCuePlan.mockResolvedValue({
+      ok: true,
+      stage: "cue-presence",
+      issues: [],
+      inspection: { ready: true, issues: [], missingOnBoard: [], layerPlan: [], plan: "" },
+      composition: { issues: [], visual: preflightVisual },
+    });
+    generate.mockImplementation(async (_options: unknown, request?: { prompt?: string }) => {
+      // Model returns a draft but never calls compose — host preflight board must still win.
+      return {
+        output: {
+          puzzle: {
+            rebusPuzzle: "ignored",
+            answer: "keyboard",
+            difficulty: 5,
+            difficultyLevel: "Hard",
+            explanation: "key + board",
+            category: "compound",
+            hints: ["compound", "objects", "starts with K"],
+            techniqueId: "simple_compound",
+            visual: preflightVisual,
+          },
+        },
+        prompt: request?.prompt,
+      };
+    });
+  });
+
+  it("rejects invalid catalog cues before preflight or invent spend", async () => {
+    await expect(
+      runPuzzleAgentGeneration({
+        targetDifficulty: 5,
+        answerSeed: "mystery box",
+        answerSeedCuePlan: [{ kind: "catalog", concept: "box", role: "word-part" }],
+        maxAttempts: 1,
+        modelChainLimit: 1,
+      })
+    ).rejects.toThrow(/Invalid answer-seed cue contract/i);
+
+    expect(preflightComposeAnswerSeedCuePlan).not.toHaveBeenCalled();
+    expect(ToolLoopAgent).not.toHaveBeenCalled();
+    expect(ensureGatewayKey).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before gateway/ToolLoop when cue-plan preflight rejects", async () => {
+    // Cue plan must pass catalog validation first — then host preflight rejects composition.
+    preflightComposeAnswerSeedCuePlan.mockResolvedValue({
+      ok: false,
+      stage: "composition",
+      issues: ["Cue-plan composition produced an empty board"],
+      inspection: {
+        ready: false,
+        issues: ["composition failed"],
+        missingOnBoard: [],
+        layerPlan: [],
+        plan: "",
+      },
+      composition: null,
+    });
+
+    await expect(
+      runPuzzleAgentGeneration({
+        targetDifficulty: 5,
+        answerSeed: "keyboard",
+        answerSeedCuePlan: cuePlan,
+        maxAttempts: 1,
+        modelChainLimit: 1,
+      })
+    ).rejects.toThrow(/Cue-plan preflight failed/i);
+
+    expect(preflightComposeAnswerSeedCuePlan).toHaveBeenCalled();
+    expect(ToolLoopAgent).not.toHaveBeenCalled();
+    expect(ensureGatewayKey).not.toHaveBeenCalled();
+    expect(enforceQuota).not.toHaveBeenCalled();
+  });
+
+  it("injects host preflight layers into the invent prompt and uses them as board fallback", async () => {
+    const result = await runPuzzleAgentGeneration({
+      targetDifficulty: 5,
+      answerSeed: "keyboard",
+      answerSeedCuePlan: cuePlan,
+      preferredTechniques: ["simple_compound"],
+      maxAttempts: 1,
+      modelChainLimit: 1,
+      deferRenderedEvaluation: true,
+    });
+
+    expect(preflightComposeAnswerSeedCuePlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        answer: "keyboard",
+        cues: cuePlan,
+      })
+    );
+    expect(ToolLoopAgent).toHaveBeenCalled();
+    const generateArgs = generate.mock.calls[0]?.[1] as { prompt: string };
+    expect(generateArgs?.prompt).toMatch(/HOST CUE-PLAN PREFLIGHT/i);
+    expect(generateArgs?.prompt).toMatch(/pictogram:key/);
+    expect(generateArgs?.prompt).toMatch(/text:BOARD/);
+    expect(result.puzzle.answer).toBe("keyboard");
+    expect(result.puzzle.visual.layers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "pictogram", concept: "key" }),
+        expect.objectContaining({ kind: "text", content: "BOARD" }),
+      ])
+    );
+  });
+
+  it("still rejects when the model board omits a mandatory cue after preflight", async () => {
+    generate.mockImplementation(
+      async (options: {
+        onToolExecutionEnd?: (event: {
+          toolCall: { toolName: string; input: { answer?: string } };
+          toolOutput: { type: string; output: { visual: unknown } };
+        }) => void;
+      }) => {
+        options.onToolExecutionEnd?.({
+          toolCall: {
+            toolName: "compose_puzzle_visual",
+            input: { answer: "keyboard" },
+          },
+          toolOutput: {
+            type: "tool-result",
+            output: {
+              visual: {
+                styleId: "ink-pictogram-v1",
+                mode: "composed",
+                layout: "row",
+                unicodeFallback: "🔑",
+                layers: [
+                  {
+                    kind: "pictogram",
+                    concept: "key",
+                    emojiFallback: "🔑",
+                    svg: "<svg />",
+                    source: "catalog",
+                  },
+                ],
+              },
+            },
+          },
+        });
+        return {
+          output: {
+            puzzle: {
+              rebusPuzzle: "🔑",
+              answer: "keyboard",
+              difficulty: 5,
+              difficultyLevel: "Hard",
+              explanation: "key",
+              category: "compound",
+              hints: ["a", "b", "c"],
+              techniqueId: "simple_compound",
+              visual: preflightVisual,
+            },
+          },
+        };
+      }
+    );
+
+    await expect(
+      runPuzzleAgentGeneration({
+        targetDifficulty: 5,
+        answerSeed: "keyboard",
+        answerSeedCuePlan: cuePlan,
+        maxAttempts: 1,
+        modelChainLimit: 1,
+      })
+    ).rejects.toThrow(/Answer-first visual cue contract failed|Missing text cue BOARD/i);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/critique-repair.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/critique-repair.test.ts
@@ -1,0 +1,61 @@
+import {
+  buildCritiqueRepairParams,
+  critiqueRepairIssues,
+} from "../critique-repair";
+
+describe("critique-locked repair specialist", () => {
+  const cuePlan = [
+    { kind: "catalog" as const, concept: "key", role: "word-part" as const },
+    { kind: "text" as const, content: "BOARD", role: "word-part" as const },
+  ];
+
+  it("requires locked answer, cue plan, and revise instructions", () => {
+    expect(
+      critiqueRepairIssues({
+        answer: "keyboard",
+        answerSeedCuePlan: cuePlan,
+        reviseInstructions: ["Replace the abstract icon"],
+      })
+    ).toEqual([]);
+
+    expect(
+      critiqueRepairIssues({
+        answer: "keyboard",
+        reviseInstructions: ["Replace the abstract icon"],
+      })
+    ).toContain("Critique repair requires a locked answer-seed cue plan");
+  });
+
+  it("builds ToolLoop params that lock answer/cues and disable invent seeds", () => {
+    const params = buildCritiqueRepairParams({
+      answer: "keyboard",
+      answerSeedCuePlan: cuePlan,
+      techniqueId: "simple_compound",
+      reviseInstructions: ["Use a clearer key silhouette"],
+      preferredTechniques: ["simple_compound", "positional_phrase"],
+      targetDifficulty: 5,
+      qualityThreshold: 74,
+      briefSummary: "test brief",
+    });
+
+    expect(params.repairMode).toBe("critique-locked");
+    expect(params.answerSeed).toBe("keyboard");
+    expect(params.answerSeedCuePlan).toEqual(cuePlan);
+    expect(params.revisionInstructions).toEqual(["Use a clearer key silhouette"]);
+    expect(params.maxAttempts).toBe(1);
+    expect(params.modelChainLimit).toBe(1);
+    expect(params.phraseSeeds).toEqual([]);
+    expect(params.preferredTechniques?.[0]).toBe("simple_compound");
+  });
+
+  it("throws when the repair cannot stay locked", () => {
+    expect(() =>
+      buildCritiqueRepairParams({
+        answer: "keyboard",
+        techniqueId: "simple_compound",
+        reviseInstructions: ["fix it"],
+        targetDifficulty: 5,
+      })
+    ).toThrow(/locked answer-seed cue plan/i);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/cue-plan-preflight.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/cue-plan-preflight.test.ts
@@ -1,0 +1,96 @@
+jest.mock("../../visual/compose-visual", () => ({
+  composePuzzleVisual: jest.fn(async ({ layers }: { layers: unknown[] }) => ({
+    visual: {
+      styleId: "ink-pictogram-v1",
+      mode: "composed",
+      layout: "row",
+      layers,
+      unicodeFallback: "🌸 POT",
+    },
+    totalParts: layers.length,
+    withinBudget: true,
+    componentBudget: { min: 1, max: 4 },
+    funScore: 80,
+    issues: [],
+    tips: [],
+    generated: { pictograms: 1, images: 0, failedPictograms: 0, failedImages: 0 },
+  })),
+}));
+
+import { resolveCuratedPictogram } from "../../visual/curated-pictograms";
+import {
+  inspectAnswerSeedCuePlan,
+  layersFromAnswerSeedCues,
+  preflightComposeAnswerSeedCuePlan,
+} from "../cue-plan-preflight";
+
+describe("cue-plan preflight", () => {
+  it("builds deterministic layers from host-owned cues", () => {
+    const layers = layersFromAnswerSeedCues([
+      { kind: "catalog", concept: "flower", role: "word-part" },
+      { kind: "text", content: "POT", role: "word-part" },
+      { kind: "operator", symbol: "+", role: "structural-anchor" },
+    ]);
+
+    expect(layers).toEqual([
+      expect.objectContaining({
+        kind: "pictogram",
+        concept: "flower",
+        source: "catalog",
+        assetId: expect.stringContaining("lucide:flower"),
+        svg: expect.stringContaining("<svg"),
+      }),
+      { kind: "text", content: "POT", emphasis: "normal" },
+      { kind: "operator", symbol: "+" },
+    ]);
+    expect(resolveCuratedPictogram("flower")).not.toBeNull();
+  });
+
+  it("inspects cue plans and rejects quarantined catalog concepts", () => {
+    const inspection = inspectAnswerSeedCuePlan({
+      cues: [
+        { kind: "catalog", concept: "flower", role: "word-part" },
+        { kind: "catalog", concept: "box", role: "word-part" },
+      ],
+    });
+
+    expect(inspection.ready).toBe(false);
+    expect(inspection.issues).toEqual([
+      "Answer-seed cue is not an approved catalog concept: box",
+    ]);
+  });
+
+  it("composes a catalog-backed board without invent when cues are valid", async () => {
+    const result = await preflightComposeAnswerSeedCuePlan({
+      answer: "flower pot",
+      targetDifficulty: 5,
+      techniqueId: "simple_compound",
+      cues: [
+        { kind: "catalog", concept: "flower", role: "word-part" },
+        { kind: "text", content: "POT", role: "word-part" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.composition?.issues).toEqual([]);
+    expect(result.composition?.visual.layers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "pictogram", concept: "flower" }),
+        expect.objectContaining({ kind: "text", content: "POT" }),
+      ])
+    );
+    expect(result.inspection.ready).toBe(true);
+  });
+
+  it("fails closed before compose when the cue plan is invalid", async () => {
+    const result = await preflightComposeAnswerSeedCuePlan({
+      answer: "mystery box",
+      targetDifficulty: 5,
+      cues: [{ kind: "catalog", concept: "box", role: "word-part" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.stage).toBe("cue-plan");
+    expect(result.composition).toBeNull();
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/curriculum-calibration.integration.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/curriculum-calibration.integration.test.ts
@@ -1,0 +1,104 @@
+const loadDiversitySnapshot = jest.fn();
+const loadLearningDigest = jest.fn();
+const loadAllAnswerKeys = jest.fn();
+const loadTechniqueSolveRates = jest.fn();
+const samplePhraseBank = jest.fn();
+
+jest.mock("../diversity-memory", () => ({
+  loadDiversitySnapshot: (...args: unknown[]) => loadDiversitySnapshot(...args),
+}));
+jest.mock("../learning-context", () => ({
+  loadLearningDigest: (...args: unknown[]) => loadLearningDigest(...args),
+}));
+jest.mock("../../../learning/answer-registry", () => ({
+  loadAllAnswerKeys: (...args: unknown[]) => loadAllAnswerKeys(...args),
+}));
+jest.mock("../technique-calibration", () => {
+  const actual = jest.requireActual("../technique-calibration") as typeof import("../technique-calibration");
+  return {
+    ...actual,
+    loadTechniqueSolveRates: (...args: unknown[]) => loadTechniqueSolveRates(...args),
+  };
+});
+jest.mock("../phrase-bank", () => {
+  const actual = jest.requireActual("../phrase-bank") as typeof import("../phrase-bank");
+  return {
+    ...actual,
+    samplePhraseBank: (...args: unknown[]) => samplePhraseBank(...args),
+  };
+});
+
+import { buildGenerationBrief } from "../curriculum";
+
+describe("curriculum ← technique calibration integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadDiversitySnapshot.mockResolvedValue({
+      recentAnswers: [],
+      recentTechniques: [],
+      recentCategories: [],
+      overusedTechniques: [],
+      underusedTechniques: [],
+      bannedAnswerKeys: [],
+      lookbackDays: 45,
+    });
+    loadAllAnswerKeys.mockResolvedValue([]);
+    samplePhraseBank.mockReturnValue([
+      {
+        answer: "moonlight",
+        category: "compound",
+        difficultyHint: 5,
+        techniqueAffinity: ["simple_compound"],
+        visualCues: [{ kind: "catalog", concept: "moon", role: "word-part" }],
+      },
+    ]);
+    loadTechniqueSolveRates.mockResolvedValue({
+      lookbackDays: 45,
+      sampleSize: 30,
+      rates: [
+        // Hard-tier families only — difficulty 5 cannot prefer Evil techniques.
+        { techniqueId: "simple_compound", sampleSize: 12, solveRate: 0.95 },
+        { techniqueId: "single_homophone", sampleSize: 10, solveRate: 0.28 },
+        { techniqueId: "basic_positional", sampleSize: 8, solveRate: 0.5 },
+        { techniqueId: "obvious_emoji_sum", sampleSize: 9, solveRate: 0.88 },
+      ],
+      notes: ["Loaded technique rates"],
+    });
+  });
+
+  it("biases preferred techniques toward harder families when learning says too easy", async () => {
+    loadLearningDigest.mockResolvedValue({
+      enabled: true,
+      avoidPatterns: [],
+      preferPatterns: [],
+      difficultyDriftNotes: [],
+      sampleSize: 20,
+      targetDifficultyDelta: 1,
+      tooEasy: true,
+      tooHard: false,
+      medianSolveSeconds: 40,
+      solveRate: 0.9,
+    });
+
+    const brief = await buildGenerationBrief({
+      targetDifficulty: 5,
+      useLearningFeedback: true,
+    });
+
+    expect(loadTechniqueSolveRates).toHaveBeenCalled();
+    // Lowest live solve rate in-tier should lead when the window is too easy.
+    expect(brief.preferredTechniques[0]).toBe("single_homophone");
+    expect(brief.preferredTechniques.at(-1)).toBe("simple_compound");
+    expect(brief.briefSummary).toMatch(/Technique calibration \(too easy\)/i);
+  });
+
+  it("skips technique calibration load when learning feedback is disabled", async () => {
+    const brief = await buildGenerationBrief({
+      targetDifficulty: 5,
+      useLearningFeedback: false,
+    });
+    expect(loadTechniqueSolveRates).not.toHaveBeenCalled();
+    expect(loadLearningDigest).not.toHaveBeenCalled();
+    expect(brief.learning.enabled).toBe(false);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-budget.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-budget.test.ts
@@ -64,6 +64,10 @@ function puzzleResult(answer: string) {
       funScore: 82,
       visualStyleId: "ink-pictogram-v1" as const,
       answerSeed: answer,
+      answerSeedCuePlan: [
+        { kind: "catalog" as const, concept: "key", role: "word-part" as const },
+        { kind: "text" as const, content: "BOARD", role: "word-part" as const },
+      ],
       thinkingSummary: "test",
     },
     status: "success" as const,
@@ -219,8 +223,14 @@ describe("Apex spending-cap behavior", () => {
     expect(runPuzzleAgentGeneration.mock.calls[2][0]).toMatchObject({
       maxAttempts: 1,
       modelChainLimit: 1,
+      repairMode: "critique-locked",
       revisionInstructions: ["Replace the abstract icon with a concrete silhouette"],
       answerSeed: "top",
+      answerSeedCuePlan: [
+        { kind: "catalog", concept: "key", role: "word-part" },
+        { kind: "text", content: "BOARD", role: "word-part" },
+      ],
+      phraseSeeds: [],
       bannedAnswerKeys: [],
       candidateIndex: undefined,
       candidateCount: undefined,

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-repair-lock.integration.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/engine-repair-lock.integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Apex revise lane must refuse unlocked repairs (no cue plan) instead of
+ * inventing a replacement answer/board.
+ */
+
+const runPuzzleAgentGeneration = jest.fn();
+const buildGenerationBrief = jest.fn();
+const critiqueCandidate = jest.fn();
+const qualifyRenderedCandidate = jest.fn();
+
+jest.mock("../../run-generation", () => ({ runPuzzleAgentGeneration }));
+jest.mock("../../tool-impl", () => ({
+  stableId: jest.fn((...parts: string[]) => parts.join("-")),
+}));
+jest.mock("../curriculum", () => ({ buildGenerationBrief }));
+jest.mock("../critique", () => ({ critiqueCandidate }));
+jest.mock("../rendered-qualification", () => ({ qualifyRenderedCandidate }));
+jest.mock("../player-sim", () => ({
+  applyPlayerSimHeuristics: jest.fn(),
+  playerSimPublishBlockers: jest.fn(() => []),
+  simulatePlayerSolve: jest.fn(),
+}));
+jest.mock("../../../learning/answer-registry", () => ({
+  isAnswerRegistered: jest.fn(async () => ({ taken: false })),
+}));
+jest.mock("../../../learning/sim-calibration", () => ({
+  loadSimCalibration: jest.fn(async () => ({ adjustment: 0, sampleSize: 0 })),
+}));
+
+import { INK_PICTOGRAM_EXAMPLE_KEY } from "../../visual/style";
+import { runApexGeneration } from "../engine";
+
+function puzzleResult(answer: string, withCuePlan: boolean) {
+  return {
+    puzzle: {
+      rebusPuzzle: `${answer} visual`,
+      answer,
+      difficulty: 5,
+      difficultyLevel: "Hard" as const,
+      explanation: "A clean positional mechanism.",
+      category: "phrases",
+      hints: ["Look at the layout.", "Read the objects together.", "It is a phrase."],
+      techniqueId: "simple_compound" as const,
+      visual: {
+        styleId: "ink-pictogram-v1" as const,
+        mode: "composed" as const,
+        layout: "row" as const,
+        unicodeFallback: "key",
+        layers: [
+          {
+            kind: "pictogram" as const,
+            concept: "key",
+            emojiFallback: "🔑",
+            source: "catalog" as const,
+            assetId: "key",
+            svg: INK_PICTOGRAM_EXAMPLE_KEY,
+          },
+        ],
+      },
+    },
+    metadata: {
+      fingerprint: `fingerprint-${answer}`,
+      uniquenessScore: 90,
+      calibratedDifficulty: 5,
+      difficultyLevel: "Hard" as const,
+      qualityScore: 92,
+      qualityVerdict: "good" as const,
+      funScore: 82,
+      visualStyleId: "ink-pictogram-v1" as const,
+      answerSeed: answer,
+      answerSeedCuePlan: withCuePlan
+        ? [{ kind: "catalog" as const, concept: "key", role: "word-part" as const }]
+        : undefined,
+      thinkingSummary: "test",
+    },
+    status: "success" as const,
+    recommendations: [],
+  };
+}
+
+describe("Apex critique-locked repair integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildGenerationBrief.mockResolvedValue({
+      targetDifficulty: 5,
+      tierLabel: "Hard",
+      qualityThreshold: 74,
+      minRubricOverall: 78,
+      candidateCount: 1,
+      preferredTechniques: ["simple_compound"],
+      avoidTechniques: [],
+      phraseSuggestions: [
+        {
+          answer: "keyboard",
+          category: "compound",
+          difficultyHint: 5,
+          techniqueAffinity: ["simple_compound"],
+          visualCues: [{ kind: "catalog", concept: "key", role: "word-part" }],
+        },
+      ],
+      diversity: { bannedAnswerKeys: [] },
+      briefSummary: "test",
+      learning: {
+        enabled: false,
+        avoidPatterns: [],
+        preferPatterns: [],
+        difficultyDriftNotes: [],
+        sampleSize: 0,
+        targetDifficultyDelta: 0,
+        tooEasy: false,
+        tooHard: false,
+        medianSolveSeconds: null,
+        solveRate: null,
+      },
+      requireNovelty: true,
+      minFunScore: 68,
+      componentBudget: { min: 1, max: 4 },
+      puzzleType: "rebus",
+    });
+  });
+
+  it("does not call invent when critique asks to revise but cue plan is missing", async () => {
+    runPuzzleAgentGeneration.mockResolvedValueOnce(puzzleResult("keyboard", false));
+    critiqueCandidate.mockResolvedValue({
+      source: "model",
+      verdict: "revise",
+      summary: "Use a concrete icon",
+      strengths: [],
+      flaws: ["The cue is abstract"],
+      reviseInstructions: ["Replace the abstract icon with a concrete silhouette"],
+      falseLeadQuality: 60,
+      ahaPredicted: 70,
+      creativityScore: 70,
+      iconRecognizability: 45,
+      overusedTrope: false,
+    });
+    // Qualification fails so revise is attempted, then still no winner if repair skipped.
+    qualifyRenderedCandidate.mockImplementation(async (candidate: { rejectReasons: string[] }) => ({
+      ...candidate,
+      publishable: false,
+      rejectReasons: [...candidate.rejectReasons, "Rendered board objects not recognized: key"],
+    }));
+
+    await expect(runApexGeneration({ targetDifficulty: 5 })).rejects.toThrow(
+      /no candidate meeting the publish rubric/i
+    );
+
+    // Slot invent once; locked repair must not invent a second time without cues.
+    expect(runPuzzleAgentGeneration).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/learning-digest-rejection.integration.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/learning-digest-rejection.integration.test.ts
@@ -1,0 +1,106 @@
+const measureWindowPerformance = jest.fn();
+const loadQualityVoteAggregate = jest.fn();
+const qualityVotesToGuidance = jest.fn();
+const loadRejectionDigest = jest.fn();
+const isFeatureEnabled = jest.fn(() => true);
+
+jest.mock("../../../config/feature-flags", () => ({
+  isFeatureEnabled: (...args: unknown[]) => isFeatureEnabled(...args),
+}));
+jest.mock("../../../learning/performance-monitor", () => ({
+  measureWindowPerformance: (...args: unknown[]) => measureWindowPerformance(...args),
+}));
+jest.mock("../../../learning/puzzle-quality-vote", () => ({
+  loadQualityVoteAggregate: (...args: unknown[]) => loadQualityVoteAggregate(...args),
+  qualityVotesToGuidance: (...args: unknown[]) => qualityVotesToGuidance(...args),
+}));
+jest.mock("../../../learning/rejection-digest", () => ({
+  loadRejectionDigest: (...args: unknown[]) => loadRejectionDigest(...args),
+}));
+
+import { loadLearningDigest } from "../learning-context";
+
+describe("learning digest ← rejection digester integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isFeatureEnabled.mockReturnValue(true);
+    measureWindowPerformance.mockResolvedValue({
+      lookbackDays: 7,
+      finalPlays: 20,
+      solves: 10,
+      abandons: 2,
+      solveRate: 0.5,
+      abandonRate: 0.1,
+      medianSolveSeconds: 90,
+      avgSolveSeconds: 100,
+      avgAttemptsOnSolve: 2,
+      avgHintsOnFinal: 1.2,
+      puzzleCount: 7,
+      tooEasy: false,
+      tooHard: false,
+      difficultyDelta: 0,
+      notes: ["window ok"],
+    });
+    loadQualityVoteAggregate.mockResolvedValue({ total: 0 });
+    qualityVotesToGuidance.mockReturnValue({
+      preferPatterns: [],
+      avoidPatterns: [],
+      notes: [],
+    });
+  });
+
+  it("merges rejection-mode avoid/prefer guidance into the digest", async () => {
+    loadRejectionDigest.mockResolvedValue({
+      lookbackDays: 14,
+      sampleSize: 5,
+      buckets: [{ code: "missing_seed_cues", count: 5, examples: [] }],
+      avoidPatterns: ["Composing boards that omit host-owned answer-seed cues"],
+      preferPatterns: [
+        "Place every mandatory catalog/text/operator cue before returning a draft",
+      ],
+      notes: ["Recent reject mode missing_seed_cues ×5"],
+    });
+
+    const digest = await loadLearningDigest({ lookbackDays: 7 });
+
+    expect(loadRejectionDigest).toHaveBeenCalled();
+    expect(digest.enabled).toBe(true);
+    expect(digest.avoidPatterns).toEqual(
+      expect.arrayContaining([
+        "Composing boards that omit host-owned answer-seed cues",
+      ])
+    );
+    expect(digest.preferPatterns).toEqual(
+      expect.arrayContaining([
+        "Place every mandatory catalog/text/operator cue before returning a draft",
+      ])
+    );
+    expect(digest.difficultyDriftNotes.join(" ")).toMatch(/missing_seed_cues/);
+    expect(digest.sampleSize).toBeGreaterThanOrEqual(25);
+  });
+
+  it("stays quiet when rejection digest is empty", async () => {
+    loadRejectionDigest.mockResolvedValue({
+      lookbackDays: 14,
+      sampleSize: 0,
+      buckets: [],
+      avoidPatterns: [],
+      preferPatterns: [],
+      notes: [],
+    });
+
+    const digest = await loadLearningDigest();
+    expect(digest.avoidPatterns).not.toEqual(
+      expect.arrayContaining([
+        "Composing boards that omit host-owned answer-seed cues",
+      ])
+    );
+  });
+
+  it("does not load rejection modes when learning feature flag is off", async () => {
+    isFeatureEnabled.mockReturnValue(false);
+    const digest = await loadLearningDigest();
+    expect(digest.enabled).toBe(false);
+    expect(loadRejectionDigest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/player-sim-hinted.integration.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/player-sim-hinted.integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Progressive-hint vision wiring inside simulatePlayerSolve:
+ * spend only after blind dominance fails; honor skip flag; block unlock misses.
+ */
+
+const generateAIObjectFromImage = jest.fn();
+const renderPuzzleVisualProfiles = jest.fn();
+const runPuzzleEditorialTournament = jest.fn();
+
+jest.mock("../../../client", () => ({
+  generateAIObjectFromImage: (...args: unknown[]) => generateAIObjectFromImage(...args),
+}));
+jest.mock("../../../config", () => ({
+  AI_CONFIG: {
+    visualRecognition: {
+      models: ["judge-a", "judge-b"],
+      minConfidence: 0.68,
+      requiredVotes: 2,
+      boardEnabled: true,
+    },
+  },
+}));
+jest.mock("../../visual/render-board", () => ({
+  renderPuzzleVisualProfiles: (...args: unknown[]) => renderPuzzleVisualProfiles(...args),
+}));
+jest.mock("../../visual/editorial-review", () => ({
+  runPuzzleEditorialTournament: (...args: unknown[]) => runPuzzleEditorialTournament(...args),
+}));
+jest.mock("../../visual/editorial-consensus", () => ({
+  editorialReviewPublishBlockers: jest.fn(() => []),
+  summarizeEditorialReviewAttempts: jest.fn(() => ({
+    profileCount: 0,
+    acceptedProfiles: 0,
+    confidence: 1,
+    failureKinds: [],
+    reasons: [],
+  })),
+}));
+
+import { playerSimPublishBlockers, simulatePlayerSolve } from "../player-sim";
+
+const visual = {
+  styleId: "ink-pictogram-v1" as const,
+  mode: "composed" as const,
+  layout: "row" as const,
+  unicodeFallback: "🔑 BOARD",
+  layers: [
+    {
+      kind: "pictogram" as const,
+      concept: "key",
+      emojiFallback: "🔑",
+      svg: "<svg />",
+      source: "catalog" as const,
+    },
+    { kind: "text" as const, content: "BOARD", emphasis: "normal" as const },
+  ],
+};
+
+function visionResult(answer: string, confidence = 0.9) {
+  return {
+    visibleElements: ["key", "BOARD"],
+    relationships: ["side by side"],
+    hypotheses: [
+      { answer, confidence, rationale: "from board" },
+      { answer: "decoy", confidence: Math.max(0.1, confidence - 0.4), rationale: "noise" },
+    ],
+    confidence,
+  };
+}
+
+describe("simulatePlayerSolve progressive-hint integration", () => {
+  const prevSkip = process.env.REBUZZLE_SKIP_HINTED_VISION;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.REBUZZLE_SKIP_HINTED_VISION;
+    renderPuzzleVisualProfiles.mockResolvedValue([
+      {
+        profileId: "compact-320",
+        viewportWidth: 320,
+        tileSize: 44,
+        pixels: new Uint8Array([1]),
+      },
+      {
+        profileId: "mobile-375",
+        viewportWidth: 375,
+        tileSize: 72,
+        pixels: new Uint8Array([2]),
+      },
+      {
+        profileId: "desktop-768",
+        viewportWidth: 768,
+        tileSize: 72,
+        pixels: new Uint8Array([3]),
+      },
+    ]);
+    runPuzzleEditorialTournament.mockResolvedValue([]);
+  });
+
+  afterAll(() => {
+    if (prevSkip === undefined) delete process.env.REBUZZLE_SKIP_HINTED_VISION;
+    else process.env.REBUZZLE_SKIP_HINTED_VISION = prevSkip;
+  });
+
+  it("does not spend hinted vision when blind dominance already passes", async () => {
+    generateAIObjectFromImage.mockImplementation(async () => visionResult("keyboard", 0.95));
+
+    const result = await simulatePlayerSolve({
+      rebusPuzzle: "🔑 BOARD",
+      answer: "keyboard",
+      explanation: "key + board",
+      hints: ["compound word", "starts with K", "keyboard"],
+      techniqueId: "simple_compound",
+      tierLabel: "Hard",
+      visual,
+    });
+
+    const hintedCalls = generateAIObjectFromImage.mock.calls.filter(
+      (call) => (call[0] as { operation?: string }).operation === "vision-hinted-solve"
+    );
+    expect(hintedCalls).toHaveLength(0);
+    expect(result.hintedAttempted).toBe(false);
+    expect(result.blindProfilesWithDominantTarget).toBeGreaterThanOrEqual(2);
+  });
+
+  it("spends hinted vision after blind failure and blocks unlock misses", async () => {
+    generateAIObjectFromImage.mockImplementation(async (args: { operation?: string }) => {
+      if (args.operation === "vision-hinted-solve") {
+        return visionResult("lockboard", 0.85);
+      }
+      return visionResult("lockboard", 0.9);
+    });
+
+    const result = await simulatePlayerSolve({
+      rebusPuzzle: "🔑 BOARD",
+      answer: "keyboard",
+      explanation: "key + board",
+      hints: ["compound word", "starts with K", "keyboard"],
+      techniqueId: "simple_compound",
+      tierLabel: "Hard",
+      visual,
+    });
+
+    const hintedCalls = generateAIObjectFromImage.mock.calls.filter(
+      (call) => (call[0] as { operation?: string }).operation === "vision-hinted-solve"
+    );
+    expect(hintedCalls.length).toBeGreaterThan(0);
+    expect(result.hintedAttempted).toBe(true);
+    expect(result.hintedUnlocksVisualSolve).toBe(false);
+    expect(playerSimPublishBlockers(result).join(" ")).toMatch(/Progressive-hint vision failed/i);
+  });
+
+  it("honors REBUZZLE_SKIP_HINTED_VISION to avoid spend", async () => {
+    process.env.REBUZZLE_SKIP_HINTED_VISION = "1";
+    generateAIObjectFromImage.mockImplementation(async () => visionResult("lockboard", 0.9));
+
+    const result = await simulatePlayerSolve({
+      rebusPuzzle: "🔑 BOARD",
+      answer: "keyboard",
+      explanation: "key + board",
+      hints: ["compound word", "starts with K", "keyboard"],
+      techniqueId: "simple_compound",
+      tierLabel: "Hard",
+      visual,
+    });
+
+    const hintedCalls = generateAIObjectFromImage.mock.calls.filter(
+      (call) => (call[0] as { operation?: string }).operation === "vision-hinted-solve"
+    );
+    expect(hintedCalls).toHaveLength(0);
+    expect(result.hintedAttempted).toBe(false);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/progressive-hint-vision.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/progressive-hint-vision.test.ts
@@ -1,0 +1,39 @@
+import {
+  progressiveHintPublishBlockers,
+  shouldRunProgressiveHintVision,
+} from "../progressive-hint-vision";
+import type { PlayerSimResult } from "../types";
+
+describe("progressive-hint vision gating", () => {
+  it("skips hinted spend when blind dominance already passed", () => {
+    expect(
+      shouldRunProgressiveHintVision({
+        profilesWithDominantTarget: 3,
+        profileCount: 3,
+        topTargetFoundBy: 6,
+        requiredVotes: 2,
+      })
+    ).toBe(false);
+  });
+
+  it("runs hinted unlock check when blind dominance failed", () => {
+    expect(
+      shouldRunProgressiveHintVision({
+        profilesWithDominantTarget: 1,
+        profileCount: 3,
+        topTargetFoundBy: 2,
+        requiredVotes: 2,
+      })
+    ).toBe(true);
+  });
+
+  it("publishes a clear blocker when progressive hints fail to unlock", () => {
+    const sim = {
+      hintedAttempted: true,
+      hintedUnlocksVisualSolve: false,
+    } as PlayerSimResult;
+    expect(progressiveHintPublishBlockers(sim).join(" ")).toMatch(
+      /Progressive-hint vision failed/i
+    );
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/__tests__/technique-calibration.test.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/__tests__/technique-calibration.test.ts
@@ -1,0 +1,58 @@
+import { biasTechniquesBySolveRates } from "../technique-calibration";
+
+describe("technique-family difficulty calibrator", () => {
+  const preferred = [
+    "simple_compound",
+    "false_lead_visual",
+    "positional_phrase",
+  ] as const;
+
+  const rates = [
+    { techniqueId: "simple_compound", sampleSize: 12, solveRate: 0.92 },
+    { techniqueId: "false_lead_visual", sampleSize: 8, solveRate: 0.35 },
+    { techniqueId: "positional_phrase", sampleSize: 6, solveRate: 0.55 },
+  ];
+
+  it("demotes high-solve techniques when the window is too easy", () => {
+    const result = biasTechniquesBySolveRates({
+      preferredTechniques: [...preferred],
+      rates,
+      tooEasy: true,
+      tooHard: false,
+    });
+    expect(result.techniques[0]).toBe("false_lead_visual");
+    expect(result.techniques.at(-1)).toBe("simple_compound");
+    expect(result.notes[0]).toMatch(/too easy/i);
+  });
+
+  it("promotes friendlier techniques when the window is too hard", () => {
+    const result = biasTechniquesBySolveRates({
+      preferredTechniques: [...preferred],
+      rates,
+      tooEasy: false,
+      tooHard: true,
+    });
+    expect(result.techniques[0]).toBe("simple_compound");
+    expect(result.notes[0]).toMatch(/too hard/i);
+  });
+
+  it("keeps order when pressure is balanced or samples are thin", () => {
+    expect(
+      biasTechniquesBySolveRates({
+        preferredTechniques: [...preferred],
+        rates,
+        tooEasy: false,
+        tooHard: false,
+      }).techniques
+    ).toEqual([...preferred]);
+
+    expect(
+      biasTechniquesBySolveRates({
+        preferredTechniques: [...preferred],
+        rates: [{ techniqueId: "simple_compound", sampleSize: 1, solveRate: 0.99 }],
+        tooEasy: true,
+        tooHard: false,
+      }).techniques
+    ).toEqual([...preferred]);
+  });
+});

--- a/apps/web/src/ai/puzzle-agent/apex/critique-repair.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/critique-repair.ts
@@ -1,0 +1,86 @@
+/**
+ * Critique-locked repair specialist.
+ *
+ * Formalizes the Apex ≤1 revise lane: preserve answer + cue plan, rewrite the
+ * board only to satisfy model critique instructions. No re-seed invent.
+ */
+
+import type { PuzzleGenerationParams } from "../run-generation";
+import type { AnswerSeedVisualCue } from "./types";
+
+export type CritiqueRepairRequest = {
+  answer: string;
+  answerSeedCuePlan?: readonly AnswerSeedVisualCue[];
+  techniqueId: string;
+  reviseInstructions: readonly string[];
+  preferredTechniques?: string[];
+  avoidTechniques?: string[];
+  bannedAnswerKeys?: string[];
+  briefSummary?: string;
+  qualityThreshold?: number;
+  targetDifficulty: number;
+  puzzleType?: string;
+  category?: string;
+  theme?: string;
+};
+
+/**
+ * Fail closed when a repair cannot stay answer/cue locked.
+ */
+export function critiqueRepairIssues(input: {
+  answer?: string;
+  answerSeedCuePlan?: readonly AnswerSeedVisualCue[];
+  reviseInstructions?: readonly string[];
+}): string[] {
+  const issues: string[] = [];
+  if (!input.answer?.trim()) {
+    issues.push("Critique repair requires a locked answer");
+  }
+  if (!input.answerSeedCuePlan?.length) {
+    issues.push("Critique repair requires a locked answer-seed cue plan");
+  }
+  if (!input.reviseInstructions?.length) {
+    issues.push("Critique repair requires model reviseInstructions");
+  }
+  return issues;
+}
+
+/**
+ * Build ToolLoop params for a single critique-locked repair pass.
+ */
+export function buildCritiqueRepairParams(
+  request: CritiqueRepairRequest,
+  base?: Partial<PuzzleGenerationParams>
+): PuzzleGenerationParams {
+  const issues = critiqueRepairIssues(request);
+  if (issues.length) {
+    throw new Error(`Critique repair unavailable: ${issues.join("; ")}`);
+  }
+
+  return {
+    ...base,
+    targetDifficulty: request.targetDifficulty,
+    puzzleType: request.puzzleType,
+    category: request.category,
+    theme: request.theme,
+    qualityThreshold: request.qualityThreshold,
+    briefSummary: request.briefSummary,
+    preferredTechniques: [
+      request.techniqueId,
+      ...(request.preferredTechniques ?? []).filter((id) => id !== request.techniqueId),
+    ],
+    avoidTechniques: request.avoidTechniques,
+    bannedAnswerKeys: request.bannedAnswerKeys,
+    answerSeed: request.answer,
+    answerSeedCuePlan: request.answerSeedCuePlan,
+    revisionInstructions: [...request.reviseInstructions],
+    repairMode: "critique-locked",
+    maxAttempts: 1,
+    modelChainLimit: 1,
+    deferRenderedEvaluation: true,
+    candidateIndex: undefined,
+    candidateCount: undefined,
+    // Repair must not brainstorm replacement answers.
+    phraseSeeds: [],
+  };
+}

--- a/apps/web/src/ai/puzzle-agent/apex/cue-plan-preflight.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/cue-plan-preflight.ts
@@ -1,0 +1,192 @@
+/**
+ * Cheap cue-plan preflight — compose from host-owned seed cues before ToolLoop invent.
+ *
+ * Proves the answer-seed contract is catalog-grounded and composable without
+ * paying for a creative invent loop. Failures here fail closed with zero model spend.
+ */
+
+import type { PuzzleVisual, VisualLayer } from "../visual/composition";
+import type { ComposePuzzleVisualResult } from "../visual/compose-visual";
+import { resolveCuratedPictogram } from "../visual/curated-pictograms";
+import {
+  answerSeedCuePlanIssues,
+  formatAnswerSeedCuePlan,
+  missingAnswerSeedCues,
+} from "./answer-seed-cues";
+import type { AnswerSeedVisualCue } from "./types";
+
+function emojiForConcept(concept: string): string {
+  // Share-string placeholder only — compose fills reviewed SVG + real fallback.
+  const cleaned = concept.replace(/[^a-z0-9]+/gi, "").slice(0, 2).toUpperCase();
+  return cleaned || "◆";
+}
+
+/**
+ * Deterministic layer plan from host-owned answer-seed cues.
+ */
+export function layersFromAnswerSeedCues(
+  cues: readonly AnswerSeedVisualCue[]
+): VisualLayer[] {
+  return cues.map((cue): VisualLayer => {
+    if (cue.kind === "catalog") {
+      const resolved = resolveCuratedPictogram(cue.concept);
+      const concept = resolved?.canonicalConcept ?? cue.concept;
+      return {
+        kind: "pictogram",
+        concept,
+        role: cue.role,
+        emojiFallback: emojiForConcept(concept),
+        ...(resolved
+          ? {
+              svg: resolved.svg,
+              assetId: resolved.assetId,
+              source: "catalog" as const,
+            }
+          : {}),
+      };
+    }
+    if (cue.kind === "text") {
+      return {
+        kind: "text",
+        content: cue.content,
+        emphasis: "normal",
+      };
+    }
+    return {
+      kind: "operator",
+      symbol: cue.symbol,
+    };
+  });
+}
+
+export type InspectAnswerSeedCuePlanResult = {
+  plan: string;
+  issues: string[];
+  missingOnBoard: string[];
+  layerPlan: VisualLayer[];
+  catalogConcepts: string[];
+  ready: boolean;
+  guidance: string[];
+};
+
+/**
+ * Model-facing inspector for an answer-seed cue contract (+ optional board check).
+ */
+export function inspectAnswerSeedCuePlan(input: {
+  cues?: readonly AnswerSeedVisualCue[];
+  visual?: PuzzleVisual;
+}): InspectAnswerSeedCuePlanResult {
+  const cues = input.cues ?? [];
+  const issues = answerSeedCuePlanIssues(cues);
+  const layerPlan = issues.length ? [] : layersFromAnswerSeedCues(cues);
+  const missingOnBoard = input.visual
+    ? missingAnswerSeedCues({ visual: input.visual, cues })
+    : [];
+  const catalogConcepts = cues
+    .filter((cue): cue is Extract<AnswerSeedVisualCue, { kind: "catalog" }> => cue.kind === "catalog")
+    .map((cue) => cue.concept);
+
+  const guidance: string[] = [];
+  if (!cues.length) {
+    guidance.push("No cue plan provided — invent only when the host has not reserved an answer-first seed");
+  }
+  if (issues.length) {
+    guidance.push("Fix cue-plan issues before compose_puzzle_visual");
+  } else if (cues.length) {
+    guidance.push("Call compose_puzzle_visual with these exact layer concepts/text/operators");
+    guidance.push("Do not substitute catalog concepts with vaguely related icons");
+  }
+  if (missingOnBoard.length) {
+    guidance.push(`Board is still missing: ${missingOnBoard.join("; ")}`);
+  }
+
+  return {
+    plan: formatAnswerSeedCuePlan(cues),
+    issues,
+    missingOnBoard,
+    layerPlan,
+    catalogConcepts,
+    ready: issues.length === 0 && cues.length > 0 && missingOnBoard.length === 0,
+    guidance,
+  };
+}
+
+export type CuePlanPreflightResult = {
+  ok: boolean;
+  stage: "cue-plan" | "compose" | "cue-presence";
+  issues: string[];
+  inspection: InspectAnswerSeedCuePlanResult;
+  composition: ComposePuzzleVisualResult | null;
+};
+
+/**
+ * Host-side preflight: validate cues → compose deterministically → verify presence.
+ */
+export async function preflightComposeAnswerSeedCuePlan(input: {
+  answer: string;
+  targetDifficulty: number;
+  techniqueId?: string;
+  cues: readonly AnswerSeedVisualCue[];
+  layout?: "row" | "stack" | "grid" | "overlay";
+}): Promise<CuePlanPreflightResult> {
+  const inspection = inspectAnswerSeedCuePlan({ cues: input.cues });
+  if (!input.cues.length || inspection.issues.length) {
+    return {
+      ok: false,
+      stage: "cue-plan",
+      issues: inspection.issues.length
+        ? inspection.issues
+        : ["Answer-seed cue plan is empty"],
+      inspection,
+      composition: null,
+    };
+  }
+
+  // Dynamic import keeps pure inspectors free of the AI SDK ESM graph in Jest.
+  const { composePuzzleVisual } = await import("../visual/compose-visual");
+  const composition = await composePuzzleVisual({
+    answer: input.answer,
+    targetDifficulty: input.targetDifficulty,
+    techniqueId: input.techniqueId,
+    layout: input.layout ?? "row",
+    layers: inspection.layerPlan,
+  });
+
+  if (composition.issues.length) {
+    return {
+      ok: false,
+      stage: "compose",
+      issues: composition.issues,
+      inspection,
+      composition,
+    };
+  }
+
+  const missing = missingAnswerSeedCues({
+    visual: composition.visual,
+    cues: input.cues,
+  });
+  if (missing.length) {
+    return {
+      ok: false,
+      stage: "cue-presence",
+      issues: missing,
+      inspection: inspectAnswerSeedCuePlan({
+        cues: input.cues,
+        visual: composition.visual,
+      }),
+      composition,
+    };
+  }
+
+  return {
+    ok: true,
+    stage: "cue-presence",
+    issues: [],
+    inspection: inspectAnswerSeedCuePlan({
+      cues: input.cues,
+      visual: composition.visual,
+    }),
+    composition,
+  };
+}

--- a/apps/web/src/ai/puzzle-agent/apex/curriculum.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/curriculum.ts
@@ -10,6 +10,10 @@ import type { TechniqueId } from "../technique-library";
 import { loadDiversitySnapshot } from "./diversity-memory";
 import { loadLearningDigest } from "./learning-context";
 import { PHRASE_BANK, samplePhraseBank } from "./phrase-bank";
+import {
+  biasTechniquesBySolveRates,
+  loadTechniqueSolveRates,
+} from "./technique-calibration";
 import type { GenerationBrief } from "./types";
 
 export type CurriculumInput = {
@@ -32,7 +36,7 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
   const minFunScore = AI_CONFIG.puzzleAgent.minFunScore;
   const candidateCount = input.candidateCount ?? AI_CONFIG.puzzleAgent.apex?.candidateCount ?? 3;
 
-  const [diversity, learning, archiveKeys] = await Promise.all([
+  const [diversity, learning, archiveKeys, techniqueCalibration] = await Promise.all([
     loadDiversitySnapshot({ lookbackDays: 45 }),
     input.useLearningFeedback === false
       ? Promise.resolve({
@@ -49,6 +53,14 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
         })
       : loadLearningDigest(),
     loadAllAnswerKeys(500),
+    input.useLearningFeedback === false
+      ? Promise.resolve({
+          lookbackDays: 45,
+          sampleSize: 0,
+          rates: [],
+          notes: [] as string[],
+        })
+      : loadTechniqueSolveRates({ lookbackDays: 45 }),
   ]);
 
   // Ban recent + full archive answers so retired puzzles still block reuse
@@ -83,7 +95,7 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
       ] as TechniqueId[])
     : [];
 
-  const preferredTechniques = (
+  const preferredTechniquesRaw = (
     [
       ...harderBias.filter((t) => supportedTierTechniques.includes(t)),
       ...diversity.underusedTechniques.filter((t) =>
@@ -93,6 +105,14 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
       ...supportedTierTechniques,
     ] as TechniqueId[]
   ).filter((t, i, arr) => arr.indexOf(t) === i) as TechniqueId[];
+
+  const techniqueBias = biasTechniquesBySolveRates({
+    preferredTechniques: preferredTechniquesRaw,
+    rates: techniqueCalibration.rates,
+    tooEasy: learning.tooEasy,
+    tooHard: learning.tooHard,
+  });
+  const preferredTechniques = techniqueBias.techniques;
 
   const avoidTechniques = [
     ...diversity.overusedTechniques.filter((t) =>
@@ -139,6 +159,7 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
     learning.enabled && learning.preferPatterns.length
       ? `Learning prefer: ${learning.preferPatterns.slice(0, 3).join("; ")}.`
       : null,
+    techniqueBias.notes[0] ?? techniqueCalibration.notes[0] ?? null,
     learning.targetDifficultyDelta !== 0
       ? `Applied difficulty delta: ${learning.targetDifficultyDelta > 0 ? "+" : ""}${learning.targetDifficultyDelta}.`
       : null,

--- a/apps/web/src/ai/puzzle-agent/apex/curriculum.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/curriculum.ts
@@ -134,10 +134,10 @@ export async function buildGenerationBrief(input: CurriculumInput): Promise<Gene
       ? `Self-learning: ${learning.difficultyDriftNotes.slice(0, 2).join("; ")}.`
       : null,
     learning.enabled && learning.avoidPatterns.length
-      ? `Learning avoid: ${learning.avoidPatterns.slice(0, 2).join("; ")}.`
+      ? `Learning avoid: ${learning.avoidPatterns.slice(0, 3).join("; ")}.`
       : null,
     learning.enabled && learning.preferPatterns.length
-      ? `Learning prefer: ${learning.preferPatterns.slice(0, 2).join("; ")}.`
+      ? `Learning prefer: ${learning.preferPatterns.slice(0, 3).join("; ")}.`
       : null,
     learning.targetDifficultyDelta !== 0
       ? `Applied difficulty delta: ${learning.targetDifficultyDelta > 0 ? "+" : ""}${learning.targetDifficultyDelta}.`

--- a/apps/web/src/ai/puzzle-agent/apex/engine.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/engine.ts
@@ -10,7 +10,7 @@
 
 import { AI_CONFIG } from "../../config";
 import { isHardAIBudgetError, parseAIError } from "../../errors";
-import { isKnownTechniqueId, normalizeAnswerKey } from "../quality";
+import { isKnownTechniqueId } from "../quality";
 import { type PuzzleGenerationParams, runPuzzleAgentGeneration } from "../run-generation";
 import type { PuzzleAgentResult } from "../schemas";
 import type { TechniqueId } from "../technique-library";
@@ -22,6 +22,7 @@ import {
 } from "./answer-first";
 import { toPlayabilityEvidence } from "./blind-solve-consensus";
 import { critiqueCandidate } from "./critique";
+import { buildCritiqueRepairParams, critiqueRepairIssues } from "./critique-repair";
 import { buildGenerationBrief } from "./curriculum";
 import { selectQualifiedFinalist } from "./finalist-selection";
 import { qualifyRenderedCandidate } from "./rendered-qualification";
@@ -322,31 +323,35 @@ export async function runApexGeneration(
     maxRevisions: 1,
     revise: async (candidate) => {
       try {
-        const result = await runPuzzleAgentGeneration({
-          ...params,
-          maxAttempts: 1,
-          modelChainLimit: 1,
-          qualityThreshold: brief.qualityThreshold,
-          briefSummary: brief.briefSummary,
-          preferredTechniques: [
-            candidate.techniqueId,
-            ...brief.preferredTechniques.filter((technique) => technique !== candidate.techniqueId),
-          ],
-          avoidTechniques: brief.avoidTechniques,
-          phraseSeeds: brief.phraseSuggestions
-            .filter(
-              (phrase) => normalizeAnswerKey(phrase.answer) !== normalizeAnswerKey(candidate.answer)
-            )
-            .slice(0, 3)
-            .map((phrase) => phrase.answer),
-          answerSeed: candidate.answer,
+        const repairIssues = critiqueRepairIssues({
+          answer: candidate.answer,
           answerSeedCuePlan: candidate.answerSeedCuePlan,
-          bannedAnswerKeys: Array.from(new Set(brief.diversity.bannedAnswerKeys)),
-          candidateIndex: undefined,
-          candidateCount: undefined,
-          deferRenderedEvaluation: true,
-          revisionInstructions: candidate.critique?.reviseInstructions,
+          reviseInstructions: candidate.critique?.reviseInstructions,
         });
+        if (repairIssues.length) {
+          failures.push(`Critique repair skipped: ${repairIssues.join("; ")}`);
+          return null;
+        }
+        const result = await runPuzzleAgentGeneration(
+          buildCritiqueRepairParams(
+            {
+              answer: candidate.answer,
+              answerSeedCuePlan: candidate.answerSeedCuePlan,
+              techniqueId: candidate.techniqueId,
+              reviseInstructions: candidate.critique?.reviseInstructions ?? [],
+              preferredTechniques: brief.preferredTechniques,
+              avoidTechniques: brief.avoidTechniques,
+              bannedAnswerKeys: Array.from(new Set(brief.diversity.bannedAnswerKeys)),
+              briefSummary: brief.briefSummary,
+              qualityThreshold: brief.qualityThreshold,
+              targetDifficulty: params.targetDifficulty,
+              puzzleType: params.puzzleType,
+              category: params.category,
+              theme: params.theme,
+            },
+            params
+          )
+        );
         return toCandidate(result, brief, brief.candidateCount + 1);
       } catch (error) {
         if (isHardAIBudgetError(error)) throw parseAIError(error);

--- a/apps/web/src/ai/puzzle-agent/apex/index.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/index.ts
@@ -15,6 +15,10 @@ export {
 } from "./answer-seed-cues";
 export { critiqueCandidate } from "./critique";
 export {
+  buildCritiqueRepairParams,
+  critiqueRepairIssues,
+} from "./critique-repair";
+export {
   inspectAnswerSeedCuePlan,
   layersFromAnswerSeedCues,
   preflightComposeAnswerSeedCuePlan,
@@ -24,8 +28,20 @@ export { loadDiversitySnapshot } from "./diversity-memory";
 export { runApexGeneration } from "./engine";
 export { loadLearningDigest } from "./learning-context";
 export { phraseBankSize, samplePhraseBank } from "./phrase-bank";
-export { applyPlayerSimHeuristics, simulatePlayerSolve } from "./player-sim";
+export {
+  applyPlayerSimHeuristics,
+  playerSimPublishBlockers,
+  simulatePlayerSolve,
+} from "./player-sim";
+export {
+  progressiveHintPublishBlockers,
+  shouldRunProgressiveHintVision,
+} from "./progressive-hint-vision";
 export { scoreRubric, tournamentScore } from "./rubric";
+export {
+  biasTechniquesBySolveRates,
+  loadTechniqueSolveRates,
+} from "./technique-calibration";
 export { pickWinner, rankCandidates } from "./tournament";
 export type {
   ApexCandidate,

--- a/apps/web/src/ai/puzzle-agent/apex/index.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/index.ts
@@ -8,7 +8,17 @@ export {
   selectAnswerFirstSeed,
   selectAnswerFirstSeeds,
 } from "./answer-first";
+export {
+  formatAnswerSeedCuePlan,
+  missingAnswerSeedCues,
+  answerSeedCuePlanIssues,
+} from "./answer-seed-cues";
 export { critiqueCandidate } from "./critique";
+export {
+  inspectAnswerSeedCuePlan,
+  layersFromAnswerSeedCues,
+  preflightComposeAnswerSeedCuePlan,
+} from "./cue-plan-preflight";
 export { buildGenerationBrief } from "./curriculum";
 export { loadDiversitySnapshot } from "./diversity-memory";
 export { runApexGeneration } from "./engine";

--- a/apps/web/src/ai/puzzle-agent/apex/learning-context.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/learning-context.ts
@@ -8,6 +8,7 @@ import {
   loadQualityVoteAggregate,
   qualityVotesToGuidance,
 } from "../../learning/puzzle-quality-vote";
+import { loadRejectionDigest } from "../../learning/rejection-digest";
 import type { LearningDigest } from "./types";
 
 /**
@@ -35,12 +36,13 @@ export async function loadLearningDigest(input?: {
   const lookbackDays = input?.lookbackDays ?? 7;
 
   try {
-    const [window, qualityVotes] = await Promise.all([
+    const [window, qualityVotes, rejectionDigest] = await Promise.all([
       measureWindowPerformance({
         lookbackDays,
         minFinals: 8,
       }),
       loadQualityVoteAggregate({ lookbackDays: Math.max(lookbackDays, 14) }),
+      loadRejectionDigest({ lookbackDays: Math.max(lookbackDays, 14) }),
     ]);
 
     const avoidPatterns: string[] = [];
@@ -86,12 +88,17 @@ export async function loadLearningDigest(input?: {
     avoidPatterns.push(...qualityGuidance.avoidPatterns);
     difficultyDriftNotes.push(...qualityGuidance.notes);
 
+    // Recent Apex/Eve reject modes → "avoid last N failure modes" for the brief.
+    preferPatterns.push(...rejectionDigest.preferPatterns);
+    avoidPatterns.push(...rejectionDigest.avoidPatterns);
+    difficultyDriftNotes.push(...rejectionDigest.notes);
+
     return {
       enabled: true,
       avoidPatterns,
       preferPatterns,
       difficultyDriftNotes,
-      sampleSize: window.finalPlays + qualityVotes.total,
+      sampleSize: window.finalPlays + qualityVotes.total + rejectionDigest.sampleSize,
       targetDifficultyDelta: window.difficultyDelta,
       tooEasy: window.tooEasy,
       tooHard: window.tooHard,

--- a/apps/web/src/ai/puzzle-agent/apex/player-sim.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/player-sim.ts
@@ -17,7 +17,13 @@ import {
   blindSolvePublishBlockers,
   summarizeBlindSolveAttempts,
 } from "./blind-solve-consensus";
+import {
+  progressiveHintPublishBlockers,
+  shouldRunProgressiveHintVision,
+} from "./progressive-hint-vision";
 import type { PlayerSimResult } from "./types";
+
+export { shouldRunProgressiveHintVision } from "./progressive-hint-vision";
 
 const BlindSolveSchema = z.object({
   visibleElements: z.array(z.string().max(100)).max(20),
@@ -95,6 +101,53 @@ export async function runBlindSolveTournament(input: {
   return attempts.flat();
 }
 
+/**
+ * Progressive-hint vision: judges see the board plus early hints (never the final
+ * spoiler). Used after a weak blind solve to verify the ladder unlocks a fair reading.
+ */
+export async function runHintedSolveTournament(input: {
+  visual: PuzzleVisual;
+  tierLabel: string;
+  hints: string[];
+}): Promise<BlindSolveAttempt[]> {
+  const earlyHints = input.hints.slice(0, Math.max(0, input.hints.length - 1)).slice(0, 3);
+  if (!earlyHints.length) return [];
+
+  // Spend control: one mid-size production profile is enough for unlock evidence.
+  const renderedProfiles = await renderPuzzleVisualProfiles(input.visual);
+  const profile =
+    renderedProfiles.find((entry) => entry.profileId.includes("375")) ??
+    renderedProfiles.find((entry) => entry.profileId.includes("mobile")) ??
+    renderedProfiles[0];
+  if (!profile) return [];
+
+  const settled = await Promise.allSettled(
+    AI_CONFIG.visualRecognition.models.map(async (modelId) => ({
+      ...(await generateAIObjectFromImage({
+        modelId,
+        image: profile.pixels,
+        mediaType: "image/png",
+        temperature: 0.35,
+        operation: "vision-hinted-solve",
+        schema: BlindSolveSchema,
+        system: `You are a clever but non-expert player solving a rebus with progressive hints.
+You do not know the intended answer, icon labels, technique, or explanation.
+Use the screenshot first; treat hints as soft unlocks, not spoilers to invent invisible objects.
+Return up to five honest answer hypotheses grounded in visible evidence + the hints.`,
+        prompt: [
+          `Solve this ${input.tierLabel} rebus screenshot with progressive hints.`,
+          `Presentation: ${profile.profileId}, ${profile.viewportWidth}px viewport, ${profile.tileSize}px icons.`,
+          "Hints (earliest → later; final spoiler withheld):",
+          ...earlyHints.map((hint, index) => `${index + 1}. ${hint}`),
+        ].join("\n"),
+      })),
+      model: modelId,
+      profileId: `hinted:${profile.profileId}`,
+    }))
+  );
+  return settled.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []));
+}
+
 export async function simulatePlayerSolve(input: {
   rebusPuzzle: string;
   answer: string;
@@ -128,12 +181,54 @@ export async function simulatePlayerSolve(input: {
       minConfidence: AI_CONFIG.visualRecognition.minConfidence,
     });
 
+    let hintedAttempted = false;
+    let hintedTopTargetFoundBy = 0;
+    let hintedEstimatedSolveRate = 0;
+    let hintedConfidence = 0;
+    let hintedUnlocksVisualSolve = true;
+    const unfairReasons = [...hintReview.unfairReasons];
+
+    if (
+      shouldRunProgressiveHintVision(blind) &&
+      input.hints.length >= 2 &&
+      process.env.REBUZZLE_SKIP_HINTED_VISION !== "1"
+    ) {
+      hintedAttempted = true;
+      const hintedAttempts = await runHintedSolveTournament({
+        visual: input.visual,
+        tierLabel: input.tierLabel,
+        hints: input.hints,
+      });
+      const hinted = summarizeBlindSolveAttempts({
+        answer: input.answer,
+        attempts: hintedAttempts,
+      });
+      hintedTopTargetFoundBy = hinted.topTargetFoundBy;
+      hintedEstimatedSolveRate = hinted.estimatedSolveRate;
+      hintedConfidence = hinted.confidence;
+      // Early hints should unlock a top-rank reading when blind dominance failed.
+      hintedUnlocksVisualSolve = hinted.topTargetFoundBy >= Math.max(1, hinted.requiredVotes);
+      if (!hintedUnlocksVisualSolve) {
+        unfairReasons.push(
+          "Progressive hints did not unlock a fair visual solve of the intended answer"
+        );
+      }
+    }
+
     return {
       ...hintReview,
+      unfairReasons,
+      hintUnlockOrderLooksFair:
+        hintReview.hintUnlockOrderLooksFair && hintedUnlocksVisualSolve,
       firstWrongParses: blind.wrongParses,
       likelySolvePath: blind.likelySolvePath,
       estimatedSolveRate: blind.estimatedSolveRate,
-      confidence: Math.min(hintReview.confidence, blind.confidence, editorial.confidence),
+      confidence: Math.min(
+        hintReview.confidence,
+        blind.confidence,
+        editorial.confidence,
+        hintedAttempted ? Math.max(hintedConfidence, 0.45) : 1
+      ),
       blindProfileCount: blind.profileCount,
       blindProfilesWithTarget: blind.profilesWithTarget,
       blindTopTargetFoundBy: blind.topTargetFoundBy,
@@ -149,6 +244,11 @@ export async function simulatePlayerSolve(input: {
       editorialConfidence: editorial.confidence,
       editorialFailureKinds: editorial.failureKinds,
       editorialReasons: editorial.reasons,
+      hintedAttempted,
+      hintedTopTargetFoundBy,
+      hintedEstimatedSolveRate,
+      hintedConfidence,
+      hintedUnlocksVisualSolve,
     };
   } catch (error) {
     const failure = safeSimulationError(error);
@@ -187,6 +287,7 @@ export function playerSimPublishBlockers(sim: PlayerSimResult): string[] {
     new Set([
       ...blindSolvePublishBlockers(sim),
       ...editorialReviewPublishBlockers(sim),
+      ...progressiveHintPublishBlockers(sim),
       ...(!sim.hintUnlockOrderLooksFair || sim.unfairReasons.length > 2
         ? sim.unfairReasons.length
           ? sim.unfairReasons

--- a/apps/web/src/ai/puzzle-agent/apex/progressive-hint-vision.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/progressive-hint-vision.ts
@@ -1,0 +1,30 @@
+/**
+ * Progressive-hint vision — pure gating helpers (no AI SDK imports).
+ *
+ * The tournament itself lives in player-sim.ts; these helpers decide when to
+ * spend and how to block publication.
+ */
+
+import type { PlayerSimResult } from "./types";
+
+/** Blind pass failed dominance — worth spending a hinted unlock check. */
+export function shouldRunProgressiveHintVision(blind: {
+  profilesWithDominantTarget: number;
+  profileCount: number;
+  topTargetFoundBy: number;
+  requiredVotes: number;
+}): boolean {
+  if (blind.profileCount <= 0) return false;
+  if (blind.profilesWithDominantTarget >= blind.profileCount) return false;
+  return blind.topTargetFoundBy < blind.requiredVotes * blind.profileCount;
+}
+
+/** Publication blockers from a completed progressive-hint pass. */
+export function progressiveHintPublishBlockers(sim: PlayerSimResult): string[] {
+  if (sim.hintedAttempted && sim.hintedUnlocksVisualSolve === false) {
+    return [
+      "Progressive-hint vision failed: early hints did not unlock the intended answer on the board",
+    ];
+  }
+  return [];
+}

--- a/apps/web/src/ai/puzzle-agent/apex/technique-calibration.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/technique-calibration.ts
@@ -1,0 +1,149 @@
+/**
+ * Technique-family difficulty calibrator.
+ *
+ * Reorders curriculum technique preference using observed human solve rates
+ * (live puzzle metadata and optional playtest strata). Techniques that players
+ * crush get demoted when the window is too easy; techniques that players miss
+ * get promoted when the window is too hard.
+ */
+
+import { getCollection } from "@/db/mongodb";
+import type { TechniqueId } from "../technique-library";
+
+export type TechniqueSolveRate = {
+  techniqueId: string;
+  sampleSize: number;
+  solveRate: number;
+};
+
+export type TechniqueCalibrationSnapshot = {
+  lookbackDays: number;
+  sampleSize: number;
+  rates: TechniqueSolveRate[];
+  notes: string[];
+};
+
+const MIN_SAMPLES = 4;
+
+/**
+ * Pure reorder — unit-tested without Mongo.
+ *
+ * - tooEasy: prefer lower solve-rate (harder) techniques first
+ * - tooHard: prefer higher solve-rate (friendlier) techniques first
+ * - balanced / insufficient data: keep input order
+ */
+export function biasTechniquesBySolveRates(input: {
+  preferredTechniques: readonly TechniqueId[];
+  rates: readonly TechniqueSolveRate[];
+  tooEasy: boolean;
+  tooHard: boolean;
+  minSamples?: number;
+}): { techniques: TechniqueId[]; notes: string[] } {
+  const minSamples = input.minSamples ?? MIN_SAMPLES;
+  const rateById = new Map(
+    input.rates
+      .filter((row) => row.sampleSize >= minSamples && Number.isFinite(row.solveRate))
+      .map((row) => [row.techniqueId, row] as const)
+  );
+
+  if (!rateById.size || (!input.tooEasy && !input.tooHard)) {
+    return { techniques: [...input.preferredTechniques], notes: [] };
+  }
+
+  const scored = input.preferredTechniques.map((techniqueId, index) => {
+    const observed = rateById.get(techniqueId);
+    const solveRate = observed?.solveRate ?? 0.5;
+    // Higher score = earlier in preferred list.
+    const pressure = input.tooEasy ? 1 - solveRate : solveRate;
+    return { techniqueId, index, pressure, sampleSize: observed?.sampleSize ?? 0 };
+  });
+
+  scored.sort((a, b) => {
+    if (b.pressure !== a.pressure) return b.pressure - a.pressure;
+    return a.index - b.index;
+  });
+
+  const notes: string[] = [];
+  const head = scored[0];
+  const tail = scored[scored.length - 1];
+  if (head && tail && head.techniqueId !== tail.techniqueId) {
+    notes.push(
+      input.tooEasy
+        ? `Technique calibration (too easy): prefer ${head.techniqueId} over high-solve ${tail.techniqueId}`
+        : `Technique calibration (too hard): prefer friendlier ${head.techniqueId} over low-solve ${tail.techniqueId}`
+    );
+  }
+
+  return {
+    techniques: scored.map((row) => row.techniqueId),
+    notes,
+  };
+}
+
+/**
+ * Aggregate liveSolveRate by techniqueId from published puzzles.
+ */
+export async function loadTechniqueSolveRates(input?: {
+  lookbackDays?: number;
+  limit?: number;
+}): Promise<TechniqueCalibrationSnapshot> {
+  const lookbackDays = input?.lookbackDays ?? 45;
+  const limit = Math.min(input?.limit ?? 400, 800);
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - lookbackDays);
+
+  try {
+    const docs = (await getCollection("puzzles")
+      .find({
+        createdAt: { $gte: cutoff },
+        "metadata.techniqueId": { $type: "string" },
+        "metadata.liveSolveRate": { $type: "number" },
+      })
+      .project({
+        "metadata.techniqueId": 1,
+        "metadata.liveSolveRate": 1,
+      })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .toArray()) as Array<{
+      metadata?: { techniqueId?: string; liveSolveRate?: number };
+    }>;
+
+    const buckets = new Map<string, { sum: number; count: number }>();
+    for (const doc of docs) {
+      const techniqueId = doc.metadata?.techniqueId;
+      const liveSolveRate = doc.metadata?.liveSolveRate;
+      if (!techniqueId || typeof liveSolveRate !== "number" || !Number.isFinite(liveSolveRate)) {
+        continue;
+      }
+      const bucket = buckets.get(techniqueId) ?? { sum: 0, count: 0 };
+      bucket.sum += Math.max(0, Math.min(1, liveSolveRate));
+      bucket.count += 1;
+      buckets.set(techniqueId, bucket);
+    }
+
+    const rates = [...buckets.entries()]
+      .map(([techniqueId, bucket]) => ({
+        techniqueId,
+        sampleSize: bucket.count,
+        solveRate: bucket.count ? bucket.sum / bucket.count : 0,
+      }))
+      .sort((a, b) => b.sampleSize - a.sampleSize);
+
+    return {
+      lookbackDays,
+      sampleSize: rates.reduce((sum, row) => sum + row.sampleSize, 0),
+      rates,
+      notes: rates.length
+        ? [`Loaded ${rates.length} technique families with live solve rates (${lookbackDays}d)`]
+        : ["No technique-family live solve rates yet — curriculum uses diversity order only"],
+    };
+  } catch {
+    return {
+      lookbackDays,
+      sampleSize: 0,
+      rates: [],
+      notes: ["Technique calibration unavailable — continue without solve-rate bias"],
+    };
+  }
+}

--- a/apps/web/src/ai/puzzle-agent/apex/types.ts
+++ b/apps/web/src/ai/puzzle-agent/apex/types.ts
@@ -85,6 +85,12 @@ export const PlayerSimSchema = z.object({
   editorialConfidence: z.number().min(0).max(1).optional(),
   editorialFailureKinds: z.array(z.string().max(40)).max(8).optional(),
   editorialReasons: z.array(z.string().max(320)).max(8).optional(),
+  /** Progressive-hint vision (early hints only) — optional spend-gated evidence. */
+  hintedAttempted: z.boolean().optional(),
+  hintedTopTargetFoundBy: z.number().int().nonnegative().optional(),
+  hintedEstimatedSolveRate: z.number().min(0).max(1).optional(),
+  hintedConfidence: z.number().min(0).max(1).optional(),
+  hintedUnlocksVisualSolve: z.boolean().optional(),
 });
 
 export type PlayerSimResult = z.infer<typeof PlayerSimSchema>;

--- a/apps/web/src/ai/puzzle-agent/publication-tools.ts
+++ b/apps/web/src/ai/puzzle-agent/publication-tools.ts
@@ -1,0 +1,29 @@
+/**
+ * Publication ToolLoop active-tool lists.
+ *
+ * Kept free of AI SDK imports so contract tests can assert wiring without
+ * loading the ESM `ai` package graph.
+ */
+
+/** Active ToolLoop tools for publication generation. */
+export const PUBLICATION_AGENT_TOOLS = [
+  "get_puzzle_type_spec",
+  "get_difficulty_brief",
+  "get_generation_brief",
+  "list_recent_answers",
+  "propose_concept_seeds",
+  "list_technique_library",
+  "list_pictogram_catalog",
+  "inspect_answer_seed_cues",
+  "preflight_compose_cue_plan",
+  "compose_puzzle_visual",
+  "craft_hint_ladder",
+] as const;
+
+/** Host-side efficiency tools that must exist in both Eve and in-process surfaces. */
+export const EFFICIENCY_AGENT_TOOLS = [
+  "list_pictogram_catalog",
+  "inspect_answer_seed_cues",
+  "preflight_compose_cue_plan",
+  "get_generation_brief",
+] as const;

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -23,6 +23,7 @@ import {
   missingAnswerSeedCues,
 } from "./apex/answer-seed-cues";
 import { toPlayabilityEvidence } from "./apex/blind-solve-consensus";
+import { preflightComposeAnswerSeedCuePlan } from "./apex/cue-plan-preflight";
 import {
   applyPlayerSimHeuristics,
   playerSimPublishBlockers,
@@ -56,10 +57,13 @@ import { verifyPublicationAssets } from "./visual/publication-assets";
 const PUBLICATION_AGENT_TOOLS = [
   "get_puzzle_type_spec",
   "get_difficulty_brief",
+  "get_generation_brief",
   "list_recent_answers",
   "propose_concept_seeds",
   "list_technique_library",
   "list_pictogram_catalog",
+  "inspect_answer_seed_cues",
+  "preflight_compose_cue_plan",
   "compose_puzzle_visual",
   "craft_hint_ladder",
 ] as const;
@@ -134,6 +138,7 @@ function loadInstructions(): string {
     "- techniqueId is required and must be a real library id for the target tier.",
     "- ALWAYS call compose_puzzle_visual — unicode-only boards are rejected at publish.",
     "- Call list_pictogram_catalog before composing and use its exact reviewed concept IDs.",
+    "- When an answer-seed cue contract is present: inspect_answer_seed_cues (or use the host preflight layers) before compose.",
     "- Never call generate_pictogram in publication generation; fresh art belongs in the review lab.",
     "- Use list_recent_answers techniqueId values to choose the least-recently-used allowed technique; never default blindly to the first technique.",
     "- Prefer ≥1 pictogram SVG; styled text (large/strike/stacked) is OK when typography is the joke.",
@@ -149,7 +154,14 @@ function loadInstructions(): string {
   ].join("\n");
 }
 
-function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string): string {
+function buildUserMessage(
+  params: PuzzleGenerationParams,
+  priorFailure?: string,
+  preflight?: {
+    unicodeFallback: string;
+    layerSummary: string;
+  }
+): string {
   const puzzleType = params.puzzleType ?? "rebus";
   const qualityThreshold = params.qualityThreshold ?? AI_CONFIG.puzzleAgent.qualityThreshold;
   const minFun = AI_CONFIG.puzzleAgent.minFunScore;
@@ -188,6 +200,14 @@ function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string)
           "Text/operator cues must remain visibly present and support the named technique. Keep the complete answer hidden as a contiguous phrase.",
         ].join("\n")
       : null,
+    preflight
+      ? [
+          "HOST CUE-PLAN PREFLIGHT (already composed, zero invent): reuse these exact ingredients.",
+          `Preflight unicodeFallback: ${preflight.unicodeFallback}`,
+          `Preflight layers: ${preflight.layerSummary}`,
+          "Call compose_puzzle_visual with the same concepts/text/operators (you may refine layout/emphasis only).",
+        ].join("\n")
+      : null,
     params.phraseSeeds?.length
       ? `Phrase-bank tropes/seeds to avoid copying (invent a different mechanism/answer; cousins of bee/before/sunflower/piece-of-cake are discouraged): ${params.phraseSeeds.join("; ")}.`
       : null,
@@ -209,10 +229,18 @@ function buildUserMessage(params: PuzzleGenerationParams, priorFailure?: string)
     `Quality gates: overall >= ${qualityThreshold}, funScore >= ${minFun}, publishable=true, unique, solvable, in-band, composed visual.`,
     priorFailure ? `Previous attempt failed: ${priorFailure}. Fix that specific issue.` : null,
     "Workflow:",
-    "1) In parallel: get_puzzle_type_spec + get_difficulty_brief + list_recent_answers + list_pictogram_catalog",
-    "2) propose_concept_seeds + list_technique_library, then pick one catalog-compatible direction",
-    "3) compose_puzzle_visual + craft_hint_ladder",
-    "4) Return the strict puzzle draft with difficultyLevel + techniqueId + visual; the host owns all scoring and retries",
+    params.answerSeedCuePlan?.length
+      ? "1) In parallel: get_puzzle_type_spec + get_difficulty_brief + list_pictogram_catalog + inspect_answer_seed_cues"
+      : "1) In parallel: get_puzzle_type_spec + get_difficulty_brief + list_recent_answers + list_pictogram_catalog",
+    params.answerSeedCuePlan?.length
+      ? "2) compose_puzzle_visual using the host cue-plan layers (or preflight_compose_cue_plan), then craft_hint_ladder"
+      : "2) propose_concept_seeds + list_technique_library, then pick one catalog-compatible direction",
+    params.answerSeedCuePlan?.length
+      ? "3) Return the strict puzzle draft with difficultyLevel + techniqueId + visual; the host owns all scoring and retries"
+      : "3) compose_puzzle_visual + craft_hint_ladder",
+    params.answerSeedCuePlan?.length
+      ? null
+      : "4) Return the strict puzzle draft with difficultyLevel + techniqueId + visual; the host owns all scoring and retries",
   ]
     .filter(Boolean)
     .join("\n");
@@ -253,6 +281,45 @@ export async function runPuzzleAgentGeneration(
     throw new Error(`Invalid answer-seed cue contract: ${cuePlanIssues.join("; ")}`);
   }
 
+  // Cheap host preflight: prove cue plan composes before any invent spend.
+  let hostPreflightComposition: CapturedPuzzleComposition | null = null;
+  let hostPreflightPrompt: { unicodeFallback: string; layerSummary: string } | undefined;
+  if (params.answerSeed && params.answerSeedCuePlan?.length) {
+    const preflight = await preflightComposeAnswerSeedCuePlan({
+      answer: params.answerSeed,
+      targetDifficulty: params.targetDifficulty,
+      techniqueId: params.preferredTechniques?.[0],
+      cues: params.answerSeedCuePlan,
+    });
+    if (!preflight.ok || !preflight.composition) {
+      throw new Error(
+        `Cue-plan preflight failed (${preflight.stage}): ${preflight.issues.join("; ")}`
+      );
+    }
+    hostPreflightComposition = {
+      answer: params.answerSeed,
+      visual: preflight.composition.visual,
+    };
+    hostPreflightPrompt = {
+      unicodeFallback: preflight.composition.visual.unicodeFallback,
+      layerSummary: preflight.composition.visual.layers
+        .map((layer) => {
+          if (layer.kind === "pictogram") return `pictogram:${layer.concept}`;
+          if (layer.kind === "text") return `text:${layer.content}`;
+          if (layer.kind === "operator") return `op:${layer.symbol}`;
+          return `image:${layer.concept ?? "scene"}`;
+        })
+        .join(" | "),
+    };
+    if (process.env.REBUZZLE_GENERATOR_TRACE === "1") {
+      console.log("[Puzzle Agent] cue-plan preflight ok", {
+        answer: params.answerSeed,
+        unicodeFallback: hostPreflightPrompt.unicodeFallback,
+        layers: hostPreflightPrompt.layerSummary,
+      });
+    }
+  }
+
   ensureGatewayKey();
   assertGatewayAuthConfigured();
   await enforceQuota();
@@ -284,7 +351,7 @@ export async function runPuzzleAgentGeneration(
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let completedSteps = 0;
       const completedTools: string[] = [];
-      let capturedComposition: CapturedPuzzleComposition | null = null;
+      let capturedComposition: CapturedPuzzleComposition | null = hostPreflightComposition;
       try {
         const agent = new ToolLoopAgent({
           model: getAiGateway()(modelId),
@@ -313,7 +380,8 @@ export async function runPuzzleAgentGeneration(
           },
           onToolExecutionEnd: ({ toolCall, toolOutput }) => {
             if (
-              toolCall.toolName !== "compose_puzzle_visual" ||
+              (toolCall.toolName !== "compose_puzzle_visual" &&
+                toolCall.toolName !== "preflight_compose_cue_plan") ||
               toolOutput.type !== "tool-result"
             ) {
               return;
@@ -328,7 +396,7 @@ export async function runPuzzleAgentGeneration(
         });
 
         const result = await agent.generate({
-          prompt: `${buildUserMessage(params, priorFailure)}\n\nModel ${modelId} — attempt ${attempt}/${maxAttempts}.`,
+          prompt: `${buildUserMessage(params, priorFailure, hostPreflightPrompt)}\n\nModel ${modelId} — attempt ${attempt}/${maxAttempts}.`,
           abortSignal: AbortSignal.timeout(AI_CONFIG.timeouts.agent),
         });
 

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -99,6 +99,11 @@ export interface PuzzleGenerationParams {
   deferRenderedEvaluation?: boolean;
   /** Specific model-backed critique instructions for one bounded repair pass. */
   revisionInstructions?: string[];
+  /**
+   * `critique-locked` — repair specialist: preserve answer + cue plan; rewrite
+   * the board only for reviseInstructions (no re-seed invent).
+   */
+  repairMode?: "critique-locked";
   /** Keep a repair pass from silently multiplying spend through model fallbacks. */
   modelChainLimit?: number;
 }
@@ -217,8 +222,10 @@ function buildUserMessage(
     params.briefSummary ? `Curriculum brief: ${params.briefSummary}` : null,
     params.revisionInstructions?.length
       ? [
-          "Bounded repair pass: address every critique instruction below with a new, cleaner board.",
-          "Do not defend or copy the previous mechanism; use a concrete catalog-backed pictogram and preserve a fair hint ladder.",
+          params.repairMode === "critique-locked"
+            ? "CRITIQUE-LOCKED REPAIR: keep the exact answer and every answer-seed cue. Rewrite layout/emphasis/supporting layers only."
+            : "Bounded repair pass: address every critique instruction below with a new, cleaner board.",
+          "Do not invent a replacement answer or swap catalog cues; use the locked cue plan and preserve a fair hint ladder.",
           `Critique instructions: ${params.revisionInstructions.slice(0, 4).join("; ")}`,
         ].join("\n")
       : null,

--- a/apps/web/src/ai/puzzle-agent/run-generation.ts
+++ b/apps/web/src/ai/puzzle-agent/run-generation.ts
@@ -49,24 +49,13 @@ import {
   scorePuzzleQuality,
   stressTestSolvability,
 } from "./tool-impl";
+import { PUBLICATION_AGENT_TOOLS } from "./publication-tools";
 import { puzzleAgentTools } from "./tools";
 import { PuzzleVisualSchema } from "./visual/composition";
 import { recognizePuzzleBoard } from "./visual/critique-board";
 import { verifyPublicationAssets } from "./visual/publication-assets";
 
-const PUBLICATION_AGENT_TOOLS = [
-  "get_puzzle_type_spec",
-  "get_difficulty_brief",
-  "get_generation_brief",
-  "list_recent_answers",
-  "propose_concept_seeds",
-  "list_technique_library",
-  "list_pictogram_catalog",
-  "inspect_answer_seed_cues",
-  "preflight_compose_cue_plan",
-  "compose_puzzle_visual",
-  "craft_hint_ladder",
-] as const;
+export { EFFICIENCY_AGENT_TOOLS, PUBLICATION_AGENT_TOOLS } from "./publication-tools";
 
 export interface PuzzleGenerationParams {
   targetDifficulty: number;

--- a/apps/web/src/ai/puzzle-agent/tools.ts
+++ b/apps/web/src/ai/puzzle-agent/tools.ts
@@ -5,10 +5,14 @@
 import { type ToolSet, tool } from "ai";
 import { z } from "zod";
 import { critiqueCandidate } from "./apex/critique";
+import {
+  inspectAnswerSeedCuePlan,
+  preflightComposeAnswerSeedCuePlan,
+} from "./apex/cue-plan-preflight";
 import { buildGenerationBrief } from "./apex/curriculum";
 import { applyPlayerSimHeuristics, simulatePlayerSolve } from "./apex/player-sim";
 import { scoreRubric } from "./apex/rubric";
-import type { ApexCandidate } from "./apex/types";
+import type { AnswerSeedVisualCue, ApexCandidate } from "./apex/types";
 import { isKnownTechniqueId } from "./quality";
 import { CandidatePuzzleSchema } from "./schemas";
 import type { TechniqueId } from "./technique-library";
@@ -129,6 +133,107 @@ export const puzzleAgentTools: ToolSet = {
       concepts: listCuratedPictogramIds(),
       rule: "Publication compositions must use these exact concept IDs or an existing approved-cache asset.",
     }),
+  }),
+
+  inspect_answer_seed_cues: tool({
+    description:
+      "Inspect a host-owned answer-seed cue contract: catalog validity, draft layers, and whether a board is missing required cues. Call before compose when an answer-first seed is reserved.",
+    inputSchema: z.object({
+      cues: z
+        .array(
+          z.discriminatedUnion("kind", [
+            z.object({
+              kind: z.literal("catalog"),
+              concept: z.string(),
+              role: z.enum([
+                "word-part",
+                "phonetic-anchor",
+                "semantic-anchor",
+                "structural-anchor",
+              ]),
+            }),
+            z.object({
+              kind: z.literal("text"),
+              content: z.string(),
+              role: z.enum([
+                "word-part",
+                "phonetic-anchor",
+                "semantic-anchor",
+                "structural-anchor",
+              ]),
+            }),
+            z.object({
+              kind: z.literal("operator"),
+              symbol: z.string(),
+              role: z.literal("structural-anchor"),
+            }),
+          ])
+        )
+        .optional(),
+      visual: PuzzleVisualSchema.optional(),
+    }),
+    execute: async (input) =>
+      inspectAnswerSeedCuePlan({
+        cues: input.cues as AnswerSeedVisualCue[] | undefined,
+        visual: input.visual,
+      }),
+  }),
+
+  preflight_compose_cue_plan: tool({
+    description:
+      "Cheap host preflight: compose a board deterministically from an answer-seed cue plan (no invent). Use to prove catalog cues compose before a creative rewrite.",
+    inputSchema: z.object({
+      answer: z.string(),
+      targetDifficulty: z.number(),
+      techniqueId: z.string().optional(),
+      layout: z.enum(["row", "stack", "grid", "overlay"]).optional(),
+      cues: z.array(
+        z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.literal("catalog"),
+            concept: z.string(),
+            role: z.enum([
+              "word-part",
+              "phonetic-anchor",
+              "semantic-anchor",
+              "structural-anchor",
+            ]),
+          }),
+          z.object({
+            kind: z.literal("text"),
+            content: z.string(),
+            role: z.enum([
+              "word-part",
+              "phonetic-anchor",
+              "semantic-anchor",
+              "structural-anchor",
+            ]),
+          }),
+          z.object({
+            kind: z.literal("operator"),
+            symbol: z.string(),
+            role: z.literal("structural-anchor"),
+          }),
+        ])
+      ),
+    }),
+    execute: async (input) => {
+      const result = await preflightComposeAnswerSeedCuePlan({
+        ...input,
+        cues: input.cues as AnswerSeedVisualCue[],
+      });
+      if (!result.ok) {
+        throw new Error(
+          `Cue-plan preflight failed (${result.stage}): ${result.issues.join("; ")}`
+        );
+      }
+      return {
+        ...result,
+        publicationReady: true,
+        visual: result.composition?.visual,
+        unicodeFallback: result.composition?.visual.unicodeFallback,
+      };
+    },
   }),
 
   compose_puzzle_visual: tool({

--- a/apps/web/src/app/api/admin/ai/generation-health/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/ai/generation-health/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+const verifyAdminAccess = jest.fn();
+const getGenerationSystemHealth = jest.fn();
+const loadQualityDriftReport = jest.fn();
+const measureWindowPerformance = jest.fn();
+const resolveAdaptiveDifficultyForDate = jest.fn();
+const listRecentGenerationAudits = jest.fn();
+const loadSimCalibration = jest.fn();
+const findRecent = jest.fn();
+const countUnprocessed = jest.fn();
+const getReport = jest.fn();
+
+jest.mock("@/lib/admin-auth", () => ({ verifyAdminAccess }));
+jest.mock("@/ai/learning", () => ({
+  getGenerationSystemHealth: (...args: unknown[]) => getGenerationSystemHealth(...args),
+  loadQualityDriftReport: (...args: unknown[]) => loadQualityDriftReport(...args),
+  measureWindowPerformance: (...args: unknown[]) => measureWindowPerformance(...args),
+  resolveAdaptiveDifficultyForDate: (...args: unknown[]) =>
+    resolveAdaptiveDifficultyForDate(...args),
+  listRecentGenerationAudits: (...args: unknown[]) => listRecentGenerationAudits(...args),
+  loadSimCalibration: (...args: unknown[]) => loadSimCalibration(...args),
+}));
+jest.mock("@/db/ai-operations", () => ({
+  aiFeedbackOps: { countUnprocessed: (...args: unknown[]) => countUnprocessed(...args) },
+  aiLearningEventOps: { findRecent: (...args: unknown[]) => findRecent(...args) },
+}));
+jest.mock("@/ai/puzzle-agent/review/puzzle-playtest-server", () => ({
+  puzzlePlaytestService: { getReport: (...args: unknown[]) => getReport(...args) },
+}));
+
+import { GET } from "../route";
+
+describe("GET /api/admin/ai/generation-health", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getGenerationSystemHealth.mockResolvedValue({
+      auditsLast7d: 12,
+      successRate: 0.5,
+      fallbackRate: 0.25,
+      apexShare: 0.8,
+      avgQuality: 82,
+      lastSuccessAt: "2026-08-03T00:00:00.000Z",
+    });
+    loadQualityDriftReport.mockResolvedValue({ status: "healthy" });
+    measureWindowPerformance.mockResolvedValue({
+      finalPlays: 20,
+      solveRate: 0.55,
+      medianSolveSeconds: 80,
+      abandonRate: 0.1,
+      tooEasy: false,
+      tooHard: false,
+      difficultyDelta: 0,
+      notes: [],
+    });
+    resolveAdaptiveDifficultyForDate.mockResolvedValue({
+      difficulty: 5,
+      baseline: 5,
+      delta: 0,
+      reason: "spine",
+    });
+    listRecentGenerationAudits.mockResolvedValue([
+      {
+        id: "a1",
+        status: "fallback",
+        error: "Answer-first visual cue contract failed: Missing catalog cue flower",
+        rejectReasons: ["Missing catalog cue flower"],
+      },
+    ]);
+    loadSimCalibration.mockResolvedValue({ adjustment: 0, sampleSize: 0 });
+    findRecent.mockResolvedValue([]);
+    countUnprocessed.mockResolvedValue(0);
+    getReport.mockResolvedValue({ releaseReady: false });
+  });
+
+  it("rejects unauthenticated access", async () => {
+    verifyAdminAccess.mockResolvedValue(null);
+    const response = await GET(new Request("https://rebuzzle.test/api/admin/ai/generation-health"));
+    expect(response.status).toBe(401);
+    expect(getGenerationSystemHealth).not.toHaveBeenCalled();
+  });
+
+  it("returns health, player pressure, and recent audits for operators", async () => {
+    verifyAdminAccess.mockResolvedValue({ id: "admin-1" });
+    const response = await GET(new Request("https://rebuzzle.test/api/admin/ai/generation-health"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.health.auditsLast7d).toBe(12);
+    expect(body.playerPressure.solveRate).toBe(0.55);
+    expect(body.recentAudits[0].rejectReasons).toEqual(["Missing catalog cue flower"]);
+    expect(body.generatedAt).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cuts invent spend and adds host-side efficiency tooling for the daily puzzle agent, with backend + E2E contracts so these capabilities stay proven (not just claimed).

### Features
- **Rejection digester** — taxonomy of audit failures → avoid/prefer guidance in the learning curriculum
- **Cue tools** — `list_pictogram_catalog`, `inspect_answer_seed_cues`, `preflight_compose_cue_plan` (Eve + in-process ToolLoop)
- **Host cue-plan preflight** — fail closed before gateway/ToolLoop spend; inject HOST CUE-PLAN PREFLIGHT into invent prompt; authoritative board fallback
- **Critique-locked repair** — revise lane refuses unlocked repairs (no cue plan / no invent swap)
- **Technique calibration** — bias preferred techniques from live solve rates under too-easy / too-hard pressure
- **Progressive-hint vision** — spend-gated after blind dominance fails; publish blockers when early hints don’t unlock

### Testing
Backend/integration + contract coverage (no live invent spend):
- Tool surface parity (Eve ↔ in-process) via `publication-tools.ts`
- Host invent order: cue validation → preflight → gateway → ToolLoop
- Preflight fail-closed + prompt injection + post-preflight cue omit rejection
- Repair lock, rejection digester → learning digest, curriculum calibration
- Progressive-hint spend gates + unlock blockers inside `simulatePlayerSolve`
- Admin `generation-health` route auth + payload contracts
- Playwright E2E: anonymous `/api/admin/ai/generation-health` → 401

**Verified:** 94 related Jest tests green; Playwright `e2e/generation-health.spec.ts` green against local Next webServer.

## Test plan
- [x] Jest: efficiency contract + preflight integration + repair/calibration/digest/hint suites
- [x] Jest: broader `apex/__tests__` + asset gate + generation-health route
- [x] Playwright: `e2e/generation-health.spec.ts` against local Next webServer
- [ ] Smoke invent path with answer seed + cue plan (preflight passes, zero wasted invent on bad plan)
- [ ] Confirm Eve tools under `apps/web/agent/tools/` match efficiency list in a live Eve run
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

