### PR TITLE
fix(web): restore mobile scroll on solved play stage

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -799,11 +799,16 @@
   animation-delay: 160ms;
 }
 
-/* Momentum scrolling that stops at its own edges rather than dragging the page. */
+/* Momentum scrolling that stops at its own edges rather than dragging the page.
+   When the day is locked, .play-stage becomes overflow-y:auto (see GameBoard). */
 .play-stage,
 .input-area {
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+}
+
+.play-stage.touch-pan-y {
+  touch-action: pan-y;
 }
 
 .guess-chip {

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -1104,19 +1104,28 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         {({ isKeyboardVisible }) => {
           // After lock, keep the full thread — don't collapse for the keyboard.
           const keyboardOpen = isKeyboardVisible && !gameState.gameOver;
-          const stageState = keyboardOpen ? "compact" : hasThread ? "docked" : "hero";
+          // Locked days need a page scroller: result card + docked puzzle rarely fit.
+          const stageScrollable = gameState.gameOver && !keyboardOpen;
+          const stageState = keyboardOpen
+            ? "compact"
+            : hasThread || gameState.gameOver
+              ? "docked"
+              : "hero";
 
           return (
             <div className="flex h-full min-h-0 flex-col">
               <main className="puzzle-area flex min-h-0 flex-1 flex-col overflow-hidden">
                 <div
                   className={cn(
-                    "play-stage flex min-h-0 flex-1 flex-col items-center overflow-hidden px-4 md:px-6",
-                    keyboardOpen
-                      ? "justify-start gap-1 pt-1 pb-0"
-                      : hasThread
+                    "play-stage flex min-h-0 flex-1 flex-col items-center px-4 md:px-6",
+                    stageScrollable
+                      ? "touch-pan-y justify-start gap-3 overflow-y-auto overscroll-y-contain py-[clamp(0.5rem,2vh,1rem)] pb-4"
+                      : "overflow-hidden",
+                    !(stageScrollable || keyboardOpen) &&
+                      (hasThread
                         ? "justify-start py-[clamp(0.5rem,2vh,1rem)]"
-                        : "justify-center py-[clamp(0.5rem,2vh,1rem)]"
+                        : "justify-center py-[clamp(0.5rem,2vh,1rem)]"),
+                    keyboardOpen && !stageScrollable && "justify-start gap-1 pt-1 pb-0"
                   )}
                 >
                   {showStageChrome && !keyboardOpen ? (
@@ -1180,12 +1189,13 @@ export default function GameBoard({ gameData }: GameBoardProps) {
                     <GuessThread
                       className="mt-[clamp(0.75rem,2.5vh,1.25rem)] max-w-2xl"
                       footer={resultCard}
+                      layout={stageScrollable ? "stack" : "scroll"}
                       turns={turns}
                     />
                   ) : null}
 
                   {!hasThread && resultCard && !keyboardOpen ? (
-                    <div className="mt-[clamp(0.75rem,2.5vh,1.25rem)] w-full max-w-2xl px-0.5 pb-2">
+                    <div className="mt-[clamp(0.75rem,2.5vh,1.25rem)] w-full max-w-2xl shrink-0 px-0.5 pb-2">
                       {resultCard}
                     </div>
                   ) : null}

--- a/apps/web/src/components/GuessThread.tsx
+++ b/apps/web/src/components/GuessThread.tsx
@@ -42,6 +42,11 @@ interface GuessThreadProps {
   /** Optional footer after the last turn (e.g. solve result card). */
   footer?: ReactNode;
   className?: string;
+  /**
+   * `scroll` — contained MessageScroller (active play).
+   * `stack` — natural-height list for an outer page scroller (day locked).
+   */
+  layout?: "scroll" | "stack";
 }
 
 const TIER_LABEL: Record<ReactionTier, string> = {
@@ -137,11 +142,39 @@ function AgentReply({ turn }: { turn: ThreadTurn }) {
   );
 }
 
+function ThreadTurnBlock({ turn }: { turn: ThreadTurn }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <MessageRow from="user">
+        <MessageBubble from="user">{turn.text}</MessageBubble>
+      </MessageRow>
+      <AgentReply turn={turn} />
+    </div>
+  );
+}
+
 /**
- * The conversation — shadcn MessageScroller owns scroll / anchor / jump-to-latest.
+ * The conversation — MessageScroller while playing; natural stack when the
+ * outer play-stage owns scroll (solved / locked day).
  */
-export function GuessThread({ turns, footer, className }: GuessThreadProps) {
+export function GuessThread({ turns, footer, className, layout = "scroll" }: GuessThreadProps) {
   if (turns.length === 0) return null;
+
+  if (layout === "stack") {
+    return (
+      <div
+        aria-label="Your guesses and Eve's replies"
+        aria-live="polite"
+        className={cn("guess-thread flex w-full flex-none flex-col gap-5 px-0.5 pb-3", className)}
+        role="log"
+      >
+        {turns.map((turn) => (
+          <ThreadTurnBlock key={turn.id} turn={turn} />
+        ))}
+        {footer ? <div className="pt-1">{footer}</div> : null}
+      </div>
+    );
+  }
 
   return (
     <div className={cn("guess-thread flex min-h-0 w-full flex-1 flex-col", className)}>
@@ -150,16 +183,8 @@ export function GuessThread({ turns, footer, className }: GuessThreadProps) {
           <MessageScrollerViewport aria-label="Your guesses and Eve's replies">
             <MessageScrollerContent className="px-0.5 pb-3" role="log" aria-live="polite">
               {turns.map((turn) => (
-                <MessageScrollerItem
-                  key={turn.id}
-                  messageId={`guess-${turn.id}`}
-                  scrollAnchor
-                  className="flex flex-col gap-3"
-                >
-                  <MessageRow from="user">
-                    <MessageBubble from="user">{turn.text}</MessageBubble>
-                  </MessageRow>
-                  <AgentReply turn={turn} />
+                <MessageScrollerItem key={turn.id} messageId={`guess-${turn.id}`} scrollAnchor>
+                  <ThreadTurnBlock turn={turn} />
                 </MessageScrollerItem>
               ))}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On mobile, the solved / locked day screen could not scroll. The visual-viewport shell kept `overflow: hidden` on the play stage so keyboard play stays pinned, but that also trapped the solve result card when it exceeded the viewport — especially on revisit with an empty guess thread and a full-size hero puzzle.

### Fix
- Dock the puzzle stage when the day is locked (not only when a guess thread exists)
- Make `.play-stage` `overflow-y-auto` + `touch-pan-y` while locked
- Render the guess thread as a natural-height stack in that mode so one outer scroller owns the page (avoids nested iOS scroll traps)

### Test plan
- [x] `pnpm --filter @rebuzzle/web lint`
- [x] `pnpm --filter @rebuzzle/web typecheck`
- [ ] On phone: open a solved day → scroll through result card / feedback / stats above the locked chat dock
- [ ] Active unsolved play with keyboard open still keeps the compact pinned stage (no body rubber-band)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

