### PR TITLE
fix(web): unblock Vercel production build on /game-over

### DIFF
--- a/apps/web/src/app/game-over/page.tsx
+++ b/apps/web/src/app/game-over/page.tsx
@@ -9,11 +9,10 @@ async function GameOverContent({
 }: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
-  const [, params, solution] = await Promise.all([
-    connection(),
-    searchParams,
-    fetchGameOverSolution(),
-  ]);
+  // Must await connection() before Date/cookie-dependent server actions.
+  // Parallelizing it with fetchGameOverSolution() races prerender and fails the build.
+  await connection();
+  const [params, solution] = await Promise.all([searchParams, fetchGameOverSolution()]);
 
   return (
     <GameOverClient


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Production Vercel builds failed while prerendering `/game-over`.

### Cause
`GameOverContent` ran `connection()` in `Promise.all` alongside `fetchGameOverSolution()`. That raced Next.js 16 Cache Components prerender rules and hit:
- `cookies()` hanging/rejection during prerender
- `new Date()` used before uncached/request data

### Fix
Await `connection()` first, then fetch search params + game-over solution (same pattern as the home puzzle content).

### Verification
`pnpm turbo build --filter=@rebuzzle/web` succeeds locally after this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

