### PR TITLE
feat(web): unlock daily puzzle at local midnight

### DIFF
--- a/apps/web/src/app/actions/gameActions.ts
+++ b/apps/web/src/app/actions/gameActions.ts
@@ -4,8 +4,9 @@ import { cookies } from "next/headers";
 import { db } from "@/db";
 import { isAdmin } from "@/lib/admin-auth";
 import { AUTH_COOKIE_NAME, LEGACY_AUTH_COOKIE_NAME } from "@/lib/cookies";
-import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
+import { getLocalPuzzleDate } from "@/lib/game/daily-lock";
 import { verifyToken } from "@/lib/jwt";
+import { resolveRequestTimeZone } from "@/lib/timezone";
 import type { GameData, PuzzleMetadata, PuzzleType, PuzzleVisual } from "../../lib/gameSettings";
 import { getTodaysPuzzle } from "./puzzleGenerationActions";
 
@@ -66,7 +67,9 @@ export async function isPuzzleCompletedForToday(): Promise<AttemptStatus> {
       return { hasAttempt: false, wasSuccessful: false };
     }
 
-    const result = await db.puzzleAttemptOps.hasTodayAttempt(userId, getUtcPuzzleDate());
+    const timeZone = await resolveRequestTimeZone();
+    const localDateKey = getLocalPuzzleDate(new Date(), timeZone);
+    const result = await db.puzzleAttemptOps.hasTodayAttempt(userId, localDateKey);
     return {
       hasAttempt: result.hasAttempt,
       wasSuccessful: result.wasSuccessful,
@@ -129,7 +132,12 @@ export async function fetchGameOverSolution(): Promise<{
   puzzleId?: string;
 }> {
   try {
-    const [userId, puzzleResult] = await Promise.all([getCurrentUserId(), getTodaysPuzzle()]);
+    const timeZone = await resolveRequestTimeZone();
+    const localDateKey = getLocalPuzzleDate(new Date(), timeZone);
+    const [userId, puzzleResult] = await Promise.all([
+      getCurrentUserId(),
+      getTodaysPuzzle(undefined, localDateKey, { allowAiGenerate: false }),
+    ]);
     const puzzle = (puzzleResult.success ? puzzleResult.puzzle : null) as TodaysPuzzle | null;
 
     if (!puzzle) {
@@ -138,7 +146,7 @@ export async function fetchGameOverSolution(): Promise<{
 
     let locked = false;
     if (userId) {
-      const status = await db.puzzleAttemptOps.hasTodayAttempt(userId, getUtcPuzzleDate());
+      const status = await db.puzzleAttemptOps.hasTodayAttempt(userId, localDateKey);
       locked = status.hasAttempt;
     }
 
@@ -163,7 +171,11 @@ export async function fetchGameOverSolution(): Promise<{
 export async function fetchGameData(_isPreview = false): Promise<PublicGameData> {
   try {
     // Never run Eve/AI on the interactive board path — cron owns generation.
-    const result = await getTodaysPuzzle(undefined, undefined, { allowAiGenerate: false });
+    // Serve the puzzle for the player's *local* calendar day (generated once
+    // under that YYYY-MM-DD publication key, unlocked after local midnight).
+    const timeZone = await resolveRequestTimeZone();
+    const localDateKey = getLocalPuzzleDate(new Date(), timeZone);
+    const result = await getTodaysPuzzle(undefined, localDateKey, { allowAiGenerate: false });
     const puzzle = (result.success ? result.puzzle : null) as TodaysPuzzle | null;
 
     if (!puzzle) {

--- a/apps/web/src/app/api/puzzle/today/route.ts
+++ b/apps/web/src/app/api/puzzle/today/route.ts
@@ -1,24 +1,27 @@
 import { NextResponse } from "next/server";
-import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getLocalPuzzleDate, getNextLocalMidnight } from "@/lib/game/daily-lock";
 import { toPublicPuzzle } from "@/lib/game/public-puzzle";
 import { buildCacheControl } from "@/lib/http/cache-headers";
+import { resolveRequestTimeZone } from "@/lib/timezone";
 import { getTodaysPuzzle } from "../../../actions/puzzleGenerationActions";
 
 /**
  * GET /api/puzzle/today
  *
- * Public daily puzzle for clients. Never includes the answer.
- * Scoring goes through POST /api/puzzles/guess.
+ * Public daily puzzle for the caller's local calendar day.
+ * Never includes the answer. Scoring goes through POST /api/puzzles/guess.
+ *
+ * Generation still stores one puzzle per YYYY-MM-DD; this route only chooses
+ * which date key is "today" for the request timezone.
  */
 export async function GET() {
   try {
-    const result = await getTodaysPuzzle();
     const now = new Date();
-    const nextPuzzleTime = getNextUtcMidnight(now).toISOString();
-    const secondsUntilMidnight = Math.max(
-      30,
-      Math.floor((getNextUtcMidnight(now).getTime() - now.getTime()) / 1000)
-    );
+    const timeZone = await resolveRequestTimeZone();
+    const localDateKey = getLocalPuzzleDate(now, timeZone);
+    const nextPuzzleTime = getNextLocalMidnight(now, timeZone).toISOString();
+
+    const result = await getTodaysPuzzle(undefined, localDateKey, { allowAiGenerate: false });
 
     if (result.success && result.puzzle) {
       const raw = result.puzzle as Record<string, unknown>;
@@ -32,7 +35,7 @@ export async function GET() {
             puzzleType: raw.puzzleType ?? "rebus",
             difficulty: raw.difficulty,
             hints: raw.hints ?? [],
-            date: raw.date,
+            date: raw.date ?? localDateKey,
             category: raw.category,
             topic: raw.topic,
             relevanceScore: raw.relevanceScore,
@@ -41,16 +44,14 @@ export async function GET() {
           cached: result.cached,
           generatedAt: result.generatedAt,
           serverTime: now.toISOString(),
+          puzzleDate: localDateKey,
+          timeZone,
           nextPuzzleTime,
         },
         {
           headers: {
-            "Cache-Control": buildCacheControl({
-              public: true,
-              maxAge: 60,
-              sMaxAge: Math.min(300, secondsUntilMidnight),
-              staleWhileRevalidate: 60,
-            }),
+            // Private: nextPuzzleTime / date key are timezone-specific.
+            "Cache-Control": buildCacheControl({ private: true }),
           },
         }
       );
@@ -59,8 +60,10 @@ export async function GET() {
     return NextResponse.json(
       {
         success: false,
-        error: "Failed to generate puzzle",
+        error: "Failed to load puzzle",
         serverTime: now.toISOString(),
+        puzzleDate: localDateKey,
+        timeZone,
         nextPuzzleTime,
       },
       { status: 500, headers: { "Cache-Control": buildCacheControl({ private: true }) } }
@@ -73,7 +76,7 @@ export async function GET() {
         success: false,
         error: "Internal server error",
         serverTime: now.toISOString(),
-        nextPuzzleTime: getNextUtcMidnight(now).toISOString(),
+        nextPuzzleTime: getNextLocalMidnight(now).toISOString(),
       },
       { status: 500, headers: { "Cache-Control": buildCacheControl({ private: true }) } }
     );

--- a/apps/web/src/app/api/puzzles/guess/route.ts
+++ b/apps/web/src/app/api/puzzles/guess/route.ts
@@ -11,12 +11,14 @@ import {
   clampHints,
   clampTimeSpent,
   getArchiveLockKey,
+  getLocalPuzzleDate,
   getUtcPuzzleDate,
 } from "@/lib/game/daily-lock";
 import { buildGuessReaction } from "@/lib/game/reactions";
 import { composePointsMultiplier, rollEngagementMultipliers } from "@/lib/game/retention-stats";
 import { calculateGamePoints } from "@/lib/gameSettings";
 import { getUserKey, rateLimit } from "@/lib/middleware/rate-limit";
+import { resolveRequestTimeZone } from "@/lib/timezone";
 
 const guessRateLimit = rateLimit({
   windowMs: 60 * 1000,
@@ -94,23 +96,26 @@ export async function POST(request: Request) {
       return NextResponse.json({ success: false, error: "Guess is too long" }, { status: 400 });
     }
 
-    const todayKey = getUtcPuzzleDate();
+    // Player's local calendar day — unlocks at their midnight; generation still
+    // uses one YYYY-MM-DD publication key per puzzle.
+    const timeZone = await resolveRequestTimeZone();
+    const localDateKey = getLocalPuzzleDate(new Date(), timeZone);
 
     const [puzzle, todays] = await Promise.all([
       db.puzzleOps.findById(puzzleId),
-      db.puzzleOps.findTodaysPuzzle(),
+      db.puzzleOps.findByDate(localDateKey),
     ]);
 
     if (!puzzle?.answer) {
       return NextResponse.json({ success: false, error: "Puzzle not found" }, { status: 404 });
     }
 
-    const isDaily = Boolean(todays && todays.id === puzzle.id);
     const publishedKey = puzzle.publishedAt ? getUtcPuzzleDate(new Date(puzzle.publishedAt)) : null;
+    const isDaily = Boolean(todays && todays.id === puzzle.id && publishedKey === localDateKey);
 
-    // Archive: any published puzzle that is not today's daily
+    // Archive: any published puzzle before the player's local today
     if (!isDaily) {
-      if (!publishedKey || publishedKey >= todayKey) {
+      if (!publishedKey || publishedKey >= localDateKey) {
         return NextResponse.json(
           { success: false, error: "This puzzle is not playable yet" },
           { status: 403 }
@@ -119,7 +124,8 @@ export async function POST(request: Request) {
     }
 
     const isArchive = !isDaily;
-    const lockKey = isArchive ? getArchiveLockKey(puzzle.id) : todayKey;
+    // Lock by publication key so the same daily puzzle can't be replayed after TZ travel.
+    const lockKey = isArchive ? getArchiveLockKey(puzzle.id) : (publishedKey ?? localDateKey);
     const basePointsMultiplier = isArchive ? ARCHIVE_POINTS_MULTIPLIER : 1;
     // Engagement rolls are server-authoritative (lucky + shared daily bonus day).
     const engagement = rollEngagementMultipliers();
@@ -194,7 +200,7 @@ export async function POST(request: Request) {
 
     const write = await db.puzzleAttemptOps.createAtomicDailyAttempt(
       user.userId,
-      new Date(`${todayKey}T00:00:00.000Z`),
+      new Date(`${localDateKey}T00:00:00.000Z`),
       {
         id: crypto.randomUUID(),
         userId: user.userId,

--- a/apps/web/src/app/api/puzzles/quip/route.ts
+++ b/apps/web/src/app/api/puzzles/quip/route.ts
@@ -18,8 +18,9 @@ import { NextResponse } from "next/server";
 import { streamAIText } from "@/ai/client";
 import { db } from "@/db";
 import { getAuthenticatedUser } from "@/lib/auth-middleware";
-import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
+import { getLocalPuzzleDate } from "@/lib/game/daily-lock";
 import { getUserKey, rateLimit } from "@/lib/middleware/rate-limit";
+import { resolveRequestTimeZone } from "@/lib/timezone";
 
 /** Mid-game tiers only while the day is still open. */
 const MID_GAME_TIERS = ["close", "warm", "cold"] as const;
@@ -106,7 +107,9 @@ export async function POST(request: Request) {
     }
 
     // Day already locked — only the closing win/loss riff may still spend credits.
-    const lock = await db.puzzleAttemptOps.hasTodayAttempt(user.userId, getUtcPuzzleDate());
+    const timeZone = await resolveRequestTimeZone();
+    const localDateKey = getLocalPuzzleDate(new Date(), timeZone);
+    const lock = await db.puzzleAttemptOps.hasTodayAttempt(user.userId, localDateKey);
     if (lock.hasAttempt && !isFinalTier(tier)) {
       return NextResponse.json(
         { success: false, error: "Puzzle already finished for today" },

--- a/apps/web/src/app/api/puzzles/stats/route.ts
+++ b/apps/web/src/app/api/puzzles/stats/route.ts
@@ -6,9 +6,10 @@
 
 import { NextResponse } from "next/server";
 import { ensureConnection, getCollection } from "@/db/mongodb";
-import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
+import { getLocalPuzzleDate } from "@/lib/game/daily-lock";
 import { buildCacheControl } from "@/lib/http/cache-headers";
 import { rateLimiters } from "@/lib/middleware/rate-limit";
+import { resolveRequestTimeZone } from "@/lib/timezone";
 
 interface PuzzleStats {
   todaySolves: number;
@@ -47,7 +48,8 @@ export async function GET(request: Request) {
     await ensureConnection();
     const attemptsCollection = getCollection("puzzleAttempts");
 
-    const dateKey = getUtcPuzzleDate();
+    const timeZone = await resolveRequestTimeZone();
+    const dateKey = getLocalPuzzleDate(new Date(), timeZone);
     const today = new Date(`${dateKey}T00:00:00.000Z`);
     const tomorrow = new Date(`${dateKey}T23:59:59.999Z`);
 

--- a/apps/web/src/app/api/user/achievements/route.ts
+++ b/apps/web/src/app/api/user/achievements/route.ts
@@ -14,10 +14,11 @@ import {
   getUserAchievementProgress,
 } from "@/lib/achievements";
 import { getAuthenticatedUser } from "@/lib/auth-middleware";
-import { getUtcPuzzleDate } from "@/lib/game/daily-lock";
+import { getLocalPuzzleDate } from "@/lib/game/daily-lock";
 import { buildCacheControl } from "@/lib/http/cache-headers";
 import { rateLimiters } from "@/lib/middleware/rate-limit";
 import { sendAchievementUnlockedEmail } from "@/lib/notifications/email-service";
+import { resolveRequestTimeZone } from "@/lib/timezone";
 
 /** Achievements that may be claimed from the client (everything else is server-only). */
 const CLIENT_AWARDABLE = new Set(["share_first"]);
@@ -157,7 +158,9 @@ export async function POST(request: NextRequest) {
     // share_first: require today's puzzle to be finished first
     if (achievementId === "share_first") {
       const { puzzleAttemptOps } = await import("@/db/operations");
-      const lock = await puzzleAttemptOps.hasTodayAttempt(user.id, getUtcPuzzleDate());
+      const timeZone = await resolveRequestTimeZone();
+      const localDateKey = getLocalPuzzleDate(new Date(), timeZone);
+      const lock = await puzzleAttemptOps.hasTodayAttempt(user.id, localDateKey);
       if (!lock.hasAttempt) {
         return NextResponse.json(
           { success: false, error: "Finish today's puzzle before sharing for achievements" },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -145,7 +145,7 @@ function NoPuzzleDisplay() {
         secondaryAction={{ href: "/blog", label: "Read the blog while you wait" }}
         title="Today's puzzle isn't live."
       >
-        A new puzzle lands every day at midnight. Check back shortly.
+        A new puzzle unlocks every day at your local midnight. Check back shortly.
       </StatusPanel>
     </Layout>
   );

--- a/apps/web/src/components/AlreadyPlayedPanel.tsx
+++ b/apps/web/src/components/AlreadyPlayedPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { AppLink as Link } from "@/components/AppLink";
 import { Timer } from "@/components/Timer";
-import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getNextLocalMidnight } from "@/lib/game/daily-lock";
 import { getStreakTease } from "@/lib/game/streak-tease";
 import { useLocalStorageJson, useLocalStorageRaw } from "@/lib/hooks/use-local-storage";
 import { cn } from "@/lib/utils";
@@ -40,7 +40,7 @@ export function AlreadyPlayedPanel({ wasSuccessful }: AlreadyPlayedPanelProps) {
   const eveRaw = useLocalStorageRaw("lastEveClosingLine");
   const eveLine = typeof eveRaw === "string" && eveRaw.trim() ? eveRaw.trim() : null;
 
-  const [nextPlayTime] = useState(() => getNextUtcMidnight());
+  const [nextPlayTime] = useState(() => getNextLocalMidnight());
 
   const tease = getStreakTease(wasSuccessful ? streak : 0, wasSuccessful);
   const resultsHref = wasSuccessful ? "/game-over?success=true" : "/game-over?success=false";

--- a/apps/web/src/components/CountdownTimer.tsx
+++ b/apps/web/src/components/CountdownTimer.tsx
@@ -3,7 +3,7 @@
 import { Clock } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getNextLocalMidnight } from "@/lib/game/daily-lock";
 
 function formatCountdown(diffMs: number): string {
   const totalSeconds = Math.max(0, Math.floor(diffMs / 1000));
@@ -16,7 +16,7 @@ function formatCountdown(diffMs: number): string {
 }
 
 /**
- * Counts down to a fixed next UTC midnight (captured once on the client),
+ * Counts down to the player's next local midnight (captured once),
  * then navigates home so today's puzzle can load.
  */
 export function CountdownTimer() {
@@ -27,9 +27,9 @@ export function CountdownTimer() {
   const reloadedRef = useRef(false);
 
   useEffect(() => {
-    // Capture once — calling getNextUtcMidnight() every tick never reaches zero
+    // Capture once — calling getNextLocalMidnight() every tick never reaches zero
     if (!targetRef.current) {
-      targetRef.current = getNextUtcMidnight();
+      targetRef.current = getNextLocalMidnight();
       setNextAt(targetRef.current);
     }
 
@@ -60,8 +60,8 @@ export function CountdownTimer() {
         <div className="font-bold text-3xl tabular-nums">{timeLeft}</div>
         {nextAt && (
           <div className="mt-1 text-[10px] uppercase tracking-wide opacity-75">
-            Resets {nextAt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}{" "}
-            local ({nextAt.toISOString().slice(11, 16)} UTC)
+            Resets at local midnight (
+            {nextAt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })})
           </div>
         )}
       </div>

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/analytics";
 import { fireConfetti } from "@/lib/confetti";
 import { fail } from "@/lib/fail";
-import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getLocalPuzzleDate, getNextLocalMidnight } from "@/lib/game/daily-lock";
 import { buildGameOverHref, markJustSolvedInSession } from "@/lib/game/game-over-href";
 import { isComebackVisit, recordPlayDay, shouldPromptGuestSave } from "@/lib/game/play-days";
 import type { GuessReaction, ReactionTier } from "@/lib/game/reactions";
@@ -381,7 +381,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
         finalGuess: "",
         wasSuccessful: false,
         attempts: gameSettings.maxAttempts,
-        nextPlayTime: getNextUtcMidnight(),
+        nextPlayTime: getNextLocalMidnight(),
         score: 0,
         timeTakenSeconds: 0,
       },
@@ -424,7 +424,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
       dailyBonusMultiplier?: number;
     }
   ) => {
-    const tomorrow = getNextUtcMidnight();
+    const tomorrow = getNextLocalMidnight();
     const timeTakenSeconds = Math.max(0, Math.floor((Date.now() - gameState.startTime) / 1000));
     const difficultyLevel = typeof gameData.difficulty === "number" ? gameData.difficulty : 5;
     const serverScore = opts?.serverScore;
@@ -766,7 +766,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               answer: result.answer,
               explanation: result.explanation,
               puzzleId: gameData.id,
-              puzzleDate: new Date().toISOString().slice(0, 10),
+              puzzleDate: getLocalPuzzleDate(),
             })
           );
         }
@@ -866,7 +866,7 @@ export default function GameBoard({ gameData }: GameBoardProps) {
               answer: result.answer,
               explanation: result.explanation,
               puzzleId: gameData.id,
-              puzzleDate: new Date().toISOString().slice(0, 10),
+              puzzleDate: getLocalPuzzleDate(),
             })
           );
         }

--- a/apps/web/src/components/InfoButton.tsx
+++ b/apps/web/src/components/InfoButton.tsx
@@ -119,7 +119,7 @@ export function InfoButton({ puzzleType }: InfoButtonProps) {
                   <ul className="list-inside list-disc space-y-1 text-sm">
                     <li>You have unlimited attempts to solve the puzzle</li>
                     <li>Use hints if you're stuck - they guide you progressively</li>
-                    <li>A new puzzle publishes each day at UTC midnight</li>
+                    <li>A new puzzle unlocks each day at your local midnight</li>
                     <li>Each puzzle type has its own unique solving approach</li>
                   </ul>
                 </div>
@@ -127,8 +127,8 @@ export function InfoButton({ puzzleType }: InfoButtonProps) {
             )}
             <div className="border-t pt-4">
               <p className="text-muted-foreground text-xs">
-                A new puzzle publishes each day at UTC midnight. Email reminders go out around 4 PM
-                UTC. Use the notification bell in the header to get daily reminders.
+                A new puzzle unlocks each day at your local midnight. Email reminders go out around
+                4 PM UTC. Use the notification bell in the header to get daily reminders.
               </p>
             </div>
           </div>

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { Footer } from "./Footer";
 import { GameProvider, useGameContext } from "./GameContext";
 import Header from "./Header";
+import { SyncTimezoneCookie } from "./SyncTimezoneCookie";
 import { VisualViewportShell } from "./VisualViewportShell";
 
 const DevToolsPanel = dynamic(() => import("./DevToolsPanel").then((m) => m.DevToolsPanel), {
@@ -98,6 +99,7 @@ function LayoutContent({
         </div>
       ) : null}
 
+      <SyncTimezoneCookie />
       <DevToolsPanel />
     </>
   );

--- a/apps/web/src/components/SyncTimezoneCookie.tsx
+++ b/apps/web/src/components/SyncTimezoneCookie.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { buildTimeZoneCookie, TIMEZONE_COOKIE_NAME } from "@/lib/timezone-shared";
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Persists the browser IANA time zone so server renders unlock the daily
+ * puzzle at the player's local midnight (generation stays one UTC day key).
+ */
+export function SyncTimezoneCookie() {
+  const router = useRouter();
+  const refreshedRef = useRef(false);
+
+  useEffect(() => {
+    const timeZone = globalThis.Intl?.DateTimeFormat?.().resolvedOptions?.().timeZone;
+    if (!timeZone) return;
+
+    const existing = readCookie(TIMEZONE_COOKIE_NAME);
+    if (existing === timeZone) return;
+
+    const hadCookie = Boolean(existing);
+    document.cookie = buildTimeZoneCookie(timeZone);
+
+    // Cookie wasn't available for the RSC payload — refresh once so serve/lock
+    // match local midnight. Vercel IP TZ usually covers first paint.
+    if (!(hadCookie || refreshedRef.current)) {
+      refreshedRef.current = true;
+      router.refresh();
+    }
+  }, [router]);
+
+  return null;
+}

--- a/apps/web/src/components/Timer.tsx
+++ b/apps/web/src/components/Timer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { getNextUtcMidnight } from "@/lib/game/daily-lock";
+import { getNextLocalMidnight } from "@/lib/game/daily-lock";
 import { haptics } from "@/lib/haptics";
 import { cn } from "@/lib/utils";
 
@@ -35,7 +35,7 @@ export function Timer({ nextPlayTime, className, compact = false }: TimerProps) 
 
   useEffect(() => {
     if (!fallbackTargetRef.current) {
-      fallbackTargetRef.current = getNextUtcMidnight();
+      fallbackTargetRef.current = getNextLocalMidnight();
     }
     const targetTime = nextPlayTime ? new Date(nextPlayTime) : fallbackTargetRef.current;
 
@@ -117,7 +117,7 @@ export function Timer({ nextPlayTime, className, compact = false }: TimerProps) 
             <span className="text-foreground tabular-nums">{timeLeft}</span>
           </div>
         </TooltipTrigger>
-        <TooltipContent>New puzzle available at midnight UTC</TooltipContent>
+        <TooltipContent>New puzzle available at your local midnight</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/apps/web/src/lib/game/__tests__/daily-lock-local.test.ts
+++ b/apps/web/src/lib/game/__tests__/daily-lock-local.test.ts
@@ -1,0 +1,48 @@
+import {
+  addCalendarDays,
+  getLocalPuzzleDate,
+  getNextLocalMidnight,
+  getUtcPuzzleDate,
+  getZonedMidnightUtc,
+  isValidIanaTimeZone,
+} from "@/lib/game/daily-lock";
+
+describe("local midnight unlock helpers", () => {
+  it("validates IANA time zones", () => {
+    expect(isValidIanaTimeZone("America/New_York")).toBe(true);
+    expect(isValidIanaTimeZone("UTC")).toBe(true);
+    expect(isValidIanaTimeZone("Not/A_Zone")).toBe(false);
+    expect(isValidIanaTimeZone("")).toBe(false);
+  });
+
+  it("returns the Eastern calendar day while UTC has already rolled over", () => {
+    // 2026-08-04 01:30 UTC → still Aug 3 evening in New York (EDT, UTC-4)
+    const instant = new Date("2026-08-04T01:30:00.000Z");
+    expect(getUtcPuzzleDate(instant)).toBe("2026-08-04");
+    expect(getLocalPuzzleDate(instant, "America/New_York")).toBe("2026-08-03");
+  });
+
+  it("returns the Tokyo calendar day before UTC midnight", () => {
+    // 2026-08-03 16:00 UTC → Aug 4 01:00 in Tokyo (UTC+9)
+    const instant = new Date("2026-08-03T16:00:00.000Z");
+    expect(getUtcPuzzleDate(instant)).toBe("2026-08-03");
+    expect(getLocalPuzzleDate(instant, "Asia/Tokyo")).toBe("2026-08-04");
+  });
+
+  it("computes next local midnight for America/New_York", () => {
+    const instant = new Date("2026-08-03T20:00:00.000Z"); // 4pm EDT
+    const next = getNextLocalMidnight(instant, "America/New_York");
+    expect(next.toISOString()).toBe("2026-08-04T04:00:00.000Z"); // midnight EDT
+    expect(getLocalPuzzleDate(next, "America/New_York")).toBe("2026-08-04");
+  });
+
+  it("computes zoned midnight for Asia/Tokyo", () => {
+    const midnight = getZonedMidnightUtc("2026-08-04", "Asia/Tokyo");
+    expect(midnight.toISOString()).toBe("2026-08-03T15:00:00.000Z");
+  });
+
+  it("adds calendar days without timezone drift", () => {
+    expect(addCalendarDays("2026-08-31", 1)).toBe("2026-09-01");
+    expect(addCalendarDays("2026-12-31", 1)).toBe("2027-01-01");
+  });
+});

--- a/apps/web/src/lib/game/__tests__/reminder-copy.test.ts
+++ b/apps/web/src/lib/game/__tests__/reminder-copy.test.ts
@@ -16,7 +16,7 @@ describe("reminder-copy", () => {
       PUZZLE_PUBLISH_COPY,
     ].join(" ");
     expect(blobs).not.toMatch(/8\s*AM/i);
-    expect(blobs).toMatch(/4 PM UTC|UTC midnight/);
+    expect(blobs).toMatch(/4 PM UTC|local midnight/);
   });
 
   it("keeps the opt-in CTA short and quiet", () => {

--- a/apps/web/src/lib/game/daily-lock.ts
+++ b/apps/web/src/lib/game/daily-lock.ts
@@ -1,13 +1,141 @@
 /**
- * Daily puzzle lock helpers — UTC calendar day keys for anti-replay.
+ * Daily puzzle lock helpers.
+ *
+ * Generation keys puzzles by a calendar date string (YYYY-MM-DD) with
+ * publishedAt at that UTC midnight — one puzzle document per day.
+ *
+ * Players unlock / roll over on *their* local midnight. The lock key for a
+ * daily final is the puzzle's publication date key (same YYYY-MM-DD).
  */
 
 /** Archive replays award half of normal points. */
 export const ARCHIVE_POINTS_MULTIPLIER = 0.5;
 
-/** UTC YYYY-MM-DD for a Date (defaults to now). */
+const IANA_TIME_ZONE_PATTERN = /^[A-Za-z0-9_+\-/]+$/;
+
+/** UTC YYYY-MM-DD for a Date (defaults to now). Used for generation / publishedAt. */
 export function getUtcPuzzleDate(date: Date = new Date()): string {
   return date.toISOString().slice(0, 10);
+}
+
+/** True when `timeZone` is a usable IANA zone id. */
+export function isValidIanaTimeZone(timeZone: string): boolean {
+  if (!timeZone || timeZone.length > 64 || !IANA_TIME_ZONE_PATTERN.test(timeZone)) {
+    return false;
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Calendar YYYY-MM-DD in the given IANA zone (or the runtime's local zone when
+ * `timeZone` is omitted — browsers use the player's zone).
+ */
+export function getLocalPuzzleDate(date: Date = new Date(), timeZone?: string): string {
+  if (!timeZone) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (!(year && month && day)) {
+    return getUtcPuzzleDate(date);
+  }
+  return `${year}-${month}-${day}`;
+}
+
+/** Add one civil day to a YYYY-MM-DD key (UTC-safe arithmetic). */
+export function addCalendarDays(dateKey: string, days: number): string {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  if (!(year && month && day)) {
+    throw new Error(`Invalid date key: ${dateKey}`);
+  }
+  const utc = new Date(Date.UTC(year, month - 1, day + days));
+  return utc.toISOString().slice(0, 10);
+}
+
+/**
+ * Offset (ms) such that `utcInstant + offset ≈ wall-clock as if it were UTC`.
+ * Recomputed at the target instant so DST is handled.
+ */
+function getTimeZoneOffsetMs(timeZone: string, instant: Date): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(instant);
+
+  const map = Object.fromEntries(
+    parts.filter((part) => part.type !== "literal").map((part) => [part.type, part.value])
+  ) as Record<string, string>;
+
+  const asUtc = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour),
+    Number(map.minute),
+    Number(map.second)
+  );
+  return asUtc - instant.getTime();
+}
+
+/** UTC instant for local midnight at the start of `dateKey` in `timeZone`. */
+export function getZonedMidnightUtc(dateKey: string, timeZone: string): Date {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  if (!(year && month && day)) {
+    throw new Error(`Invalid date key: ${dateKey}`);
+  }
+  const wallAsUtc = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
+  let utcMs = wallAsUtc - getTimeZoneOffsetMs(timeZone, new Date(wallAsUtc));
+  // Second pass at the corrected instant (DST boundaries).
+  utcMs = wallAsUtc - getTimeZoneOffsetMs(timeZone, new Date(utcMs));
+  return new Date(utcMs);
+}
+
+/**
+ * Next local midnight after `date`.
+ * - With `timeZone`: IANA-aware (server + cookie).
+ * - Without: runtime local zone (browser countdown).
+ */
+export function getNextLocalMidnight(date: Date = new Date(), timeZone?: string): Date {
+  if (!timeZone) {
+    const next = new Date(date.getTime());
+    next.setHours(24, 0, 0, 0);
+    return next;
+  }
+
+  const todayLocal = getLocalPuzzleDate(date, timeZone);
+  const tomorrowLocal = addCalendarDays(todayLocal, 1);
+  return getZonedMidnightUtc(tomorrowLocal, timeZone);
+}
+
+/** @deprecated Prefer getNextLocalMidnight — kept for cron/generation call sites. */
+export function getNextUtcMidnight(date: Date = new Date()): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + 1);
+  next.setUTCHours(0, 0, 0, 0);
+  return next;
 }
 
 /**
@@ -20,31 +148,6 @@ export function getArchiveLockKey(puzzleId: string): string {
 
 export function isArchiveLockKey(key: string): boolean {
   return key.startsWith("archive:");
-}
-
-function getUtcDayBounds(puzzleDate: string): { start: Date; end: Date } {
-  return {
-    start: new Date(`${puzzleDate}T00:00:00.000Z`),
-    end: new Date(`${puzzleDate}T23:59:59.999Z`),
-  };
-}
-
-/** Next UTC midnight — when the daily puzzle rolls over. */
-export function getNextUtcMidnight(date: Date = new Date()): Date {
-  const next = new Date(date);
-  next.setUTCDate(next.getUTCDate() + 1);
-  next.setUTCHours(0, 0, 0, 0);
-  return next;
-}
-
-/** Milliseconds until next UTC midnight (0 if already past). */
-function msUntilNextUtcMidnight(date: Date = new Date()): number {
-  return Math.max(0, getNextUtcMidnight(date).getTime() - date.getTime());
-}
-
-function clampAttempts(value: unknown, maxAttempts: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
-  return Math.min(Math.max(Math.floor(value), 1), maxAttempts);
 }
 
 export function clampHints(value: unknown, maxHints: number): number {

--- a/apps/web/src/lib/game/reminder-copy.ts
+++ b/apps/web/src/lib/game/reminder-copy.ts
@@ -1,9 +1,9 @@
 /**
  * Single source of truth for daily reminder timing copy.
- * Puzzle publish: UTC midnight. Puzzle-ready email cron: 16:00 UTC.
+ * Puzzle unlock: player's local midnight. Puzzle-ready email cron: 16:00 UTC.
  */
 
-export const PUZZLE_PUBLISH_COPY = "UTC midnight";
+export const PUZZLE_PUBLISH_COPY = "your local midnight";
 export const PUZZLE_EMAIL_REMINDER_COPY = "4 PM UTC";
 export const PUZZLE_EMAIL_REMINDER_SHORT = "4 PM UTC";
 

--- a/apps/web/src/lib/timezone-shared.ts
+++ b/apps/web/src/lib/timezone-shared.ts
@@ -1,0 +1,20 @@
+import { isValidIanaTimeZone } from "@/lib/game/daily-lock";
+
+/** Cookie written by the client from `Intl.resolvedOptions().timeZone`. */
+export const TIMEZONE_COOKIE_NAME = "rebuzzle-tz";
+
+export const FALLBACK_TIME_ZONE = "UTC";
+
+/** Normalize a candidate IANA zone; returns null when unusable. */
+export function normalizeTimeZone(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!isValidIanaTimeZone(trimmed)) return null;
+  return trimmed;
+}
+
+/** Client-side cookie writer (path=/, 1 year, Lax). */
+export function buildTimeZoneCookie(timeZone: string): string {
+  const maxAge = 60 * 60 * 24 * 365;
+  return `${TIMEZONE_COOKIE_NAME}=${encodeURIComponent(timeZone)}; Path=/; Max-Age=${maxAge}; SameSite=Lax`;
+}

--- a/apps/web/src/lib/timezone.ts
+++ b/apps/web/src/lib/timezone.ts
@@ -1,0 +1,33 @@
+import { cookies, headers } from "next/headers";
+import { FALLBACK_TIME_ZONE, normalizeTimeZone, TIMEZONE_COOKIE_NAME } from "@/lib/timezone-shared";
+
+export {
+  buildTimeZoneCookie,
+  FALLBACK_TIME_ZONE,
+  normalizeTimeZone,
+  TIMEZONE_COOKIE_NAME,
+} from "@/lib/timezone-shared";
+
+/**
+ * Resolve the player's IANA time zone for request-time puzzle day math.
+ * Preference: cookie → Vercel IP timezone → UTC.
+ */
+export async function resolveRequestTimeZone(): Promise<string> {
+  try {
+    const cookieStore = await cookies();
+    const fromCookie = normalizeTimeZone(cookieStore.get(TIMEZONE_COOKIE_NAME)?.value);
+    if (fromCookie) return fromCookie;
+  } catch {
+    // cookies() unavailable outside a request
+  }
+
+  try {
+    const headerStore = await headers();
+    const fromVercel = normalizeTimeZone(headerStore.get("x-vercel-ip-timezone"));
+    if (fromVercel) return fromVercel;
+  } catch {
+    // headers() unavailable outside a request
+  }
+
+  return FALLBACK_TIME_ZONE;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The “Next puzzle” countdown was aiming at **UTC midnight**, which lands at 8 PM Eastern (and other off-hours for most players). Players now unlock the new day at **their local midnight**.

### Still one generated puzzle per day
- Cron / generation keeps writing a single puzzle per `YYYY-MM-DD` publication key (UTC `publishedAt` unchanged).
- Tomorrow pre-generation still covers east-of-UTC players before UTC midnight.

### What changed
- Resolve IANA timezone from `rebuzzle-tz` cookie (set in-browser) → Vercel IP timezone → UTC
- Serve / lock / guess / stats / quip / achievements against the **local calendar date key**
- Countdown + copy use local midnight
- Daily final lock key remains the puzzle publication date (prevents double-play if TZ changes mid-day)

### Test plan
- [x] Unit tests for Eastern / Tokyo local date + midnight math
- [x] Lint + typecheck
- [ ] On phone after deploy: countdown should land at **12:00 AM local**, not 8 PM
- [ ] After solving, refresh before local midnight → still locked; after local midnight → new puzzle

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5874a5-7d64-4be5-8144-b87922e48968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5874a5-7d64-4be5-8144-b87922e48968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

